### PR TITLE
Remap Physical Back Button As Guide Button

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -2471,6 +2471,10 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             context.inputMap &= ~ControllerPacket.PLAY_FLAG;
             break;
         case KeyEvent.KEYCODE_BACK:
+            if (prefConfig.backAsGuide) {
+                context.inputMap &= ~ControllerPacket.MISC_FLAG;
+                break;
+            }
         case KeyEvent.KEYCODE_BUTTON_SELECT:
             context.inputMap &= ~ControllerPacket.BACK_FLAG;
             break;
@@ -2689,6 +2693,11 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             context.inputMap |= ControllerPacket.PLAY_FLAG;
             break;
         case KeyEvent.KEYCODE_BACK:
+            if (prefConfig.backAsGuide) {
+                context.hasSelect = true;
+                context.inputMap |= ControllerPacket.MISC_FLAG;
+                break;
+            }
         case KeyEvent.KEYCODE_BUTTON_SELECT:
             context.hasSelect = true;
             context.inputMap |= ControllerPacket.BACK_FLAG;

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -90,6 +90,7 @@ public class PreferenceConfiguration {
     private static final String CHECKBOX_FORCE_QWERTY = "checkbox_force_qwerty";
     private static final String CHECKBOX_BACK_AS_META = "checkbox_back_as_meta";
     private static final String CHECKBOX_IGNORE_SYNTH_EVENTS = "checkbox_ignore_synth_events";
+    private static final String CHECKBOX_BACK_AS_GUIDE = "checkbox_back_as_guide";
     private static final String CHECKBOX_SMART_CLIPBOARD_SYNC = "checkbox_smart_clipboard_sync";
     private static final String CHECKBOX_SMART_CLIPBOARD_SYNC_TOAST = "checkbox_smart_clipboard_sync_toast";
     private static final String CHECKBOX_HIDE_CLIPBOARD_CONTENT = "checkbox_hide_clipboard_content";
@@ -163,6 +164,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_FORCE_QWERTY = true;
     private static final boolean DEFAULT_SEND_META_ON_PHYSICAL_BACK = false;
     private static final boolean DEFAULT_IGNORE_SYNTH_EVENTS = false;
+    private static final boolean DEFAULT_BACK_AS_GUIDE = false;
     private static final boolean DEFAULT_SMART_CLIPBOARD_SYNC = false;
     private static final boolean DEFAULT_SMART_CLIPBOARD_SYNC_TOAST = true;
     private static final boolean DEFAULT_HIDE_CLIPBOARD_CONTENT = true;
@@ -204,6 +206,7 @@ public class PreferenceConfiguration {
     public boolean forceQwerty;
     public boolean backAsMeta;
     public boolean ignoreSynthEvents;
+    public boolean backAsGuide;
     public boolean smartClipboardSync;
     public boolean smartClipboardSyncToast;
     public boolean hideClipboardContent;
@@ -849,6 +852,7 @@ public class PreferenceConfiguration {
         config.forceQwerty = prefs.getBoolean(CHECKBOX_FORCE_QWERTY, DEFAULT_FORCE_QWERTY);
         config.backAsMeta = prefs.getBoolean(CHECKBOX_BACK_AS_META, DEFAULT_SEND_META_ON_PHYSICAL_BACK);
         config.ignoreSynthEvents = prefs.getBoolean(CHECKBOX_IGNORE_SYNTH_EVENTS, DEFAULT_IGNORE_SYNTH_EVENTS);
+        config.backAsGuide = prefs.getBoolean(CHECKBOX_BACK_AS_GUIDE, DEFAULT_BACK_AS_GUIDE);
         config.smartClipboardSync = prefs.getBoolean(CHECKBOX_SMART_CLIPBOARD_SYNC, DEFAULT_SMART_CLIPBOARD_SYNC);
         config.smartClipboardSyncToast = prefs.getBoolean(CHECKBOX_SMART_CLIPBOARD_SYNC_TOAST, DEFAULT_SMART_CLIPBOARD_SYNC_TOAST);
         config.hideClipboardContent = prefs.getBoolean(CHECKBOX_HIDE_CLIPBOARD_CONTENT, DEFAULT_HIDE_CLIPBOARD_CONTENT);

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -442,6 +442,8 @@
     <string name="summary_checkbox_force_qwerty">强制使用 QWERTY 键盘布局。GFE必须使用。\n如果你希望使用其他键盘布局的话，请关闭此选项。</string>
     <string name="title_checkbox_back_as_meta">使用返回键作为 Meta</string>
     <string name="summary_back_as_meta">在按下物理返回键时发送 Meta(Win) 键</string>
+    <string name="title_back_as_guide">使用返回键作为导航键</string>
+    <string name="summary_back_as_guide">按下手柄上的返回键时发送导航(PS/HOME)键</string>
     <string name="title_checkbox_ignore_synth_events">忽略合成事件</string>
     <string name="summary_ignore_synth_events">忽略 Android 系统发送的合成事件。可能可以解决某些设备上的鼠标点击触发其他非预期按键的问题。\n启用此选项会导致系统软键盘不工作。</string>
     <string name="title_smart_clipboard_sync">智能剪贴板同步（实验性）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,6 +477,8 @@
     <string name="summary_back_as_meta">Send Meta(Win) key on physical back button press.</string>
     <string name="title_checkbox_ignore_synth_events">Ignore synthetic events</string>
     <string name="summary_ignore_synth_events">Ignore synthetic events sent by the Android system. This may resolve issues where mouse clicks trigger other unexpected keys on certain devices.\nEnabling this option will cause the system\'s soft keyboard to stop working.</string>
+    <string name="title_back_as_guide">Back button as Guide</string>
+    <string name="summary_back_as_guide">Remap physical Back button as Guide (PS/HOME) button.</string>
     <string name="title_smart_clipboard_sync">Smart Clipboard Sync (Experimental)</string>
     <string name="summary_smart_clipboard_sync">Automatically upload clipboard content to server when the stream starts/resumes, download clipboard from server when losing focus(requires Apollo)</string>
     <string name="title_smart_clipboard_sync_toast">Clipboard Sync Toast</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,10 +475,10 @@
     <string name="summary_checkbox_force_qwerty">Force use QWERTY keyboard layout.\nRequired by GFE.\nTurn off if you want to use a different keyboard layout.</string>
     <string name="title_checkbox_back_as_meta">Back button as Meta</string>
     <string name="summary_back_as_meta">Send Meta(Win) key on physical back button press.</string>
+    <string name="title_back_as_guide">Back button as Guide</string>
+    <string name="summary_back_as_guide">Send Guide(PS/HOME) button press when Back button is pressed on controllers.</string>
     <string name="title_checkbox_ignore_synth_events">Ignore synthetic events</string>
     <string name="summary_ignore_synth_events">Ignore synthetic events sent by the Android system. This may resolve issues where mouse clicks trigger other unexpected keys on certain devices.\nEnabling this option will cause the system\'s soft keyboard to stop working.</string>
-    <string name="title_back_as_guide">Back button as Guide</string>
-    <string name="summary_back_as_guide">Remap physical Back button as Guide (PS/HOME) button.</string>
     <string name="title_smart_clipboard_sync">Smart Clipboard Sync (Experimental)</string>
     <string name="summary_smart_clipboard_sync">Automatically upload clipboard content to server when the stream starts/resumes, download clipboard from server when losing focus(requires Apollo)</string>
     <string name="title_smart_clipboard_sync_toast">Clipboard Sync Toast</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,7 +39,6 @@
             seekbar:step="500" />
 
         <ListPreference
-            android:layout_height="wrap_content"
             android:defaultValue="latency"
             android:entries="@array/video_frame_pacing_names"
             android:entryValues="@array/video_frame_pacing_values"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,6 +39,7 @@
             seekbar:step="500" />
 
         <ListPreference
+            android:layout_height="wrap_content"
             android:defaultValue="latency"
             android:entries="@array/video_frame_pacing_names"
             android:entryValues="@array/video_frame_pacing_values"
@@ -341,6 +342,12 @@
             android:key="checkbox_ignore_synth_events"
             android:summary="@string/summary_ignore_synth_events"
             android:title="@string/title_checkbox_ignore_synth_events"
+            app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="checkbox_back_as_guide"
+            android:summary="@string/summary_back_as_guide"
+            android:title="@string/title_back_as_guide"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -338,15 +338,15 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="checkbox_ignore_synth_events"
-            android:summary="@string/summary_ignore_synth_events"
-            android:title="@string/title_checkbox_ignore_synth_events"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
             android:key="checkbox_back_as_guide"
             android:summary="@string/summary_back_as_guide"
             android:title="@string/title_back_as_guide"
+            app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="checkbox_ignore_synth_events"
+            android:summary="@string/summary_ignore_synth_events"
+            android:title="@string/title_checkbox_ignore_synth_events"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 


### PR DESCRIPTION
# Summary
Devices like the Retroid Pocket 5 have a physical back button that's mapped as Select. I find it is more useful as a guide button.

# New Feature
- Added a new preference option to remap physical back button to guide.