### PR TITLE
Fix Physical Back Button to Guide Remap for Emulated DS4

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -2472,7 +2472,12 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             break;
         case KeyEvent.KEYCODE_BACK:
             if (prefConfig.backAsGuide) {
-                context.inputMap &= ~ControllerPacket.MISC_FLAG;
+                if (context.needsClickpadEmulation) {
+                    context.inputMap &= ~ControllerPacket.SPECIAL_BUTTON_FLAG;
+                }
+                else {
+                    context.inputMap &= ~ControllerPacket.MISC_FLAG;
+                }
                 break;
             }
         case KeyEvent.KEYCODE_BUTTON_SELECT:
@@ -2695,7 +2700,12 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         case KeyEvent.KEYCODE_BACK:
             if (prefConfig.backAsGuide) {
                 context.hasSelect = true;
-                context.inputMap |= ControllerPacket.MISC_FLAG;
+                if (context.needsClickpadEmulation) {
+                    context.inputMap |= ControllerPacket.SPECIAL_BUTTON_FLAG;
+                }
+                else {
+                    context.inputMap |= ControllerPacket.MISC_FLAG;
+                }
                 break;
             }
         case KeyEvent.KEYCODE_BUTTON_SELECT:


### PR DESCRIPTION
When using the "Emulate gamepad motion sensor support" option, the emulated DS4 will output the trackpad button press when pressing the physical back button.

The controllerpacket flag for the Guide button differs between the emulated X360 and DS4. Added a check for that.