### PR TITLE
Drag & Drop Support for Trackpad Devices

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -2391,7 +2391,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                         );
 
                         if (synthClickPending &&
-                            event.getEventTime() - synthTouchDownTime >= 250) {
+                            event.getEventTime() - synthTouchDownTime >= prefConfig.trackpadDragDropThreshold) {
                             if (positionDelta > 50) {
                                 pendingDrag = false;
                             } else if (pendingDrag) {
@@ -2449,8 +2449,7 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                                         isDragging = false;
                                         conn.sendMouseButtonUp(MouseButtonPacket.BUTTON_LEFT);
                                     }
-
-                                     = false;
+                                    pendingDrag = false;
                                     synthClickPending = false;
                                 }
                                 return true;

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -114,7 +114,7 @@ public class PreferenceConfiguration {
     private static final String SEEKBAR_TRACKPAD_SENSITIVITY_X = "seekbar_trackpad_sensitivity_x";
     private static final String SEEKBAR_TRACKPAD_SENSITIVITY_Y = "seekbar_trackpad_sensitivity_y";
     private static final String CHECKBOX_TRACKPAD_DRAG_DROP_VIBRATION = "checkbox_trackpad_drag_drop_vibration";
-    private static final String SEEKBAR_TRACKPAD_DRAG_DROP_THRESHOLD = "checkbox_trackpad_drag_drop_threshold";
+    private static final String SEEKBAR_TRACKPAD_DRAG_DROP_THRESHOLD = "seekbar_trackpad_drag_drop_threshold";
     private static final String CHECKBOX_TRACKPAD_SWAP_AXIS = "checkbox_trackpad_swap_axis";
 
     static final String DEFAULT_RESOLUTION = "1280x720";

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -113,6 +113,7 @@ public class PreferenceConfiguration {
     private static final String SEEKBAR_TOUCH_SENSITIVITY = "seekbar_touch_sensitivity_opacity_x";
     private static final String SEEKBAR_TRACKPAD_SENSITIVITY_X = "seekbar_trackpad_sensitivity_x";
     private static final String SEEKBAR_TRACKPAD_SENSITIVITY_Y = "seekbar_trackpad_sensitivity_y";
+    private static final String CHECKBOX_TRACKPAD_DRAG_DROP_VIBRATION = "checkbox_trackpad_drag_drop_vibration";
     private static final String CHECKBOX_TRACKPAD_SWAP_AXIS = "checkbox_trackpad_swap_axis";
 
     static final String DEFAULT_RESOLUTION = "1280x720";
@@ -170,6 +171,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_HIDE_CLIPBOARD_CONTENT = true;
     private static final int DEFAULT_TRACKPAD_SENSITIVITY_X = 100;
     private static final int DEFAULT_TRACKPAD_SENSITIVITY_Y = 100;
+    private static final boolean DEFAULT_TRACKPAD_DRAG_DROP_VIBRATION = false;
     private static final boolean DEFAULT_TRACKPAD_SWAP_AXIS = false;
     private static final String DEFAULT_ONSCREEN_KEYBOARD_ALIGN_MODE = "center";
 
@@ -283,6 +285,7 @@ public class PreferenceConfiguration {
 
     public int trackpadSensitivityX;
     public int trackpadSensitivityY;
+    public boolean trackpadDragDropVibration;
     public boolean trackpadSwapAxis;
 
     public boolean bindAllUsb;
@@ -845,6 +848,7 @@ public class PreferenceConfiguration {
 
         config.trackpadSensitivityX = prefs.getInt(SEEKBAR_TRACKPAD_SENSITIVITY_X, DEFAULT_TRACKPAD_SENSITIVITY_X);
         config.trackpadSensitivityY = prefs.getInt(SEEKBAR_TRACKPAD_SENSITIVITY_Y, DEFAULT_TRACKPAD_SENSITIVITY_Y);
+        config.trackpadDragDropVibration = prefs.getBoolean(CHECKBOX_TRACKPAD_DRAG_DROP_VIBRATION, DEFAULT_TRACKPAD_DRAG_DROP_VIBRATION);
         config.trackpadSwapAxis = prefs.getBoolean(CHECKBOX_TRACKPAD_SWAP_AXIS, DEFAULT_TRACKPAD_SWAP_AXIS);
 
         config.absoluteMouseMode = prefs.getBoolean(ABSOLUTE_MOUSE_MODE_PREF_STRING, DEFAULT_ABSOLUTE_MOUSE_MODE);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -114,6 +114,7 @@ public class PreferenceConfiguration {
     private static final String SEEKBAR_TRACKPAD_SENSITIVITY_X = "seekbar_trackpad_sensitivity_x";
     private static final String SEEKBAR_TRACKPAD_SENSITIVITY_Y = "seekbar_trackpad_sensitivity_y";
     private static final String CHECKBOX_TRACKPAD_DRAG_DROP_VIBRATION = "checkbox_trackpad_drag_drop_vibration";
+    private static final String SEEKBAR_TRACKPAD_DRAG_DROP_THRESHOLD = "checkbox_trackpad_drag_drop_threshold";
     private static final String CHECKBOX_TRACKPAD_SWAP_AXIS = "checkbox_trackpad_swap_axis";
 
     static final String DEFAULT_RESOLUTION = "1280x720";
@@ -172,6 +173,7 @@ public class PreferenceConfiguration {
     private static final int DEFAULT_TRACKPAD_SENSITIVITY_X = 100;
     private static final int DEFAULT_TRACKPAD_SENSITIVITY_Y = 100;
     private static final boolean DEFAULT_TRACKPAD_DRAG_DROP_VIBRATION = false;
+    private static final int DEFAULT_TRACKPAD_DRAG_DROP_THRESHOLD = 250;
     private static final boolean DEFAULT_TRACKPAD_SWAP_AXIS = false;
     private static final String DEFAULT_ONSCREEN_KEYBOARD_ALIGN_MODE = "center";
 
@@ -286,6 +288,7 @@ public class PreferenceConfiguration {
     public int trackpadSensitivityX;
     public int trackpadSensitivityY;
     public boolean trackpadDragDropVibration;
+    public int trackpadDragDropThreshold;
     public boolean trackpadSwapAxis;
 
     public boolean bindAllUsb;
@@ -849,6 +852,7 @@ public class PreferenceConfiguration {
         config.trackpadSensitivityX = prefs.getInt(SEEKBAR_TRACKPAD_SENSITIVITY_X, DEFAULT_TRACKPAD_SENSITIVITY_X);
         config.trackpadSensitivityY = prefs.getInt(SEEKBAR_TRACKPAD_SENSITIVITY_Y, DEFAULT_TRACKPAD_SENSITIVITY_Y);
         config.trackpadDragDropVibration = prefs.getBoolean(CHECKBOX_TRACKPAD_DRAG_DROP_VIBRATION, DEFAULT_TRACKPAD_DRAG_DROP_VIBRATION);
+        config.trackpadDragDropThreshold = prefs.getInt(SEEKBAR_TRACKPAD_DRAG_DROP_THRESHOLD, DEFAULT_TRACKPAD_DRAG_DROP_THRESHOLD);
         config.trackpadSwapAxis = prefs.getBoolean(CHECKBOX_TRACKPAD_SWAP_AXIS, DEFAULT_TRACKPAD_SWAP_AXIS);
 
         config.absoluteMouseMode = prefs.getBoolean(ABSOLUTE_MOUSE_MODE_PREF_STRING, DEFAULT_ABSOLUTE_MOUSE_MODE);

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -436,6 +436,10 @@
     <string name="summary_trackpad_sensitivity_x">触摸板 X 轴灵敏度，负值则反向移动</string>
     <string name="title_trackpad_sensitivity_y">触摸板 Y 轴灵敏度</string>
     <string name="summary_trackpad_sensitivity_y">触摸板 Y 轴灵敏度，负值则反向移动</string>
+    <string name="title_trackpad_drag_drop_vibration">触摸板拖拽时震动设备</string>
+    <string name="summary_trackpad_drag_drop_vibration">在三星设备上启用触摸板拖拽震动反馈。</string>
+    <string name="title_trackpad_drag_drop_threshold">触摸板按压拖拽动作触发时间阈值</string>
+    <string name="summary_trackpad_drag_drop_threshold">调整三星设备上按压触发触摸板拖拽操作的时间阈值。</string>
     <string name="title_trackpad_swap_axis">交换触摸板XY坐标</string>
     <string name="summary_trackpad_swap_axis">在某些设备上，触摸板输入坐标可能会与当前视图方向不符。开启此选项可能会有用。</string>
     <string name="title_checkbox_force_qwerty">强制使用 QWERTY 布局</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -470,9 +470,9 @@
     <string name="title_trackpad_sensitivity_y">Trackpad Sensitivity Y</string>
     <string name="summary_trackpad_sensitivity_y">Y axis Sensitivity of the trackpad, negative to invert direction</string>
     <string name="title_trackpad_drag_drop_vibration">Enable Vibration for Drag-and-Drop on Trackpad</string>
-    <string name="summary_trackpad_drag_drop_vibration">Enables vibration feedback for drag-and-drop actions on trackpad devices.</string>
+    <string name="summary_trackpad_drag_drop_vibration">Enables vibration feedback for drag-and-drop actions on Samsung trackpad devices.</string>
     <string name="title_trackpad_drag_drop_threshold">Hold Duration for Drag-and-Drop Activation on Trackpad</string>
-    <string name="summary_trackpad_drag_drop_threshold">Set the duration to hold on the trackpad before activating drag-and-drop.</string>
+    <string name="summary_trackpad_drag_drop_threshold">Set the duration to hold on the trackpad before activating drag-and-drop on Samsung devices.</string>
     <string name="title_trackpad_swap_axis">Swap X and Y axis of the trackpad input</string>
     <string name="summary_trackpad_swap_axis">On some devices, trackpad input may be rotated in axis. Enabling this option may help.</string>
     <string name="title_checkbox_force_qwerty">Force QWERTY layout</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,6 +469,8 @@
     <string name="summary_trackpad_sensitivity_x">X axis Sensitivity of the trackpad, negative to invert direction</string>
     <string name="title_trackpad_sensitivity_y">Trackpad Sensitivity Y</string>
     <string name="summary_trackpad_sensitivity_y">Y axis Sensitivity of the trackpad, negative to invert direction</string>
+    <string name="title_trackpad_drag_drop_vibration">Enable Vibration for Drag-and-Drop on Trackpad</string>
+    <string name="summary_trackpad_drag_drop_vibration">Enables vibration feedback for drag-and-drop actions on trackpad devices.</string>
     <string name="title_trackpad_swap_axis">Swap X and Y axis of the trackpad input</string>
     <string name="summary_trackpad_swap_axis">On some devices, trackpad input may be rotated in axis. Enabling this option may help.</string>
     <string name="title_checkbox_force_qwerty">Force QWERTY layout</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -471,6 +471,8 @@
     <string name="summary_trackpad_sensitivity_y">Y axis Sensitivity of the trackpad, negative to invert direction</string>
     <string name="title_trackpad_drag_drop_vibration">Enable Vibration for Drag-and-Drop on Trackpad</string>
     <string name="summary_trackpad_drag_drop_vibration">Enables vibration feedback for drag-and-drop actions on trackpad devices.</string>
+    <string name="title_trackpad_drag_drop_threshold">Hold Duration for Drag-and-Drop Activation on Trackpad</string>
+    <string name="summary_trackpad_drag_drop_threshold">Set the duration to hold on the trackpad before activating drag-and-drop.</string>
     <string name="title_trackpad_swap_axis">Swap X and Y axis of the trackpad input</string>
     <string name="summary_trackpad_swap_axis">On some devices, trackpad input may be rotated in axis. Enabling this option may help.</string>
     <string name="title_checkbox_force_qwerty">Force QWERTY layout</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -320,6 +320,12 @@
             seekbar:step="10" />
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="checkbox_trackpad_drag_drop_vibration"
+            android:summary="@string/summary_trackpad_drag_drop_vibration"
+            android:title="@string/title_trackpad_drag_drop_vibration"
+            app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="checkbox_trackpad_swap_axis"
             android:summary="@string/summary_trackpad_swap_axis"
             android:title="@string/title_trackpad_swap_axis"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -327,8 +327,8 @@
         <com.limelight.preferences.SeekBarPreference
             android:defaultValue="250"
             android:key="seekbar_trackpad_drag_drop_threshold"
-            seekbar:step="10"
-            seekbar:min="100"
+            seekbar:step="1"
+            seekbar:min="0"
             android:max="2000"
             android:text="ms"
             android:summary="@string/summary_trackpad_drag_drop_threshold"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -324,6 +324,16 @@
             android:summary="@string/summary_trackpad_drag_drop_vibration"
             android:title="@string/title_trackpad_drag_drop_vibration"
             app:iconSpaceReserved="false" />
+        <com.limelight.preferences.SeekBarPreference
+            android:defaultValue="250"
+            android:key="seekbar_trackpad_drag_drop_threshold"
+            seekbar:step="10"
+            seekbar:min="100"
+            android:max="2000"
+            android:text="ms"
+            android:summary="@string/summary_trackpad_drag_drop_threshold"
+            android:title="@string/title_trackpad_drag_drop_threshold"
+            app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="checkbox_trackpad_swap_axis"


### PR DESCRIPTION
This pull request adds drag-and-drop support for trackpad devices and works well on my Samsung tablet.

I placed the code earlier for better organization, even though it would also work in the switch statement below.

By default, Samsung trackpads support normal drag-and-drop but don't allow double-tap followed by a quick drag. This is because the second tap is consumed as a move action.

The reason for this is that Samsung applies a threshold based on speed, time, and position before triggering an onTouch event. If the threshold is exceeded, it sends an onGenericMotion event, which is always treated as a move action.

However, double-tapping and then holding to drag works as expected, similar to regular drag-and-drop behavior.