### PR TITLE
Enable 3 finger tap & 5 finger tap in multitouch mode to toggle screen keyboard & show quick menu

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -2592,7 +2592,6 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                     if (prefConfig.enableMultiTouchScreen) {
                         int actionMasked = event.getActionMasked();
                         int pointerCount = event.getPointerCount();
-                        // long currentEventTime = event.getEventTime();
 
                         if (actionMasked == MotionEvent.ACTION_POINTER_DOWN && pointerCount == 3) {
                             threeFingerDownTime = event.getEventTime();

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -245,7 +245,6 @@ public class PreferenceConfiguration {
     public boolean enableLatencyToast;
     //软键盘
     public boolean enableBackMenu;
-    public boolean enableFiveFingerTapForBackMenu;
     //Invert video width/height
     public boolean autoInvertVideoResolution;
     public int resolutionScaleFactor;
@@ -287,6 +286,8 @@ public class PreferenceConfiguration {
 
     //物理光标捕获
     public boolean enableMouseLocalCursor;
+
+    public boolean enableMultiTouchGestures;
 
     //禁用内置的特殊指令
     public boolean enableClearDefaultSpecial;
@@ -864,7 +865,8 @@ public class PreferenceConfiguration {
 
         config.enableMouseLocalCursor=prefs.getBoolean("checkbox_mouse_local_cursor",false);
 
-        config.enableFiveFingerTapForBackMenu=prefs.getBoolean("checkbox_five_finger_tap_for_back_menu",false);
+        config.enableMultiTouchGestures = prefs.getBoolean("checkbox_multi_touch_gestures", false);
+
 
         config.enablePerfOverlayLiteDialog=prefs.getBoolean("checkbox_enable_perf_overlay_lite_dialog",false);
 

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -245,6 +245,7 @@ public class PreferenceConfiguration {
     public boolean enableLatencyToast;
     //软键盘
     public boolean enableBackMenu;
+    public boolean enableFiveFingerTapForBackMenu;
     //Invert video width/height
     public boolean autoInvertVideoResolution;
     public int resolutionScaleFactor;
@@ -862,6 +863,8 @@ public class PreferenceConfiguration {
         config.enableTouchSensitivity=prefs.getBoolean("checkbox_enable_touch_sensitivity",false);
 
         config.enableMouseLocalCursor=prefs.getBoolean("checkbox_mouse_local_cursor",false);
+
+        config.enableFiveFingerTapForBackMenu=prefs.getBoolean("checkbox_five_finger_tap_for_back_menu",false);
 
         config.enablePerfOverlayLiteDialog=prefs.getBoolean("checkbox_enable_perf_overlay_lite_dialog",false);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,6 +406,8 @@
     <!-- New Strings -->
     <string name="title_checkbox_mouse_local_cursor">Use local mouse cursor</string>
     <string name="summary_checkbox_mouse_local_cursor">Default external physical mouse cursor will be captured, this option can display Android system cursor</string>
+    <string name="title_checkbox_five_finger_tap_for_back_menu">Five-finger tap to open back menu</string>
+    <string name="summary_checkbox_five_finger_tap_for_back_menu">Tap the screen with five fingers at once to open the back menu</string>
     <string name="title_checkbox_onscreen_style_official">Official Virtual Gamepad Skin</string>
     <string name="summary_checkbox_onscreen_style_official">If you still like the old style of official virtual gamepad buttons, you can select this option.\nButton shapes can be square if you selected the bottom virtual button [Normal buttons are square buttons]</string>
     <string name="title_checkbox_enable_perf_overlay_lite">Enable Lite mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,8 +406,8 @@
     <!-- New Strings -->
     <string name="title_checkbox_mouse_local_cursor">Use local mouse cursor</string>
     <string name="summary_checkbox_mouse_local_cursor">Default external physical mouse cursor will be captured, this option can display Android system cursor</string>
-    <string name="title_checkbox_five_finger_tap_for_back_menu">Five-finger tap to open back menu</string>
-    <string name="summary_checkbox_five_finger_tap_for_back_menu">Tap the screen with five fingers at once to open the back menu</string>
+    <string name="title_checkbox_multi_touch_gestures">Enable multi-touch gestures</string>
+    <string name="summary_checkbox_multi_touch_gestures">Use multi-finger taps in multi-touch touchscreen mode to perform actions like opening menus or toggling the keyboard</string>
     <string name="title_checkbox_onscreen_style_official">Official Virtual Gamepad Skin</string>
     <string name="summary_checkbox_onscreen_style_official">If you still like the old style of official virtual gamepad buttons, you can select this option.\nButton shapes can be square if you selected the bottom virtual button [Normal buttons are square buttons]</string>
     <string name="title_checkbox_enable_perf_overlay_lite">Enable Lite mode</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -323,6 +323,13 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="checkbox_five_finger_tap_for_back_menu"
+            android:summary="@string/summary_checkbox_five_finger_tap_for_back_menu"
+            android:title="@string/title_checkbox_five_finger_tap_for_back_menu"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="checkbox_mouse_nav_buttons"
             android:summary="@string/summary_checkbox_mouse_nav_buttons"
             android:title="@string/title_checkbox_mouse_nav_buttons"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -323,9 +323,9 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="checkbox_five_finger_tap_for_back_menu"
-            android:summary="@string/summary_checkbox_five_finger_tap_for_back_menu"
-            android:title="@string/title_checkbox_five_finger_tap_for_back_menu"
+            android:key="checkbox_multi_touch_gestures"
+            android:summary="@string/summary_checkbox_multi_touch_gestures"
+            android:title="@string/title_checkbox_multi_touch_gestures"
             app:iconSpaceReserved="false" />
 
         <CheckBoxPreference


### PR DESCRIPTION
- Enable three-finger tap to show the on-screen keyboard in multi-touch mode: In the original Moonlight app, I frequently used this feature. However, it appears to be missing in multi-touch mode, and I'm not sure why it was removed. Re-enabling it would improve usability for those who rely on quick keyboard access.

- Enable five-finger tap to open the back/quick menu in multi-touch mode: Currently, the "swipe from the right edge" gesture conflicts with the right-side widget opening event when I'm using my tablet to remote into Windows. As a result, I have to swipe twice to access the quick menu. Adding a five-finger tap gesture would provide a more reliable alternative, especially for devices where edge swipes are not smooth or responsive.