### PR TITLE
Fix: ESC and Alt+Tab not working on Xiaomi Pad 6S Pro

### DIFF
--- a/app/src/main/java/com/limelight/KeyboardAccessibilityService.java
+++ b/app/src/main/java/com/limelight/KeyboardAccessibilityService.java
@@ -2,6 +2,8 @@ package com.limelight;
 
 import android.accessibilityservice.AccessibilityService;
 import android.accessibilityservice.AccessibilityServiceInfo;
+import android.os.SystemClock;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.Toast;
@@ -9,64 +11,154 @@ import android.widget.Toast;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * 键盘无障碍服务类
+ * 用于拦截和处理键盘事件，特别是将返回键映射为ESC键，以及处理组合键
+ *
+ * @author hanbo && huafeng0
+ * @since 2024/1/16
+ */
 public class KeyboardAccessibilityService extends AccessibilityService {
-
-    //不屏蔽的按键列表
-    private final static List BLACKLIST_KEYS = Arrays.asList(
+    private static final List BLACKLIST_KEYS = Arrays.asList(
             KeyEvent.KEYCODE_VOLUME_UP,
             KeyEvent.KEYCODE_VOLUME_DOWN,
-            KeyEvent.KEYCODE_POWER
+            KeyEvent.KEYCODE_POWER,
+            KeyEvent.KEYCODE_HOME
     );
 
-    @Override
-    public boolean onKeyEvent(KeyEvent event) {
-        int action = event.getAction();
-        int keyCode = event.getKeyCode();
-//        Toast.makeText(getApplicationContext(),"scancode:"+event.getScanCode()+",code:"+event.getKeyCode(),Toast.LENGTH_LONG).show();
-        //主要解决系统自带快捷键在pc端无法使用问题 home键 scancode=172 code- 3
-        if (Game.instance != null && Game.instance.connected && !BLACKLIST_KEYS.contains(keyCode)) {
-
-            if (action == KeyEvent.ACTION_DOWN) {
-                //fix 小米平板esc键按钮映射错误 KEYCODE_BACK=4
-                if(event.getScanCode()==1){
-                    Game.instance.handleKeyDown(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ESCAPE));
-                    return true;
-                }
-                Game.instance.handleKeyDown(event);
-                return true;
-            } else if (action == KeyEvent.ACTION_UP) {
-                //fix 小米平板esc键按钮映射错误 KEYCODE_BACK=4
-                if(event.getScanCode()==1){
-                    Game.instance.handleKeyUp(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ESCAPE));
-                    return true;
-                }
-                Game.instance.handleKeyUp(event);
-                return true;
-            }
-        }
-
-        return super.onKeyEvent(event);
-    }
-
-    @Override
-    public void onServiceConnected() {
-        LimeLog.info("Keyboard service is connected");
-        AccessibilityServiceInfo info = new AccessibilityServiceInfo();
-        info.packageNames = new String[] { BuildConfig.APPLICATION_ID };
-        info.eventTypes = AccessibilityEvent.TYPES_ALL_MASK;
-        info.notificationTimeout = 100;
-        info.flags = AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS;
-        info.feedbackType = AccessibilityServiceInfo.FEEDBACK_SPOKEN;
-        setServiceInfo(info);
-    }
+    // 跟踪修饰键状态
+    private boolean isAltPressed = false;
+    private boolean isCtrlPressed = false;
+    private boolean isShiftPressed = false;
+    private boolean isMetaPressed = false;
 
     @Override
     public void onAccessibilityEvent(AccessibilityEvent accessibilityEvent) {
-//        LimeLog.info("onAccessibilityEvent:"+accessibilityEvent.toString());
     }
+
     @Override
     public void onInterrupt() {
-
     }
 
+    private int escNum = 0;
+    private long escClickTime = 0;
+
+    @Override
+    public boolean onKeyEvent(KeyEvent keyEvent) {
+        int action = keyEvent.getAction();
+        int keyCode = keyEvent.getKeyCode();
+        if (action == KeyEvent.ACTION_DOWN) {
+            Log.i("hh","KeyboardAccessibilityService press keyevent-->" + keyEvent);
+
+            // 更新修饰键状态
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_ALT_LEFT:
+                case KeyEvent.KEYCODE_ALT_RIGHT:
+                    isAltPressed = true;
+                    break;
+                case KeyEvent.KEYCODE_CTRL_LEFT:
+                case KeyEvent.KEYCODE_CTRL_RIGHT:
+                    isCtrlPressed = true;
+                    break;
+                case KeyEvent.KEYCODE_SHIFT_LEFT:
+                case KeyEvent.KEYCODE_SHIFT_RIGHT:
+                    isShiftPressed = true;
+                    break;
+                case KeyEvent.KEYCODE_META_LEFT:
+                case KeyEvent.KEYCODE_META_RIGHT:
+                    isMetaPressed = true;
+                    break;
+            }
+        } else if (action == KeyEvent.ACTION_UP) {
+            // 重置修饰键状态
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_ALT_LEFT:
+                case KeyEvent.KEYCODE_ALT_RIGHT:
+                    isAltPressed = false;
+                    break;
+                case KeyEvent.KEYCODE_CTRL_LEFT:
+                case KeyEvent.KEYCODE_CTRL_RIGHT:
+                    isCtrlPressed = false;
+                    break;
+                case KeyEvent.KEYCODE_SHIFT_LEFT:
+                case KeyEvent.KEYCODE_SHIFT_RIGHT:
+                    isShiftPressed = false;
+                    break;
+                case KeyEvent.KEYCODE_META_LEFT:
+                case KeyEvent.KEYCODE_META_RIGHT:
+                    isMetaPressed = false;
+                    break;
+            }
+        }
+
+        Game game = Game.instance;
+        if (game != null && game.connected && !BLACKLIST_KEYS.contains(Integer.valueOf(keyCode))) {
+            // 检测组合键情况
+            boolean isModifierKey = keyCode == KeyEvent.KEYCODE_ALT_LEFT ||
+                    keyCode == KeyEvent.KEYCODE_ALT_RIGHT ||
+                    keyCode == KeyEvent.KEYCODE_CTRL_LEFT ||
+                    keyCode == KeyEvent.KEYCODE_CTRL_RIGHT ||
+                    keyCode == KeyEvent.KEYCODE_SHIFT_LEFT ||
+                    keyCode == KeyEvent.KEYCODE_SHIFT_RIGHT ||
+                    keyCode == KeyEvent.KEYCODE_META_LEFT ||
+                    keyCode == KeyEvent.KEYCODE_META_RIGHT;
+
+            // 处理Alt+Tab组合键
+            if (isAltPressed && keyCode == KeyEvent.KEYCODE_TAB) {
+                // 直接传递给PC，不让系统处理
+                if (action == KeyEvent.ACTION_DOWN) {
+                    Game.instance.handleKeyDown(keyEvent);
+                    return true; // 消费事件，防止系统响应
+                } else if (action == KeyEvent.ACTION_UP) {
+                    Game.instance.handleKeyUp(keyEvent);
+                    return true; // 消费事件，防止系统响应
+                }
+            }
+
+            // 处理其他可能的组合键
+            // 如果当前有修饰键被按下，并且当前按键不是修饰键，则认为是组合键
+            if ((isAltPressed || isCtrlPressed || isShiftPressed || isMetaPressed) && !isModifierKey) {
+                if (action == KeyEvent.ACTION_DOWN) {
+                    Game.instance.handleKeyDown(keyEvent);
+                    return true; // 消费事件，防止系统响应
+                } else if (action == KeyEvent.ACTION_UP) {
+                    Game.instance.handleKeyUp(keyEvent);
+                    return true; // 消费事件，防止系统响应
+                }
+            }
+
+            // 处理返回键，将其转换为ESC键 此处解决小米平板esc问题
+            if (keyCode == KeyEvent.KEYCODE_BACK) {
+                keyEvent = new KeyEvent(keyEvent.getDownTime(), 
+                keyEvent.getEventTime(), 
+                keyEvent.getAction(),
+                KeyEvent.KEYCODE_ESCAPE, 
+                keyEvent.getRepeatCount(), 
+                keyEvent.getMetaState(), 
+                keyEvent.getDeviceId(),
+                keyEvent.getScanCode(), 
+                keyEvent.getFlags(), 
+                keyEvent.getSource());
+            }
+
+            // 处理普通按键
+            if (action == KeyEvent.ACTION_DOWN) {
+                Game.instance.handleKeyDown(keyEvent);
+                return true;
+            } else if (action == KeyEvent.ACTION_UP) {
+                Game.instance.handleKeyUp(keyEvent);
+                return true;
+            }
+        }
+        return super.onKeyEvent(keyEvent);
+    }
+
+   /* private KeyEvent processBack(KeyEvent keyEvent) {
+        // ... existing code ...
+    }*/
+
+   /* 已在xml配置@Override
+    public void onServiceConnected() {
+        // ... existing code ...
+    }*/
 }

--- a/app/src/main/java/com/limelight/KeyboardAccessibilityService.java
+++ b/app/src/main/java/com/limelight/KeyboardAccessibilityService.java
@@ -26,7 +26,6 @@ public class KeyboardAccessibilityService extends AccessibilityService {
             KeyEvent.KEYCODE_HOME
     );
 
-    // 跟踪修饰键状态
     private boolean isAltPressed = false;
     private boolean isCtrlPressed = false;
     private boolean isShiftPressed = false;
@@ -50,7 +49,6 @@ public class KeyboardAccessibilityService extends AccessibilityService {
         if (action == KeyEvent.ACTION_DOWN) {
             Log.i("hh","KeyboardAccessibilityService press keyevent-->" + keyEvent);
 
-            // 更新修饰键状态
             switch (keyCode) {
                 case KeyEvent.KEYCODE_ALT_LEFT:
                 case KeyEvent.KEYCODE_ALT_RIGHT:
@@ -70,7 +68,6 @@ public class KeyboardAccessibilityService extends AccessibilityService {
                     break;
             }
         } else if (action == KeyEvent.ACTION_UP) {
-            // 重置修饰键状态
             switch (keyCode) {
                 case KeyEvent.KEYCODE_ALT_LEFT:
                 case KeyEvent.KEYCODE_ALT_RIGHT:
@@ -105,13 +102,12 @@ public class KeyboardAccessibilityService extends AccessibilityService {
 
             // 处理Alt+Tab组合键
             if (isAltPressed && keyCode == KeyEvent.KEYCODE_TAB) {
-                // 直接传递给PC，不让系统处理
                 if (action == KeyEvent.ACTION_DOWN) {
                     Game.instance.handleKeyDown(keyEvent);
-                    return true; // 消费事件，防止系统响应
+                    return true; 
                 } else if (action == KeyEvent.ACTION_UP) {
                     Game.instance.handleKeyUp(keyEvent);
-                    return true; // 消费事件，防止系统响应
+                    return true; 
                 }
             }
 
@@ -120,10 +116,10 @@ public class KeyboardAccessibilityService extends AccessibilityService {
             if ((isAltPressed || isCtrlPressed || isShiftPressed || isMetaPressed) && !isModifierKey) {
                 if (action == KeyEvent.ACTION_DOWN) {
                     Game.instance.handleKeyDown(keyEvent);
-                    return true; // 消费事件，防止系统响应
+                    return true; 
                 } else if (action == KeyEvent.ACTION_UP) {
                     Game.instance.handleKeyUp(keyEvent);
-                    return true; // 消费事件，防止系统响应
+                    return true; 
                 }
             }
 


### PR DESCRIPTION
This PR fixes the issue where ESC and Alt+Tab were not working properly on the Xiaomi Pad 6S Pro.

Based on [ihanbo/Moonlight-Android-Pad](https://github.com/ihanbo/Moonlight-Android-Pad), which resolves the ESC key issue.

Added support for handling modifier key combinations such as Alt+Tab.

Note: I'm not an experienced developer, so the implementation might not be perfect.
Tested and working on:

Xiaomi Pad 6S Pro

Redmi K50 Ultra
Other devices have not been tested yet.