### PR TITLE
PerformanceDataTracker

### DIFF
--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -1883,7 +1883,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
     @SuppressLint("DefaultLocale")
     public String getMinDecoderLatency() {
-        return String.format("%1$.2f ms", minDecodeTime);
+        return String.format("%1$.2f", minDecodeTime);
     }
 
     public String getMinDecoderLatencyFullLog() {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -560,6 +560,11 @@ public class PreferenceConfiguration {
         }
     }
 
+    public static String getSelectedFramePacingName(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        return prefs.getString(FRAME_PACING_PREF_STRING, DEFAULT_FRAME_PACING);
+    }
+
     private static int getFramePacingValue(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 

--- a/app/src/main/java/com/limelight/utils/PerformanceDataTracker.java
+++ b/app/src/main/java/com/limelight/utils/PerformanceDataTracker.java
@@ -1,0 +1,102 @@
+package com.limelight.utils;
+
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class PerformanceDataTracker {
+
+    private static final String API_URL = "https://script.google.com/macros/s/AKfycbwU-jKQdSAHgd-emZjqkF9TH3hJzNmX1caxeTybuhCzjTWOsxQHa62xIYGgGQHwecOraw/exec";
+
+    // Constants for field names
+    private static final String FIELD_DEVICE = "Device";
+    private static final String FIELD_OS_VERSION = "OS Version";
+    private static final String FIELD_APP_VERSION = "App Version";
+    private static final String FIELD_CODEC = "Codec";
+    private static final String FIELD_STATS_LOG = "Performance Stats Log";
+    private static final String FIELD_DECODING_TIME = "Decoding Time (ms)";
+    private static final String FIELD_BITRATE = "Bitrate (Mbps)";
+    private static final String FIELD_RESOLUTION = "Resolution";
+    private static final String FIELD_FRAME_RATE = "Frame Rate (FPS)";
+    private static final String FIELD_AVERAGE = "Average Latency";
+    private static final String FIELD_FRAME_PACING = "Frame Pacing";
+    private static final String FIELD_DATETIME = "Date/Time";
+
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    public void sendPerformanceStatistics(
+            String device,
+            String osVersion,
+            String appVersion,
+            String codec,
+            String decodingTimeMs,
+            String stats,
+            String bitrateMbps,
+            String resolution,
+            String frameRateFps,
+            String average,
+            String framePacing,
+            String dateTime) {
+
+        executorService.execute(() -> sendData(device, osVersion, appVersion, codec, decodingTimeMs, stats, bitrateMbps, resolution, frameRateFps, average, framePacing, dateTime));
+    }
+
+    private void sendData(String device, String osVersion, String appVersion, String codec, String decodingTimeMs, String stats, String bitrateMbps, String resolution, String frameRateFps, String average, String framePacing, String dateTime) {
+        HttpURLConnection urlConnection = null;
+        try {
+            URL url = new URL(API_URL);
+            urlConnection = (HttpURLConnection) url.openConnection();
+            urlConnection.setRequestMethod("POST");
+            urlConnection.setRequestProperty("Content-Type", "application/json");
+            urlConnection.setDoOutput(true);
+
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put(FIELD_DEVICE, device);
+            jsonObject.put(FIELD_OS_VERSION, osVersion);
+            jsonObject.put(FIELD_APP_VERSION, appVersion);
+            jsonObject.put(FIELD_CODEC, codec);
+            jsonObject.put(FIELD_DECODING_TIME, decodingTimeMs);
+            jsonObject.put(FIELD_STATS_LOG, stats);
+            jsonObject.put(FIELD_BITRATE, bitrateMbps);
+            jsonObject.put(FIELD_RESOLUTION, resolution);
+            jsonObject.put(FIELD_FRAME_RATE, frameRateFps);
+            jsonObject.put(FIELD_AVERAGE, average);
+            jsonObject.put(FIELD_FRAME_PACING, framePacing);
+            jsonObject.put(FIELD_DATETIME, dateTime);
+
+            OutputStream os = new BufferedOutputStream(urlConnection.getOutputStream());
+            os.write(jsonObject.toString().getBytes());
+            os.flush();
+            os.close();
+
+            int responseCode = urlConnection.getResponseCode();
+            Log.d("PerformanceDataTracker", "Response Code: " + responseCode);
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = br.readLine()) != null) {
+                response.append(line);
+            }
+            br.close();
+
+            Log.d("PerformanceDataTracker", "Response: " + response.toString());
+
+        } catch (Exception e) {
+            Log.e("PerformanceDataTracker", "Error: " + e.getMessage());
+        } finally {
+            if (urlConnection != null) {
+                urlConnection.disconnect();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This feature implements fully anonymous data reporting functionality that sends performance statistics from the application to a designated Google Sheets document via a web API.

No personal identifiers are collected or transmitted.

Data is only being send when performance overlay was activated and game stream ends.

Reports performance metrics such as codec, decoding time, bitrate, resolution, frame rate, and network latency.

Data https://tinyurl.com/artemistics

**UseCase**: Users like me are asking frequently on reddit etc. "what is the decoding latency of device xy", including settings etc. When considering a new device to buy with the purpose to game stream - that would help alot!

**Potential improvements:**
- Opt in for users to send those data, even though free and anonymous anyway.
- Ranking for devices
- Adding Snapdragon Ultra Support Activated flag

Im happy to adapt it in a way that it sends the data to a google sheets of your choice etc...just created a unused google account for it basically and published the sheet. The Api is also hostet on Google App Scripts for free.