### PR TITLE
Fix Back as Guide Button

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -2515,12 +2515,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             break;
         case KeyEvent.KEYCODE_BACK:
             if (prefConfig.backAsGuide) {
-                if (context.needsClickpadEmulation) {
-                    context.inputMap &= ~ControllerPacket.SPECIAL_BUTTON_FLAG;
-                }
-                else {
-                    context.inputMap &= ~ControllerPacket.MISC_FLAG;
-                }
+                context.inputMap &= ~ControllerPacket.SPECIAL_BUTTON_FLAG;
                 break;
             }
         case KeyEvent.KEYCODE_BUTTON_SELECT:
@@ -2743,12 +2738,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         case KeyEvent.KEYCODE_BACK:
             if (prefConfig.backAsGuide) {
                 context.hasSelect = true;
-                if (context.needsClickpadEmulation) {
-                    context.inputMap |= ControllerPacket.SPECIAL_BUTTON_FLAG;
-                }
-                else {
-                    context.inputMap |= ControllerPacket.MISC_FLAG;
-                }
+                context.inputMap |= ControllerPacket.SPECIAL_BUTTON_FLAG;
                 break;
             }
         case KeyEvent.KEYCODE_BUTTON_SELECT:


### PR DESCRIPTION
Issue brought up in PR #99 where the back as guide doesn't work on Linux machines.
The SPECIAL_BUTTON_FLAG suffices as the guide button for all cases while the MISC_FLAG seems to only work for Windows, so the logic for emulated DS4 fix is also redundant.