### PR TITLE
Adding toggle button for floating modifier keys in game menu.

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -17,6 +17,7 @@ import com.limelight.binding.input.touch.TrackpadContext;
 import com.limelight.binding.input.virtual_controller.VirtualController;
 import com.limelight.binding.input.virtual_controller.keyboard.KeyBoardController;
 import com.limelight.binding.input.virtual_controller.keyboard.KeyBoardLayoutController;
+import com.limelight.binding.input.virtual_controller.keyboard.FloatingModifierKeysController;
 import com.limelight.binding.video.CrashListener;
 import com.limelight.binding.video.MediaCodecDecoderRenderer;
 import com.limelight.binding.video.MediaCodecHelper;
@@ -144,6 +145,8 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     private VirtualController virtualController;
 
     private KeyBoardController keyBoardController;
+
+    private FloatingModifierKeysController floatingModifierKeysController;
 
     private KeyBoardLayoutController keyBoardLayoutController;
 
@@ -777,6 +780,13 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             return;
         }
         keyBoardController.toggleVisibility();
+    }
+
+    public void toggleFloatingModifierKeys() {
+        if (floatingModifierKeysController == null) {
+            floatingModifierKeysController = new FloatingModifierKeysController(conn, (FrameLayout)rootView, this);
+        }
+        floatingModifierKeysController.toggle();
     }
 
     public void showHidekeyBoardLayoutController(){

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -307,8 +307,12 @@ public class GameMenu implements Game.GameMenuCallbacks {
 
         options.add(new MenuOption(getString(R.string.game_menu_toggle_virtual_model), true,
                 game::showHideVirtualController));
+
         options.add(new MenuOption(getString(R.string.game_menu_toggle_virtual_keyboard_model), true,
                 game::showHidekeyBoardLayoutController));
+
+        options.add(new MenuOption(getString(R.string.game_menu_toggle_floating_modifier_keys), true,
+                game::toggleFloatingModifierKeys));
 
         options.add(new MenuOption(getString(R.string.game_menu_task_manager), true,
                 () -> sendKeys(new short[]{KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_LSHIFT, KeyboardTranslator.VK_ESCAPE})));

--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/keyboard/FloatingModifierKeysController.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/keyboard/FloatingModifierKeysController.java
@@ -1,0 +1,152 @@
+package com.limelight.binding.input.virtual_controller.keyboard;
+
+import android.content.Context;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+
+import com.limelight.Game;
+import com.limelight.binding.input.KeyboardTranslator;
+import com.limelight.nvstream.NvConnection;
+import com.limelight.nvstream.input.KeyboardPacket;
+import com.limelight.preferences.PreferenceConfiguration;
+
+public class FloatingModifierKeysController {
+    private final Context context;
+    private final NvConnection conn;
+    private final FrameLayout frame_layout;
+    private final PreferenceConfiguration prefConfig;
+    private LinearLayout modifierKeysView;
+    private boolean shown = false;
+    private byte modifierState = 0;
+
+    private Button ctrlButton;
+    private Button altButton;
+    private Button shiftButton;
+
+    public FloatingModifierKeysController(NvConnection conn, FrameLayout layout, Context context) {
+        this.context = context;
+        this.conn = conn;
+        this.frame_layout = layout;
+        this.prefConfig = PreferenceConfiguration.readPreferences(context);
+        
+        createModifierKeysView();
+    }
+
+    private void createModifierKeysView() {
+        modifierKeysView = new LinearLayout(context);
+        modifierKeysView.setOrientation(LinearLayout.HORIZONTAL);
+        
+        ctrlButton = createModifierButton("Ctrl", (short)KeyboardTranslator.VK_LCONTROL);
+        altButton = createModifierButton("Alt", (short)KeyboardTranslator.VK_LMENU);
+        shiftButton = createModifierButton("Shift", (short)KeyboardTranslator.VK_LSHIFT);
+
+        modifierKeysView.addView(ctrlButton);
+        modifierKeysView.addView(altButton);
+        modifierKeysView.addView(shiftButton);
+
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT
+        );
+        params.gravity = Gravity.TOP | Gravity.CENTER_HORIZONTAL;
+        params.topMargin = 0;
+        
+        modifierKeysView.setLayoutParams(params);
+        modifierKeysView.setAlpha(prefConfig.oscOpacity / 100f);
+        modifierKeysView.setVisibility(View.GONE);
+    }
+
+    private Button createModifierButton(String text, final short keyCode) {
+        Button button = new Button(context);
+        button.setText(text);
+        button.setAlpha(0.7f);
+        button.setTextSize(8);
+        button.setMinWidth(0);
+        button.setMinHeight(0);
+        button.setPadding(10, 5, 10, 5);
+        
+        // Get default button height and reduce it by 30%
+        int defaultHeight = context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
+        int reducedHeight = (int)(defaultHeight * 0.7); // Reduce height by 30%
+        
+        LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                reducedHeight // Set fixed reduced height
+        );
+        buttonParams.setMargins(2, 0, 2, 0);
+        button.setLayoutParams(buttonParams);
+
+        button.setOnClickListener(v -> {
+            byte modifier = getModifierForKey(keyCode);
+            if ((modifierState & modifier) != 0) {
+                // Key is active, deactivate it
+                modifierState &= ~modifier;
+                button.setAlpha(0.7f);
+                conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_UP, (byte)modifierState, (byte)0);
+            } else {
+                // Key is inactive, activate it
+                modifierState |= modifier;
+                button.setAlpha(1.0f);
+                conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_DOWN, (byte)modifierState, (byte)0);
+            }
+        });
+
+        return button;
+    }
+
+    private byte getModifierForKey(short keyCode) {
+        switch (keyCode) {
+            case KeyboardTranslator.VK_LSHIFT:
+                return KeyboardPacket.MODIFIER_SHIFT;
+            case KeyboardTranslator.VK_LCONTROL:
+                return KeyboardPacket.MODIFIER_CTRL;
+            case KeyboardTranslator.VK_LMENU:
+                return KeyboardPacket.MODIFIER_ALT;
+            default:
+                return 0;
+        }
+    }
+
+    public void show() {
+        if (!shown) {
+            frame_layout.addView(modifierKeysView);
+            modifierKeysView.setVisibility(View.VISIBLE);
+            shown = true;
+        }
+    }
+
+    public void hide() {
+        if (shown) {
+            // Release all pressed modifier keys
+            if ((modifierState & KeyboardPacket.MODIFIER_CTRL) != 0) {
+                conn.sendKeyboardInput((short)KeyboardTranslator.VK_LCONTROL, KeyboardPacket.KEY_UP, (byte)0, (byte)0);
+            }
+            if ((modifierState & KeyboardPacket.MODIFIER_ALT) != 0) {
+                conn.sendKeyboardInput((short)KeyboardTranslator.VK_LMENU, KeyboardPacket.KEY_UP, (byte)0, (byte)0);
+            }
+            if ((modifierState & KeyboardPacket.MODIFIER_SHIFT) != 0) {
+                conn.sendKeyboardInput((short)KeyboardTranslator.VK_LSHIFT, KeyboardPacket.KEY_UP, (byte)0, (byte)0);
+            }
+            modifierState = 0;
+            
+            frame_layout.removeView(modifierKeysView);
+            modifierKeysView.setVisibility(View.GONE);
+            shown = false;
+        }
+    }
+
+    public void toggle() {
+        if (shown) {
+            hide();
+        } else {
+            show();
+        }
+    }
+
+    public boolean isShown() {
+        return shown;
+    }
+} 

--- a/app/src/main/java/com/limelight/binding/input/virtual_controller/keyboard/FloatingModifierKeysController.java
+++ b/app/src/main/java/com/limelight/binding/input/virtual_controller/keyboard/FloatingModifierKeysController.java
@@ -2,6 +2,7 @@ package com.limelight.binding.input.virtual_controller.keyboard;
 
 import android.content.Context;
 import android.view.Gravity;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.FrameLayout;
@@ -21,10 +22,13 @@ public class FloatingModifierKeysController {
     private LinearLayout modifierKeysView;
     private boolean shown = false;
     private byte modifierState = 0;
+    private float dX, dY;
 
     private Button ctrlButton;
     private Button altButton;
     private Button shiftButton;
+    private Button leftHandle;
+    private Button rightHandle;
 
     public FloatingModifierKeysController(NvConnection conn, FrameLayout layout, Context context) {
         this.context = context;
@@ -35,17 +39,62 @@ public class FloatingModifierKeysController {
         createModifierKeysView();
     }
 
+    private Button createHandleButton() {
+        Button handle = new Button(context);
+        handle.setText("");
+        handle.setBackgroundColor(android.graphics.Color.TRANSPARENT);
+        handle.setMinWidth(0);
+        handle.setMinHeight(0);
+        handle.setPadding(2, 0, 2, 0);
+        
+        int defaultHeight = context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
+        int reducedHeight = (int)(defaultHeight * 0.7);
+        
+        LinearLayout.LayoutParams handleParams = new LinearLayout.LayoutParams(
+                10,
+                reducedHeight
+        );
+        handleParams.setMargins(0, 0, 0, 0);
+        handle.setLayoutParams(handleParams);
+
+        handle.setOnTouchListener((v, event) -> {
+            switch (event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    dX = modifierKeysView.getX() - event.getRawX();
+                    dY = modifierKeysView.getY() - event.getRawY();
+                    return true;
+                case MotionEvent.ACTION_MOVE:
+                    modifierKeysView.setX(event.getRawX() + dX);
+                    modifierKeysView.setY(event.getRawY() + dY);
+                    return true;
+                default:
+                    return false;
+            }
+        });
+
+        return handle;
+    }
+
     private void createModifierKeysView() {
         modifierKeysView = new LinearLayout(context);
         modifierKeysView.setOrientation(LinearLayout.HORIZONTAL);
+        
+        leftHandle = createHandleButton();
+        Button middleHandle1 = createHandleButton();
+        Button middleHandle2 = createHandleButton();
+        rightHandle = createHandleButton();
         
         ctrlButton = createModifierButton("Ctrl", (short)KeyboardTranslator.VK_LCONTROL);
         altButton = createModifierButton("Alt", (short)KeyboardTranslator.VK_LMENU);
         shiftButton = createModifierButton("Shift", (short)KeyboardTranslator.VK_LSHIFT);
 
+        modifierKeysView.addView(leftHandle);
         modifierKeysView.addView(ctrlButton);
+        modifierKeysView.addView(middleHandle1);
         modifierKeysView.addView(altButton);
+        modifierKeysView.addView(middleHandle2);
         modifierKeysView.addView(shiftButton);
+        modifierKeysView.addView(rightHandle);
 
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.WRAP_CONTENT,
@@ -68,26 +117,25 @@ public class FloatingModifierKeysController {
         button.setMinHeight(0);
         button.setPadding(10, 5, 10, 5);
         
-        // Get default button height and reduce it by 30%
         int defaultHeight = context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
-        int reducedHeight = (int)(defaultHeight * 0.7); // Reduce height by 30%
+        int reducedHeight = (int)(defaultHeight * 0.7);
+        int defaultWidth = context.getResources().getDimensionPixelSize(android.R.dimen.app_icon_size);
+        int reducedWidth = (int)(defaultWidth * 0.9);
         
         LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.WRAP_CONTENT,
-                reducedHeight // Set fixed reduced height
+                reducedWidth,
+                reducedHeight
         );
-        buttonParams.setMargins(2, 0, 2, 0);
+        buttonParams.setMargins(0, 0, 0, 0);
         button.setLayoutParams(buttonParams);
 
         button.setOnClickListener(v -> {
             byte modifier = getModifierForKey(keyCode);
             if ((modifierState & modifier) != 0) {
-                // Key is active, deactivate it
                 modifierState &= ~modifier;
                 button.setAlpha(0.7f);
                 conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_UP, (byte)modifierState, (byte)0);
             } else {
-                // Key is inactive, activate it
                 modifierState |= modifier;
                 button.setAlpha(1.0f);
                 conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_DOWN, (byte)modifierState, (byte)0);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -357,10 +357,6 @@
     <string name="game_menu_toggle_virtual_keyboard_model">Toggle On-screen full keyboard</string>
     <string name="game_menu_switch_touch_sensitivity_model">Switch touch sensitivity</string>
     <string name="game_menu_toggle_floating_modifier_keys">Toggle Floating Modifier Keys</string>
-    <string name="title_checkbox_show_floating_modifier_keys">Show floating modifier keys</string>
-    <string name="summary_checkbox_show_floating_modifier_keys">Show floating Ctrl, Alt, Shift keys overlay on touchscreen</string>
-    <string name="title_floating_modifier_keys_opacity">Floating Modifier Keys Opacity</string>
-    <string name="summary_floating_modifier_keys_opacity">Adjust the opacity of floating modifier keys</string>
 
 
     <string name="game_menu_toggle_mouse_on">Enable Controller Mouse Emulation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -356,6 +356,11 @@
     <string name="game_menu_toggle_virtual_model">Toggle On-screen controller</string>
     <string name="game_menu_toggle_virtual_keyboard_model">Toggle On-screen full keyboard</string>
     <string name="game_menu_switch_touch_sensitivity_model">Switch touch sensitivity</string>
+    <string name="game_menu_toggle_floating_modifier_keys">Toggle Floating Modifier Keys</string>
+    <string name="title_checkbox_show_floating_modifier_keys">Show floating modifier keys</string>
+    <string name="summary_checkbox_show_floating_modifier_keys">Show floating Ctrl, Alt, Shift keys overlay on touchscreen</string>
+    <string name="title_floating_modifier_keys_opacity">Floating Modifier Keys Opacity</string>
+    <string name="summary_floating_modifier_keys_opacity">Adjust the opacity of floating modifier keys</string>
 
 
     <string name="game_menu_toggle_mouse_on">Enable Controller Mouse Emulation</string>


### PR DESCRIPTION
When using Moonlight to stream applications like photo editors or file managers, I frequently rely on modifier keys like Ctrl and Shift in combination with the mouse or touch input to select multiple items. While the on-screen full keyboard is available, it takes up a significant portion of the screen, which can be disruptive. It would be much more convenient to have the option to toggle just the essential modifier keys—such as Ctrl, Shift, and Alt—so they occupy minimal screen space while still supporting efficient interaction. 

![artemis 1](https://github.com/user-attachments/assets/498f1320-8706-4a28-bfb6-a5ffd7b8d2a3)

![artemis 2](https://github.com/user-attachments/assets/6583bc2d-1cb5-42ff-b7c0-dee4a127c0e2)
