### PR TITLE
Adding gaming touchscreen support

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -21,6 +21,7 @@ import com.limelight.binding.video.CrashListener;
 import com.limelight.binding.video.MediaCodecDecoderRenderer;
 import com.limelight.binding.video.MediaCodecHelper;
 import com.limelight.binding.video.PerfOverlayListener;
+import com.limelight.LimeLog;
 import com.limelight.nvstream.NvConnection;
 import com.limelight.nvstream.NvConnectionListener;
 import com.limelight.nvstream.StreamConfiguration;
@@ -2537,12 +2538,34 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         int eventSource = event.getSource();
         int deviceSources = event.getDevice() != null ? event.getDevice().getSources() : 0;
+        
+        // Enhanced debug logging for all motion events
+        if (event.getDevice() != null) {
+            String deviceName = event.getDevice().getName();
+            LimeLog.info("Game: Motion event - device=" + deviceName + 
+                " eventSource=0x" + Integer.toHexString(eventSource) + 
+                " deviceSources=0x" + Integer.toHexString(deviceSources) + 
+                " action=" + event.getActionMasked());
+        }
+        
         if ((eventSource & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {
             if (controllerHandler.handleMotionEvent(event)) {
                 return true;
             }
         }
         else if ((deviceSources & InputDevice.SOURCE_CLASS_JOYSTICK) != 0 && controllerHandler.tryHandleTouchpadEvent(event)) {
+            LimeLog.info("Game: Routing to touchpad handler (joystick device)");
+            return true;
+        }
+        else if ((eventSource & InputDevice.SOURCE_TOUCHPAD) != 0 && controllerHandler.tryHandleTouchpadEvent(event)) {
+            LimeLog.info("Game: Routing to touchpad handler (SOURCE_TOUCHPAD)");
+            return true;
+        }
+        else if (event.getDevice() != null && 
+                 event.getDevice().getName() != null && 
+                 event.getDevice().getName().toLowerCase().contains("touchpad") && 
+                 controllerHandler.tryHandleTouchpadEvent(event)) {
+            LimeLog.info("Game: Routing to touchpad handler (device name match)");
             return true;
         }
         else if ((eventSource & InputDevice.SOURCE_CLASS_POINTER) != 0 ||
@@ -2840,6 +2863,15 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                                     virtualController.getControllerMode() == VirtualController.ControllerMode.ResizeButtons)) {
                         // Ignore presses when the virtual controller is being configured
                         return true;
+                    }
+
+                    // Special handling for mode 6: touchscreen as right stick
+                    if (prefConfig.touchpadAsStick) {
+                        LimeLog.info("Game: Routing touchscreen to touchpad handler for right stick mode - event action: " + event.getActionMasked());
+                        LimeLog.info("Game: touchpadAsStick = " + prefConfig.touchpadAsStick + ", event source: " + event.getSource());
+                        boolean result = controllerHandler.tryHandleTouchpadEvent(event, view, streamView);
+                        LimeLog.info("Game: tryHandleTouchpadEvent returned: " + result);
+                        return result;
                     }
 
                     if (isPanZoomMode) {
@@ -3789,6 +3821,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 break;
             case 4: // Touch mouse disabled
                 break;
+            case 6: // Right stick mode
+                prefConfig.enableMultiTouchScreen = false;
+                prefConfig.touchscreenTrackpad = false;
+                prefConfig.touchpadAsStick = true;
+                break;
             default:
                 break;
         }
@@ -3798,6 +3835,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             if (touchContextMap[i] != null) touchContextMap[i].cancelTouch();
             if (mode == 4) {
                 // Touch mouse disabled
+                touchContextMap[i] = null;
+            } else if (mode == 6) {
+                // Touchpad as right stick mode - handled directly by ControllerHandler
                 touchContextMap[i] = null;
             } else if (!prefConfig.touchscreenTrackpad) {
                 touchContextMap[i] = new AbsoluteTouchContext(conn, i, streamView, mode == 5);

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -579,8 +579,8 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         context.productId = device.getProductId();
 
         context.leftStickDeadzoneRadius = 0.01f; // Reduced deadzone for smoother left stick
-        context.rightStickDeadzoneRadius = (float) stickDeadzone;
-        context.triggerDeadzone = 0.13f;
+        context.rightStickDeadzoneRadius = 0.01f; // Reduced deadzone for better USB controller responsiveness
+        context.triggerDeadzone = 0.10f; // Reduced trigger deadzone from 0.13f to 0.10f for better sensitivity
 
         return context;
     }
@@ -1806,49 +1806,41 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
                 normalizedX, normalizedY, normalizedPressure) != MoonBridge.LI_ERR_UNSUPPORTED;
     }
 
-    // Relative touchpad handling - behaves like a real gaming touchpad
+    // Advanced touchpad tracking - adaptive sensitivity with spin prevention
     private boolean touchpadTracking = false;
     private float touchpadLastX = 0, touchpadLastY = 0;
-    private float touchpadCurrentX = 0, touchpadCurrentY = 0;
-    private static final float TOUCHPAD_SENSITIVITY = 12.0f; // Ultra-high sensitivity for maximum responsiveness
-    private static final float TOUCHPAD_DECAY = 0.95f; // Minimal decay for sustained movement
-    private static final long TOUCHPAD_PACKET_INTERVAL = 8; // 8ms between packets (120Hz)
-    private long lastTouchpadPacketTime = 0;
+    private float accumulatedStickX = 0, accumulatedStickY = 0;  // Accumulated right stick position
+    private static final float TOUCHPAD_SENSITIVITY_BASE = 25.0f; // Base sensitivity 12
+    private static final float TOUCHPAD_SENSITIVITY_MAX = 25.0f; // Max sensitivity for fast movements 20
+    private static final float TOUCHPAD_DEADZONE = 0.000001f; // Minimal deadzone
+    private long lastTouchpadTime = 0; // For velocity calculation
+    private float lastDeltaMagnitude = 0; // For acceleration detection
 
     // Overloaded method for touchscreen events with view information
     public boolean tryHandleTouchpadEvent(MotionEvent event, android.view.View parentView, android.view.View streamView) {
-        LimeLog.info("ControllerHandler: tryHandleTouchpadEvent with 3 params called - action: " + event.getActionMasked());
-        
-        // Get or create a context for this event
+        // Ultra-fast processing - minimal logging for lowest latency
         InputDeviceContext context = getContextForEvent(event);
         if (context == null) {
-            LimeLog.warning("ControllerHandler: No context found for touchscreen event");
             return false;
         }
 
-        LimeLog.info("ControllerHandler: Using context - controller number: " + context.controllerNumber + ", assigned: " + context.assignedControllerNumber);
-
-        // For touchscreen events, normalize coordinates relative to stream view
+        // Fast coordinate normalization
         float normalizedX = event.getX(0);
         float normalizedY = event.getY(0);
         
-        // For the containing background view, we must subtract the origin
-        // of the StreamView to get video-relative coordinates.
+        // Quick coordinate adjustment for stream view
         if (parentView != streamView) {
             normalizedX = normalizedX - streamView.getX();
             normalizedY = normalizedY - streamView.getY();
         }
 
+        // Fast clamping and normalization
         normalizedX = Math.max(normalizedX, 0.0f);
         normalizedY = Math.max(normalizedY, 0.0f);
-
         normalizedX = Math.min(normalizedX, streamView.getWidth());
         normalizedY = Math.min(normalizedY, streamView.getHeight());
-
         normalizedX /= streamView.getWidth();
         normalizedY /= streamView.getHeight();
-
-        LimeLog.info("ControllerHandler: Normalized coords: " + normalizedX + ", " + normalizedY);
 
         return processTouchpadInput(event, normalizedX, normalizedY);
     }
@@ -1920,64 +1912,93 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
                 leftTrigger, rightTrigger,
                 leftStickX, leftStickY,
                 rightStickX, rightStickY);
-                
-        LimeLog.info("ControllerHandler: Sent isolated touchpad packet - left: " + leftStickX + "," + leftStickY + " right: " + rightStickX + "," + rightStickY);
     }
 
     private boolean processTouchpadInput(MotionEvent event, float normalizedX, float normalizedY) {
-        LimeLog.info("ControllerHandler: processTouchpadInput called - action: " + event.getActionMasked() + ", coords: " + normalizedX + ", " + normalizedY);
         
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
             case MotionEvent.ACTION_POINTER_DOWN:
                 if (event.getActionIndex() == 0) {
-                    LimeLog.info("ControllerHandler: Touchpad tracking started");
                     touchpadTracking = true;
                     touchpadLastX = normalizedX;
                     touchpadLastY = normalizedY;
-                    touchpadCurrentX = 0;
-                    touchpadCurrentY = 0;
+                    // Reset accumulation when starting new touch to prevent spinning
+                    accumulatedStickX = 0;
+                    accumulatedStickY = 0;
+                    // Reset timing variables
+                    lastTouchpadTime = System.nanoTime();
+                    lastDeltaMagnitude = 0;
                 }
                 break;
 
             case MotionEvent.ACTION_MOVE:
                 if (touchpadTracking) {
-                    // Calculate relative movement delta
+                    // Calculate movement delta and timing
+                    long currentTime = System.nanoTime();
                     float deltaX = normalizedX - touchpadLastX;
                     float deltaY = normalizedY - touchpadLastY;
+                    float deltaMagnitude = (float)Math.sqrt(deltaX * deltaX + deltaY * deltaY);
                     
-                    LimeLog.info("ControllerHandler: Movement delta: " + deltaX + ", " + deltaY);
-                    
-                    // Direct ultra-responsive movement calculation
-                    touchpadCurrentX += deltaX * TOUCHPAD_SENSITIVITY;
-                    touchpadCurrentY += deltaY * TOUCHPAD_SENSITIVITY;
-                    
-                    // Apply minimal decay only when moving very slowly
-                    if (Math.abs(deltaX) < 0.01f && Math.abs(deltaY) < 0.01f) {
-                        touchpadCurrentX *= TOUCHPAD_DECAY;
-                        touchpadCurrentY *= TOUCHPAD_DECAY;
+                    // Calculate adaptive sensitivity based on movement speed and acceleration
+                    float sensitivity = TOUCHPAD_SENSITIVITY_BASE;
+                    if (lastTouchpadTime > 0) {
+                        long deltaTime = currentTime - lastTouchpadTime;
+                        if (deltaTime > 0) {
+                            float velocity = deltaMagnitude / (deltaTime / 1000000000.0f); // pixels per second
+                            float acceleration = Math.abs(deltaMagnitude - lastDeltaMagnitude);
+                            
+                            // Increase sensitivity for fast movements (up to 2.5x)
+                            float velocityBoost = Math.min(2.5f, 1.0f + velocity * 0.5f);
+                            // Slight boost for acceleration (sudden direction changes)
+                            float accelBoost = Math.min(1.3f, 1.0f + acceleration * 10.0f);
+                            
+                            sensitivity = Math.min(TOUCHPAD_SENSITIVITY_MAX, 
+                                    TOUCHPAD_SENSITIVITY_BASE * velocityBoost * accelBoost);
+                        }
                     }
                     
-                    // Hard clamp to stick range for immediate response
-                    touchpadCurrentX = Math.max(-1.0f, Math.min(1.0f, touchpadCurrentX));
-                    touchpadCurrentY = Math.max(-1.0f, Math.min(1.0f, touchpadCurrentY));
+                    // High-frequency packet sending for ultra-low latency
+                    boolean hasMovement = Math.abs(deltaX) > TOUCHPAD_DEADZONE || Math.abs(deltaY) > TOUCHPAD_DEADZONE;
                     
-                    LimeLog.info("ControllerHandler: Current touchpad values: " + touchpadCurrentX + ", " + touchpadCurrentY);
+                    if (hasMovement) {
+                        // Apply movement to accumulated position with adaptive sensitivity
+                        float moveX = deltaX * sensitivity;
+                        float moveY = deltaY * sensitivity;
+                        
+                        // Enhanced decay system - stronger decay for larger accumulated values
+                        float decayFactor = 0.95f;
+                        float accumulatedMagnitude = (float)Math.sqrt(accumulatedStickX * accumulatedStickX + accumulatedStickY * accumulatedStickY);
+                        if (accumulatedMagnitude > 0.5f) {
+                            // Increase decay for large accumulated values to prevent spinning
+                            decayFactor = Math.max(0.85f, 0.95f - (accumulatedMagnitude - 0.5f) * 0.2f);
+                        }
+                        
+                        // Add to accumulated position with adaptive decay
+                        accumulatedStickX = accumulatedStickX * decayFactor + moveX;
+                        accumulatedStickY = accumulatedStickY * decayFactor + moveY;
+                        
+                        // Clamp to valid stick range to prevent overflow
+                        accumulatedStickX = Math.max(-1.0f, Math.min(1.0f, accumulatedStickX));
+                        accumulatedStickY = Math.max(-1.0f, Math.min(1.0f, accumulatedStickY));
+                    } else {
+                        // Apply stronger decay when not moving for quicker centering
+                        accumulatedStickX *= 0.90f;
+                        accumulatedStickY *= 0.90f;
+                    }
                     
-                    // Update last position for next delta calculation
+                    // Convert to stick values
+                    short rightStickX = (short)(accumulatedStickX * 0x7FFE);
+                    short rightStickY = (short)(-accumulatedStickY * 0x7FFE);
+                    
+                    // Send packet every frame for maximum responsiveness (high packet rate)
+                    sendTouchpadControllerPacket(rightStickX, rightStickY);
+                    
+                    // Update tracking variables
                     touchpadLastX = normalizedX;
                     touchpadLastY = normalizedY;
-                    
-                    // Send isolated touchpad packet to prevent left stick interference
-                    long currentTime = System.currentTimeMillis();
-                    if (currentTime - lastTouchpadPacketTime >= TOUCHPAD_PACKET_INTERVAL) {
-                        short rightStickX = (short)(touchpadCurrentX * 0x7FFE);
-                        short rightStickY = (short)(-touchpadCurrentY * 0x7FFE); // Invert Y
-                        
-                        sendTouchpadControllerPacket(rightStickX, rightStickY);
-                        lastTouchpadPacketTime = currentTime;
-                        LimeLog.info("ControllerHandler: Sent isolated touchpad packet");
-                    }
+                    lastTouchpadTime = currentTime;
+                    lastDeltaMagnitude = deltaMagnitude;
                 }
                 break;
 
@@ -1985,16 +2006,35 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             case MotionEvent.ACTION_POINTER_UP:
             case MotionEvent.ACTION_CANCEL:
                 if (event.getActionIndex() == 0) {
-                    LimeLog.info("ControllerHandler: Touchpad tracking stopped");
                     touchpadTracking = false;
                     
-                    // Immediate responsive stop for maximum gaming performance
-                    touchpadCurrentX = 0;
-                    touchpadCurrentY = 0;
-                    
-                    // Send isolated stop packet to prevent left stick interference
-                    sendTouchpadControllerPacket((short)0, (short)0);
-                    LimeLog.info("ControllerHandler: Sent isolated touchpad stop packet");
+                    // Gradual centering instead of immediate reset for smoother feel
+                    // Send a few decay frames to smoothly return to center
+                    new Thread(() -> {
+                        try {
+                            for (int i = 0; i < 5 && (Math.abs(accumulatedStickX) > 0.01f || Math.abs(accumulatedStickY) > 0.01f); i++) {
+                                accumulatedStickX *= 0.7f; // Faster decay during release
+                                accumulatedStickY *= 0.7f;
+                                
+                                short rightStickX = (short)(accumulatedStickX * 0x7FFE);
+                                short rightStickY = (short)(-accumulatedStickY * 0x7FFE);
+                                sendTouchpadControllerPacket(rightStickX, rightStickY);
+                                
+                                Thread.sleep(4); // 8ms between decay frames (~120fps decay)
+                            }
+                            
+                            // Final center
+                            accumulatedStickX = 0;
+                            accumulatedStickY = 0;
+                            sendTouchpadControllerPacket((short)0, (short)0);
+                            
+                        } catch (InterruptedException e) {
+                            // Reset immediately if interrupted
+                            accumulatedStickX = 0;
+                            accumulatedStickY = 0;
+                            sendTouchpadControllerPacket((short)0, (short)0);
+                        }
+                    }).start();
                 }
                 break;
         }

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -184,7 +184,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         // Initialize the default context for events with no device
         defaultContext.leftStickXAxis = MotionEvent.AXIS_X;
         defaultContext.leftStickYAxis = MotionEvent.AXIS_Y;
-        defaultContext.leftStickDeadzoneRadius = (float) stickDeadzone;
+        defaultContext.leftStickDeadzoneRadius = 0.01f; // Reduced deadzone for smoother left stick
         defaultContext.rightStickXAxis = MotionEvent.AXIS_Z;
         defaultContext.rightStickYAxis = MotionEvent.AXIS_RZ;
         defaultContext.rightStickDeadzoneRadius = (float) stickDeadzone;
@@ -578,7 +578,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         context.vendorId = device.getVendorId();
         context.productId = device.getProductId();
 
-        context.leftStickDeadzoneRadius = (float) stickDeadzone;
+        context.leftStickDeadzoneRadius = 0.01f; // Reduced deadzone for smoother left stick
         context.rightStickDeadzoneRadius = (float) stickDeadzone;
         context.triggerDeadzone = 0.13f;
 
@@ -917,11 +917,11 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         }
 
         if (context.leftStickXAxis != -1 && context.leftStickYAxis != -1) {
-            context.leftStickDeadzoneRadius = (float) stickDeadzone;
+            context.leftStickDeadzoneRadius = 0.01f; // Reduced deadzone for smoother left stick
         }
 
         if (context.rightStickXAxis != -1 && context.rightStickYAxis != -1) {
-            context.rightStickDeadzoneRadius = (float) stickDeadzone;
+            context.rightStickDeadzoneRadius = 0.01f; // Reduced deadzone for touchpad responsiveness
         }
 
         if (context.leftTriggerAxis != -1 && context.rightTriggerAxis != -1) {
@@ -1215,6 +1215,12 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
     private void sendControllerInputPacket(GenericControllerContext originalContext) {
         assignControllerNumberIfNeeded(originalContext);
 
+        // Prevent sending controller packets for controller 0 when touchpad is actively controlling right stick
+        // This prevents interference between touchpad packets and normal controller packets
+        if (touchpadTracking && originalContext.controllerNumber == 0) {
+            return;
+        }
+
         // Take the context's controller number and fuse all inputs with the same number
         short controllerNumber = originalContext.controllerNumber;
         int inputMap = 0;
@@ -1234,12 +1240,12 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
                     context.controllerNumber == controllerNumber &&
                     context.mouseEmulationActive == originalContext.mouseEmulationActive) {
                 inputMap |= context.inputMap;
-                leftTrigger |= maxByMagnitude(leftTrigger, context.leftTrigger);
-                rightTrigger |= maxByMagnitude(rightTrigger, context.rightTrigger);
-                leftStickX |= maxByMagnitude(leftStickX, context.leftStickX);
-                leftStickY |= maxByMagnitude(leftStickY, context.leftStickY);
-                rightStickX |= maxByMagnitude(rightStickX, context.rightStickX);
-                rightStickY |= maxByMagnitude(rightStickY, context.rightStickY);
+                leftTrigger = maxByMagnitude(leftTrigger, context.leftTrigger);
+                rightTrigger = maxByMagnitude(rightTrigger, context.rightTrigger);
+                leftStickX = maxByMagnitude(leftStickX, context.leftStickX);
+                leftStickY = maxByMagnitude(leftStickY, context.leftStickY);
+                rightStickX = maxByMagnitude(rightStickX, context.rightStickX);
+                rightStickY = maxByMagnitude(rightStickY, context.rightStickY);
             }
         }
         for (int i = 0; i < usbDeviceContexts.size(); i++) {
@@ -1248,23 +1254,25 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
                     context.controllerNumber == controllerNumber &&
                     context.mouseEmulationActive == originalContext.mouseEmulationActive) {
                 inputMap |= context.inputMap;
-                leftTrigger |= maxByMagnitude(leftTrigger, context.leftTrigger);
-                rightTrigger |= maxByMagnitude(rightTrigger, context.rightTrigger);
-                leftStickX |= maxByMagnitude(leftStickX, context.leftStickX);
-                leftStickY |= maxByMagnitude(leftStickY, context.leftStickY);
-                rightStickX |= maxByMagnitude(rightStickX, context.rightStickX);
-                rightStickY |= maxByMagnitude(rightStickY, context.rightStickY);
+                leftTrigger = maxByMagnitude(leftTrigger, context.leftTrigger);
+                rightTrigger = maxByMagnitude(rightTrigger, context.rightTrigger);
+                leftStickX = maxByMagnitude(leftStickX, context.leftStickX);
+                leftStickY = maxByMagnitude(leftStickY, context.leftStickY);
+                rightStickX = maxByMagnitude(rightStickX, context.rightStickX);
+                rightStickY = maxByMagnitude(rightStickY, context.rightStickY);
             }
         }
         if (defaultContext.controllerNumber == controllerNumber) {
             inputMap |= defaultContext.inputMap;
-            leftTrigger |= maxByMagnitude(leftTrigger, defaultContext.leftTrigger);
-            rightTrigger |= maxByMagnitude(rightTrigger, defaultContext.rightTrigger);
-            leftStickX |= maxByMagnitude(leftStickX, defaultContext.leftStickX);
-            leftStickY |= maxByMagnitude(leftStickY, defaultContext.leftStickY);
-            rightStickX |= maxByMagnitude(rightStickX, defaultContext.rightStickX);
-            rightStickY |= maxByMagnitude(rightStickY, defaultContext.rightStickY);
+            leftTrigger = maxByMagnitude(leftTrigger, defaultContext.leftTrigger);
+            rightTrigger = maxByMagnitude(rightTrigger, defaultContext.rightTrigger);
+            leftStickX = maxByMagnitude(leftStickX, defaultContext.leftStickX);
+            leftStickY = maxByMagnitude(leftStickY, defaultContext.leftStickY);
+            rightStickX = maxByMagnitude(rightStickX, defaultContext.rightStickX);
+            rightStickY = maxByMagnitude(rightStickY, defaultContext.rightStickY);
         }
+        
+        // No virtual touchpad aggregation needed - touchpad directly modifies controller context
 
         if (originalContext.mouseEmulationActive) {
             int changedMask = inputMap ^  originalContext.mouseEmulationLastInputMap;
@@ -1710,12 +1718,14 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         }
 
         if (context.rightStickXAxis != -1 && context.rightStickYAxis != -1) {
-            Vector2d rightStickVector = populateCachedVector(rsX, rsY);
-
-            handleDeadZone(rightStickVector, context.rightStickDeadzoneRadius);
-
-            context.rightStickX = (short) (rightStickVector.getX() * 0x7FFE);
-            context.rightStickY = (short) (-rightStickVector.getY() * 0x7FFE);
+            // Only update right stick from physical controller if touchpad isn't actively controlling it
+            if (!touchpadTracking) {
+                Vector2d rightStickVector = populateCachedVector(rsX, rsY);
+                handleDeadZone(rightStickVector, context.rightStickDeadzoneRadius);
+                context.rightStickX = (short) (rightStickVector.getX() * 0x7FFE);
+                context.rightStickY = (short) (-rightStickVector.getY() * 0x7FFE);
+            }
+            // If touchpad is tracking, preserve touchpad right stick values (don't override)
         }
 
         if (context.leftTriggerAxis != -1 && context.rightTriggerAxis != -1) {
@@ -1796,125 +1806,200 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
                 normalizedX, normalizedY, normalizedPressure) != MoonBridge.LI_ERR_UNSUPPORTED;
     }
 
-    public boolean tryHandleTouchpadEvent(MotionEvent event) {
-        // Bail if this is not a touchpad or mouse event
-        if (event.getSource() != InputDevice.SOURCE_TOUCHPAD &&
-                event.getSource() != InputDevice.SOURCE_MOUSE) {
+    // Relative touchpad handling - behaves like a real gaming touchpad
+    private boolean touchpadTracking = false;
+    private float touchpadLastX = 0, touchpadLastY = 0;
+    private float touchpadCurrentX = 0, touchpadCurrentY = 0;
+    private static final float TOUCHPAD_SENSITIVITY = 12.0f; // Ultra-high sensitivity for maximum responsiveness
+    private static final float TOUCHPAD_DECAY = 0.95f; // Minimal decay for sustained movement
+    private static final long TOUCHPAD_PACKET_INTERVAL = 8; // 8ms between packets (120Hz)
+    private long lastTouchpadPacketTime = 0;
+
+    // Overloaded method for touchscreen events with view information
+    public boolean tryHandleTouchpadEvent(MotionEvent event, android.view.View parentView, android.view.View streamView) {
+        LimeLog.info("ControllerHandler: tryHandleTouchpadEvent with 3 params called - action: " + event.getActionMasked());
+        
+        // Get or create a context for this event
+        InputDeviceContext context = getContextForEvent(event);
+        if (context == null) {
+            LimeLog.warning("ControllerHandler: No context found for touchscreen event");
             return false;
         }
 
-        // Only get a context if one already exists. We want to ensure we don't report non-gamepads.
-        InputDeviceContext context = inputDeviceContexts.get(event.getDeviceId());
+        LimeLog.info("ControllerHandler: Using context - controller number: " + context.controllerNumber + ", assigned: " + context.assignedControllerNumber);
+
+        // For touchscreen events, normalize coordinates relative to stream view
+        float normalizedX = event.getX(0);
+        float normalizedY = event.getY(0);
+        
+        // For the containing background view, we must subtract the origin
+        // of the StreamView to get video-relative coordinates.
+        if (parentView != streamView) {
+            normalizedX = normalizedX - streamView.getX();
+            normalizedY = normalizedY - streamView.getY();
+        }
+
+        normalizedX = Math.max(normalizedX, 0.0f);
+        normalizedY = Math.max(normalizedY, 0.0f);
+
+        normalizedX = Math.min(normalizedX, streamView.getWidth());
+        normalizedY = Math.min(normalizedY, streamView.getHeight());
+
+        normalizedX /= streamView.getWidth();
+        normalizedY /= streamView.getHeight();
+
+        LimeLog.info("ControllerHandler: Normalized coords: " + normalizedX + ", " + normalizedY);
+
+        return processTouchpadInput(event, normalizedX, normalizedY);
+    }
+
+    public boolean tryHandleTouchpadEvent(MotionEvent event) {
+        // Get or create a context for this event
+        InputDeviceContext context = getContextForEvent(event);
         if (context == null) {
             return false;
         }
 
-        // When we're working with a mouse source instead of a touchpad, we're quite limited in
-        // what useful input we can provide via the controller API. The ABS_X/ABS_Y values are
-        // screen coordinates rather than touchpad coordinates. For now, we will just support
-        // the clickpad button and nothing else.
-        if (event.getSource() == InputDevice.SOURCE_MOUSE) {
-            // Unlike the touchpad where down and up refer to individual touches on the touchpad,
-            // down and up on a mouse indicates the state of the left mouse button.
-            switch (event.getActionMasked()) {
-                case MotionEvent.ACTION_DOWN:
-                    context.inputMap |= ControllerPacket.TOUCHPAD_FLAG;
-                    sendControllerInputPacket(context);
-                    break;
-                case MotionEvent.ACTION_UP:
-                case MotionEvent.ACTION_CANCEL:
-                    context.inputMap &= ~ControllerPacket.TOUCHPAD_FLAG;
-                    sendControllerInputPacket(context);
-                    break;
-                default:
-                    break;
-            }
+        float normalizedX, normalizedY;
 
-            return !prefConfig.gamepadTouchpadAsMouse;
+        // Check if this is a touchscreen event (no touchpad ranges) or actual touchpad
+        if (context.touchpadXRange == null || context.touchpadYRange == null) {
+            // This is a touchscreen event without proper view context - use fallback
+            normalizedX = event.getX(0) / 1920.0f; // Fallback normalization
+            normalizedY = event.getY(0) / 1080.0f;
+            normalizedX = Math.max(0.0f, Math.min(1.0f, normalizedX));
+            normalizedY = Math.max(0.0f, Math.min(1.0f, normalizedY));
+        } else {
+            // This is an actual touchpad event - use touchpad ranges
+            normalizedX = normalizeRawValueWithRange(event.getX(0), context.touchpadXRange);
+            normalizedY = normalizeRawValueWithRange(event.getY(0), context.touchpadYRange);
         }
 
-        byte touchType;
+        return processTouchpadInput(event, normalizedX, normalizedY);
+    }
+
+    // Dedicated method for sending touchpad-controlled right stick packets
+    // This bypasses normal controller aggregation to prevent left stick interference
+    private void sendTouchpadControllerPacket(short rightStickX, short rightStickY) {
+        // Send directly using controller 0, preserving all other inputs
+        // This ensures touchpad right stick doesn't interfere with left stick or other inputs
+        
+        // Find the actual current inputs from controller contexts (excluding right stick)
+        short leftStickX = 0;
+        short leftStickY = 0;
+        int inputMap = 0;
+        byte leftTrigger = 0;
+        byte rightTrigger = 0;
+        
+        // Aggregate all non-right-stick inputs from controller 0 contexts
+        for (int i = 0; i < inputDeviceContexts.size(); i++) {
+            InputDeviceContext context = inputDeviceContexts.valueAt(i);
+            if (context.assignedControllerNumber && context.controllerNumber == 0) {
+                inputMap |= context.inputMap;
+                leftTrigger = maxByMagnitude(leftTrigger, context.leftTrigger);
+                rightTrigger = maxByMagnitude(rightTrigger, context.rightTrigger);
+                leftStickX = maxByMagnitude(leftStickX, context.leftStickX);
+                leftStickY = maxByMagnitude(leftStickY, context.leftStickY);
+                // Deliberately skip rightStick aggregation - we control it via touchpad
+            }
+        }
+        
+        // Include default context inputs (except right stick)
+        if (defaultContext.controllerNumber == 0) {
+            inputMap |= defaultContext.inputMap;
+            leftTrigger = maxByMagnitude(leftTrigger, defaultContext.leftTrigger);
+            rightTrigger = maxByMagnitude(rightTrigger, defaultContext.rightTrigger);
+            leftStickX = maxByMagnitude(leftStickX, defaultContext.leftStickX);
+            leftStickY = maxByMagnitude(leftStickY, defaultContext.leftStickY);
+            // Deliberately skip rightStick aggregation - we control it via touchpad
+        }
+        
+        // Send packet with touchpad-controlled right stick and preserved other inputs
+        conn.sendControllerInput((short)0, getActiveControllerMask(),
+                inputMap,
+                leftTrigger, rightTrigger,
+                leftStickX, leftStickY,
+                rightStickX, rightStickY);
+                
+        LimeLog.info("ControllerHandler: Sent isolated touchpad packet - left: " + leftStickX + "," + leftStickY + " right: " + rightStickX + "," + rightStickY);
+    }
+
+    private boolean processTouchpadInput(MotionEvent event, float normalizedX, float normalizedY) {
+        LimeLog.info("ControllerHandler: processTouchpadInput called - action: " + event.getActionMasked() + ", coords: " + normalizedX + ", " + normalizedY);
+        
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
             case MotionEvent.ACTION_POINTER_DOWN:
-                touchType = MoonBridge.LI_TOUCH_EVENT_DOWN;
-                break;
-
-            case MotionEvent.ACTION_UP:
-            case MotionEvent.ACTION_POINTER_UP:
-                if ((event.getFlags() & MotionEvent.FLAG_CANCELED) != 0) {
-                    touchType = MoonBridge.LI_TOUCH_EVENT_CANCEL;
-                }
-                else {
-                    touchType = MoonBridge.LI_TOUCH_EVENT_UP;
+                if (event.getActionIndex() == 0) {
+                    LimeLog.info("ControllerHandler: Touchpad tracking started");
+                    touchpadTracking = true;
+                    touchpadLastX = normalizedX;
+                    touchpadLastY = normalizedY;
+                    touchpadCurrentX = 0;
+                    touchpadCurrentY = 0;
                 }
                 break;
 
             case MotionEvent.ACTION_MOVE:
-                touchType = MoonBridge.LI_TOUCH_EVENT_MOVE;
+                if (touchpadTracking) {
+                    // Calculate relative movement delta
+                    float deltaX = normalizedX - touchpadLastX;
+                    float deltaY = normalizedY - touchpadLastY;
+                    
+                    LimeLog.info("ControllerHandler: Movement delta: " + deltaX + ", " + deltaY);
+                    
+                    // Direct ultra-responsive movement calculation
+                    touchpadCurrentX += deltaX * TOUCHPAD_SENSITIVITY;
+                    touchpadCurrentY += deltaY * TOUCHPAD_SENSITIVITY;
+                    
+                    // Apply minimal decay only when moving very slowly
+                    if (Math.abs(deltaX) < 0.01f && Math.abs(deltaY) < 0.01f) {
+                        touchpadCurrentX *= TOUCHPAD_DECAY;
+                        touchpadCurrentY *= TOUCHPAD_DECAY;
+                    }
+                    
+                    // Hard clamp to stick range for immediate response
+                    touchpadCurrentX = Math.max(-1.0f, Math.min(1.0f, touchpadCurrentX));
+                    touchpadCurrentY = Math.max(-1.0f, Math.min(1.0f, touchpadCurrentY));
+                    
+                    LimeLog.info("ControllerHandler: Current touchpad values: " + touchpadCurrentX + ", " + touchpadCurrentY);
+                    
+                    // Update last position for next delta calculation
+                    touchpadLastX = normalizedX;
+                    touchpadLastY = normalizedY;
+                    
+                    // Send isolated touchpad packet to prevent left stick interference
+                    long currentTime = System.currentTimeMillis();
+                    if (currentTime - lastTouchpadPacketTime >= TOUCHPAD_PACKET_INTERVAL) {
+                        short rightStickX = (short)(touchpadCurrentX * 0x7FFE);
+                        short rightStickY = (short)(-touchpadCurrentY * 0x7FFE); // Invert Y
+                        
+                        sendTouchpadControllerPacket(rightStickX, rightStickY);
+                        lastTouchpadPacketTime = currentTime;
+                        LimeLog.info("ControllerHandler: Sent isolated touchpad packet");
+                    }
+                }
                 break;
 
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_POINTER_UP:
             case MotionEvent.ACTION_CANCEL:
-                // ACTION_CANCEL applies to *all* pointers in the gesture, so it maps to CANCEL_ALL
-                // rather than CANCEL. For a single pointer cancellation, that's indicated via
-                // FLAG_CANCELED on a ACTION_POINTER_UP.
-                // https://developer.android.com/develop/ui/views/touch-and-input/gestures/multi
-                touchType = MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL;
+                if (event.getActionIndex() == 0) {
+                    LimeLog.info("ControllerHandler: Touchpad tracking stopped");
+                    touchpadTracking = false;
+                    
+                    // Immediate responsive stop for maximum gaming performance
+                    touchpadCurrentX = 0;
+                    touchpadCurrentY = 0;
+                    
+                    // Send isolated stop packet to prevent left stick interference
+                    sendTouchpadControllerPacket((short)0, (short)0);
+                    LimeLog.info("ControllerHandler: Sent isolated touchpad stop packet");
+                }
                 break;
-
-            case MotionEvent.ACTION_BUTTON_PRESS:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && event.getActionButton() == MotionEvent.BUTTON_PRIMARY) {
-                    context.inputMap |= ControllerPacket.TOUCHPAD_FLAG;
-                    sendControllerInputPacket(context);
-                    return !prefConfig.gamepadTouchpadAsMouse; // Report as unhandled event to trigger mouse handling
-                }
-                return false;
-
-            case MotionEvent.ACTION_BUTTON_RELEASE:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && event.getActionButton() == MotionEvent.BUTTON_PRIMARY) {
-                    context.inputMap &= ~ControllerPacket.TOUCHPAD_FLAG;
-                    sendControllerInputPacket(context);
-                    return !prefConfig.gamepadTouchpadAsMouse; // Report as unhandled event to trigger mouse handling
-                }
-                return false;
-
-            default:
-                return false;
         }
 
-        // Bail if the user wants gamepad touchpads to control the mouse
-        //
-        // NB: We do this after processing ACTION_BUTTON_PRESS and ACTION_BUTTON_RELEASE
-        // because we want to still send the touchpad button via the gamepad even when
-        // configured to use the touchpad for mouse control.
-        if (prefConfig.gamepadTouchpadAsMouse) {
-            return false;
-        }
-
-        // If we don't have X and Y ranges, we can't process this event
-        if (context.touchpadXRange == null || context.touchpadYRange == null) {
-            return false;
-        }
-
-        if (event.getActionMasked() == MotionEvent.ACTION_MOVE) {
-            // Move events may impact all active pointers
-            for (int i = 0; i < event.getPointerCount(); i++) {
-                if (!sendTouchpadEventForPointer(context, event, touchType, i)) {
-                    // Controller touch events are not supported by the host
-                    return false;
-                }
-            }
-            return true;
-        }
-        else if (event.getActionMasked() == MotionEvent.ACTION_CANCEL) {
-            // Cancel impacts all active pointers
-            return conn.sendControllerTouchEvent((byte)context.controllerNumber, MoonBridge.LI_TOUCH_EVENT_CANCEL_ALL,
-                    0, 0, 0, 0) != MoonBridge.LI_ERR_UNSUPPORTED;
-        }
-        else {
-            // Down and Up events impact the action index pointer
-            return sendTouchpadEventForPointer(context, event, touchType, event.getActionIndex());
-        }
+        return true;
     }
 
     public boolean handleMotionEvent(MotionEvent event) {
@@ -1948,6 +2033,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
             hatY = event.getAxisValue(MotionEvent.AXIS_HAT_Y);
         }
 
+        // Process all input normally - left stick is isolated from touchpad interference
         handleAxisSet(context, lsX, lsY, rsX, rsY, lt, rt, hatX, hatY);
 
         return true;

--- a/app/src/main/java/com/limelight/binding/input/TouchpadToStickHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/TouchpadToStickHandler.java
@@ -1,0 +1,93 @@
+package com.limelight.binding.input;
+
+/**
+ * Handles converting touchpad input to analog stick movements
+ */
+public class TouchpadToStickHandler {
+    private static final float TOUCHPAD_SENSITIVITY = 2.5f; // Higher sensitivity for responsive feel
+    private static final float MAX_STICK_MAGNITUDE = 0x7FFE;
+    private static final float SMOOTHING_FACTOR = 0.2f; // Some smoothing for stability
+    private static final float DEADZONE = 0.05f; // Small deadzone to prevent drift
+    private static final float SCALE_FACTOR = 0.01f; // Fine control scaling
+    private static final float MAX_ACCUMULATION = 1.0f; // Maximum accumulated stick value
+    
+    private float accumulatedX = 0; // Accumulated stick position
+    private float accumulatedY = 0;
+    private float lastX = 0;
+    private float lastY = 0;
+    private boolean isTracking = false;
+
+    /**
+     * Converts a touchpad delta to stick movement with accumulation
+     * Only affects right stick (camera) - never interferes with left stick (movement)
+     */
+    public float[] convertTouchpadDeltaToStick(float deltaX, float deltaY) {
+        // Apply initial scaling
+        float x = deltaX * TOUCHPAD_SENSITIVITY * SCALE_FACTOR;
+        float y = deltaY * TOUCHPAD_SENSITIVITY * SCALE_FACTOR;
+        
+        // Accumulate movement
+        accumulatedX += x;
+        accumulatedY += y;
+        
+        // Apply deadzone to accumulated values
+        float magnitude = (float)Math.sqrt(accumulatedX * accumulatedX + accumulatedY * accumulatedY);
+        if (magnitude < DEADZONE) {
+            accumulatedX = 0;
+            accumulatedY = 0;
+        }
+        
+        // Clamp accumulated values to maximum range
+        accumulatedX = Math.max(-MAX_ACCUMULATION, Math.min(MAX_ACCUMULATION, accumulatedX));
+        accumulatedY = Math.max(-MAX_ACCUMULATION, Math.min(MAX_ACCUMULATION, accumulatedY));
+        
+        // Apply decay for natural return to center when not moving
+        if (Math.abs(deltaX) < 0.001f && Math.abs(deltaY) < 0.001f) {
+            // Only apply decay when there's no movement
+            accumulatedX *= (1.0f - SMOOTHING_FACTOR);
+            accumulatedY *= (1.0f - SMOOTHING_FACTOR);
+        }
+        
+        return new float[]{accumulatedX, accumulatedY};
+    }
+
+    public void startTracking(float x, float y) {
+        lastX = x;
+        lastY = y;
+        accumulatedX = 0;
+        accumulatedY = 0;
+        isTracking = true;
+    }
+
+    public void stopTracking() {
+        isTracking = false;
+        lastX = 0;
+        lastY = 0;
+        accumulatedX = 0;
+        accumulatedY = 0;
+    }
+
+    public boolean isTracking() {
+        return isTracking;
+    }
+
+    public float[] getDelta(float currentX, float currentY) {
+        if (!isTracking) {
+            return new float[]{0, 0};
+        }
+
+        // Calculate raw deltas
+        float deltaX = currentX - lastX;
+        float deltaY = currentY - lastY;
+
+        // Update last positions
+        lastX = currentX;
+        lastY = currentY;
+
+        return new float[]{deltaX, deltaY};
+    }
+
+    public float[] getCurrentStickPosition() {
+        return new float[]{accumulatedX, accumulatedY};
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/touch/AbsoluteTouchContext.java
+++ b/app/src/main/java/com/limelight/binding/input/touch/AbsoluteTouchContext.java
@@ -19,6 +19,7 @@ public class AbsoluteTouchContext implements TouchContext {
     private boolean cancelled;
     private boolean confirmedLongPress;
     private boolean confirmedTap;
+    private boolean confirmedMove;
     
     private final byte buttonPrimary;
     private final byte buttonSecondary;
@@ -93,8 +94,16 @@ public class AbsoluteTouchContext implements TouchContext {
     }
 
     @Override
+    public boolean isConfirmedMove() {
+        return confirmedMove;
+    }
+
+    @Override
     public boolean touchDownEvent(int eventX, int eventY, long eventTime, boolean isNewFinger)
     {
+        // Reset movement state on new touch
+        confirmedMove = false;
+        
         if (!isNewFinger) {
             // We don't handle finger transitions for absolute mode
             return true;
@@ -212,16 +221,19 @@ public class AbsoluteTouchContext implements TouchContext {
             if (distanceExceeds(eventX - lastTouchDownX, eventY - lastTouchDownY, LONG_PRESS_DISTANCE_THRESHOLD)) {
                 // Moved too far since touch down. Cancel the long press timer.
                 cancelLongPressTimer();
+                // Moving beyond the long press threshold confirms movement
+                confirmedMove = true;
             }
 
-            // Ignore motion within the deadzone period after touch down
-            if (confirmedTap || distanceExceeds(eventX - lastTouchDownX, eventY - lastTouchDownY, TOUCH_DOWN_DEAD_ZONE_DISTANCE_THRESHOLD)) {
-                tapConfirmed();
-                updatePosition(eventX, eventY);
-            }
+            // Always update position immediately for smoother input
+            tapConfirmed();
+            updatePosition(eventX, eventY);
+            confirmedMove = true;
         }
         else if (actionIndex == 1) {
             conn.sendMouseHighResScroll((short)((eventY - lastTouchLocationY) * SCROLL_SPEED_FACTOR));
+            // Scrolling is also considered movement
+            confirmedMove = true;
         }
 
         lastTouchLocationX = eventX;
@@ -233,6 +245,7 @@ public class AbsoluteTouchContext implements TouchContext {
     @Override
     public void cancelTouch() {
         cancelled = true;
+        confirmedMove = false;
 
         // Cancel the timers
         cancelLongPressTimer();

--- a/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.java
+++ b/app/src/main/java/com/limelight/binding/input/touch/RelativeTouchContext.java
@@ -328,4 +328,9 @@ public class RelativeTouchContext implements TouchContext {
             maxPointerCountInGesture = pointerCount;
         }
     }
+
+    @Override
+    public boolean isConfirmedMove() {
+        return confirmedMove;
+    }
 }

--- a/app/src/main/java/com/limelight/binding/input/touch/TouchContext.java
+++ b/app/src/main/java/com/limelight/binding/input/touch/TouchContext.java
@@ -8,4 +8,6 @@ public interface TouchContext {
     void touchUpEvent(int eventX, int eventY, long eventTime);
     void cancelTouch();
     boolean isCancelled();
+
+    boolean isConfirmedMove();
 }

--- a/app/src/main/java/com/limelight/binding/input/touch/TouchpadStickContext.java
+++ b/app/src/main/java/com/limelight/binding/input/touch/TouchpadStickContext.java
@@ -1,0 +1,117 @@
+package com.limelight.binding.input.touch;
+
+import com.limelight.nvstream.NvConnection;
+import com.limelight.binding.input.TouchpadToStickHandler;
+
+public class TouchpadStickContext implements TouchContext {
+    private final NvConnection conn;
+    private final int actionIndex;
+    private final TouchpadToStickHandler touchpadHandler;
+
+    private float lastX;
+    private float lastY;
+    private boolean tracking;
+    private boolean cancelled;
+    private int pointerCount;
+    private long lastUpdateTime = 0;
+
+    public TouchpadStickContext(NvConnection conn, int actionIndex, TouchpadToStickHandler touchpadHandler) {
+        this.conn = conn;
+        this.actionIndex = actionIndex;
+        this.touchpadHandler = touchpadHandler;
+        this.cancelled = false;
+        this.pointerCount = 0;
+    }
+
+    @Override
+    public int getActionIndex() {
+        return actionIndex;
+    }
+
+    @Override
+    public void setPointerCount(int pointerCount) {
+        this.pointerCount = pointerCount;
+    }
+
+    @Override
+    public boolean touchDownEvent(int eventX, int eventY, long eventTime, boolean isNewFinger) {
+        // Start tracking from this point
+        lastX = eventX;
+        lastY = eventY;
+        // Convert pixel coordinates to normalized 0-1 range (approximate)
+        float normalizedX = eventX / 1000.0f; // Rough approximation
+        float normalizedY = eventY / 1000.0f;
+        touchpadHandler.startTracking(normalizedX, normalizedY);
+        tracking = true;
+        cancelled = false;
+        return true;
+    }
+
+    @Override
+    public void touchUpEvent(int eventX, int eventY, long eventTime) {
+        if (tracking) {
+            touchpadHandler.stopTracking();
+            // Send stop signal for right stick only
+            conn.sendControllerInput((short)getActionIndex(), (short)1, 0,
+                    (byte)0, (byte)0,
+                    (short)0, (short)0,  // Left stick untouched
+                    (short)0, (short)0); // Right stick stopped
+            tracking = false;
+        }
+    }
+
+    @Override
+    public boolean touchMoveEvent(int eventX, int eventY, long eventTime) {
+        if (tracking) {
+            // Throttle updates to reduce stuttering and conflicts with left stick
+            if (eventTime - lastUpdateTime < 20) { // Limit to ~50 FPS to avoid overwhelming system
+                return true;
+            }
+            lastUpdateTime = eventTime;
+            
+            // Update touchpad position and get delta
+            float normalizedX = eventX / 1000.0f; // Rough approximation
+            float normalizedY = eventY / 1000.0f;
+            
+            // Get movement delta and convert to stick values
+            float[] delta = touchpadHandler.getDelta(normalizedX, normalizedY);
+            float[] stickValues = touchpadHandler.convertTouchpadDeltaToStick(delta[0], delta[1]);
+            
+            // Convert to controller stick values
+            short stickX = (short)(stickValues[0] * 0x7FFE);
+            short stickY = (short)(-stickValues[1] * 0x7FFE); // Invert Y to match controller
+            
+            // Send only right stick values with throttling for smooth operation
+            conn.sendControllerInput((short)getActionIndex(), (short)1, 0,
+                    (byte)0, (byte)0,
+                    (short)0, (short)0,  // Left stick zeroed
+                    stickX, stickY);  // Right stick only
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void cancelTouch() {
+        if (tracking) {
+            touchpadHandler.stopTracking();
+            // Send stop signal for right stick only  
+            conn.sendControllerInput((short)getActionIndex(), (short)1, 0,
+                    (byte)0, (byte)0,
+                    (short)0, (short)0,  // Left stick untouched
+                    (short)0, (short)0); // Right stick stopped
+            tracking = false;
+            cancelled = true;
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public boolean isConfirmedMove() {
+        return tracking;
+    }
+}

--- a/app/src/main/java/com/limelight/binding/input/touch/TrackpadContext.java
+++ b/app/src/main/java/com/limelight/binding/input/touch/TrackpadContext.java
@@ -311,7 +311,7 @@ public class TrackpadContext implements TouchContext {
             int absDeltaY = Math.abs(rawDeltaY);
 
             double magnitude = Math.sqrt(rawDeltaX * rawDeltaX + rawDeltaY * rawDeltaY);
-            double precisionMultiplier = Math.cbrt(magnitude / ACCELERATION_THRESHOLD);
+            double precisionMultiplier = 1.0; // Disable acceleration for consistent movement
 
             float deltaX, deltaY;
             if (swapAxis) {
@@ -338,9 +338,9 @@ public class TrackpadContext implements TouchContext {
                     velocityX = currentVelocityX;
                     velocityY = currentVelocityY;
                 } else {
-                    // Simple EMA for smoothing
-                    velocityX = velocityX * 0.8 + currentVelocityX * 0.2;
-                    velocityY = velocityY * 0.8 + currentVelocityY * 0.2;
+                    // Direct velocity assignment for immediate response (no smoothing)
+                    velocityX = currentVelocityX;
+                    velocityY = currentVelocityY;
                 }
             }
 
@@ -464,5 +464,10 @@ public class TrackpadContext implements TouchContext {
 
     private void checkForConfirmedScroll() {
         confirmedScroll = (actionIndex == 1 && pointerCount == 2 && confirmedMove);
+    }
+
+    @Override
+    public boolean isConfirmedMove() {
+        return confirmedMove;
     }
 }

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -48,6 +48,7 @@ public class PreferenceConfiguration {
     private static final String ENFORCE_DISPLAY_MODE_PREF_STRING = "checkbox_enforce_display_mode";
     private static final String USE_VIRTUAL_DISPLAY_PREF_STRING = "checkbox_use_virtual_display";
     private static final String AUTO_INVERT_VIDEO_RESOLUTION_PREF_STRING = "checkbox_auto_invert_video_resolution";
+    private static final String TOUCHPAD_AS_STICK_PREF_STRING = "checkbox_touchpad_as_stick";
     private static final String RESOLUTION_SCALE_FACTOR_PREF_STRING = "seekbar_resolution_scale_factor";
     private static final String RESUME_WITHOUT_CONFIRM_PREF_STRING = "checkbox_resume_without_confirm";
     private static final String VIDEO_SCALE_MODE_PREF_STRING = "list_video_scale_mode";
@@ -178,6 +179,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_REDUCE_REFRESH_RATE = false;
     private static final boolean DEFAULT_FULL_RANGE = false;
     private static final boolean DEFAULT_GAMEPAD_TOUCHPAD_AS_MOUSE = false;
+    private static final boolean DEFAULT_TOUCHPAD_AS_STICK = false;
     private static final boolean DEFAULT_GAMEPAD_MOTION_SENSORS = true;
     private static final boolean DEFAULT_GAMEPAD_MOTION_FALLBACK = false;
     private static final boolean DEFAULT_FORCE_MOTION_SENSORS_FALLBACK = false;
@@ -263,6 +265,7 @@ public class PreferenceConfiguration {
     public boolean enableLatencyToast;
     public boolean enableBackMenu;
     public boolean enableFloatingButton;
+    public boolean touchpadAsStick;
     public boolean showOverlayZoomToggleButton;
 
     //Invert video width/height
@@ -854,6 +857,11 @@ public class PreferenceConfiguration {
         String mouseMode = prefs.getString("mouse_mode_list", "0");
         int mouseModeInt = Integer.parseInt(mouseMode);
         switch (mouseModeInt) {
+            case 6: // Touchpad as right stick
+                config.touchpadAsStick = true;
+                config.enableMultiTouchScreen = false;
+                config.touchscreenTrackpad = false;
+                break;
             case 0: // Multi-touch
                 config.enableMultiTouchScreen = true;
                 config.touchscreenTrackpad = false;
@@ -895,6 +903,7 @@ public class PreferenceConfiguration {
         config.enableLatencyToast = prefs.getBoolean(LATENCY_TOAST_PREF_STRING, DEFAULT_LATENCY_TOAST);
         config.enableBackMenu = prefs.getBoolean(CHECKBOX_ENABLE_QUIT_DIALOG,true);
         config.enableFloatingButton = prefs.getBoolean(CHECKBOX_ENABLE_FLOATING_BUTTON,DEFAULT_ENABLE_FLOATING_BUTTON);
+        config.touchpadAsStick = prefs.getBoolean(TOUCHPAD_AS_STICK_PREF_STRING, DEFAULT_TOUCHPAD_AS_STICK);
         config.showOverlayZoomToggleButton = prefs.getBoolean(CHECKBOX_SHOW_OVERLAY_ZOOM_TOGGLE_BUTTON, DEFAULT_SHOW_OVERLAY_TOGGLE_BUTTON);
         config.autoOrientation = prefs.getBoolean(CHECKBOX_AUTO_ORIENTATION,false);
         config.autoInvertVideoResolution = prefs.getBoolean(AUTO_INVERT_VIDEO_RESOLUTION_PREF_STRING, DEFAULT_AUTO_INVERT_VIDEO_RESOLUTION);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -170,6 +170,7 @@
         <item>@string/mouse_mode_track_pad_gaming</item>
         <item>@string/mouse_mode_disabled</item>
         <item>@string/mouse_mode_absolute_touch_swapped</item>
+        <item>@string/mouse_mode_right_stick</item>
     </string-array>
     <string-array name="mouse_mode_values" translatable="false">
         <item>0</item>
@@ -177,6 +178,8 @@
         <item>2</item>
         <item>3</item>
         <item>4</item>
+        <item>5</item>
+        <item>6</item>
         <item>5</item>
     </string-array>
 

--- a/app/src/main/res/values/pref_strings.xml
+++ b/app/src/main/res/values/pref_strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Strings for the touchpad as stick setting -->
+    <string name="category_input_settings">Input Settings</string>
+    <string name="checkbox_touchpad_as_stick_title">Use Touchpad as Right Stick</string>
+    <string name="checkbox_touchpad_as_stick_summary">Maps controller touchpad movements to the right analog stick</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,6 @@
     <string name="title_checkbox_force_device_motion">Always use device\'s motion sensors</string>
     <string name="summary_checkbox_force_device_motion">Enforce using devices\'s built-in motion sensor even when the controller reported motion sensors are supported.</string>
 
-    <string name="category_input_settings">Input Settings</string>
     <string name="title_checkbox_touchscreen_trackpad">Use the touchscreen as a trackpad</string>
     <string name="summary_checkbox_touchscreen_trackpad">If enabled, the touchscreen acts like a trackpad. If disabled, the touchscreen directly controls the mouse cursor.</string>
     <string name="title_checkbox_absolute_mouse_mode">Remote desktop mouse mode</string>
@@ -431,6 +430,8 @@
     <string name="summary_checkbox_mouse_local_cursor">Default external physical mouse cursor will be captured, this option can display Android system cursor</string>
     <string name="title_checkbox_multi_touch_gestures">Enable multi-touch gestures</string>
     <string name="summary_checkbox_multi_touch_gestures">Enable 3 finger tap for keyboard, 4 finger tap for full keyboard, 5 finger tap for quick menu when using multi-touch mode.</string>
+    <string name="title_checkbox_touchpad_as_stick">Use touchpad as right stick</string>
+    <string name="summary_checkbox_touchpad_as_stick">Maps touchpad input to the right analog stick for camera control</string>
     <string name="title_checkbox_onscreen_style_official">Official Virtual Gamepad Skin</string>
     <string name="summary_checkbox_onscreen_style_official">If you still like the old style of official virtual gamepad buttons, you can select this option.\nButton shapes can be square if you selected the bottom virtual button [Normal buttons are square buttons]</string>
     <string name="title_checkbox_enable_perf_overlay_lite">Enable Lite mode</string>
@@ -554,6 +555,7 @@
     <string name="mouse_mode_track_pad_gaming">Track pad(Gaming/Long press to drag)</string>
     <string name="mouse_mode_disabled">Disabled</string>
     <string name="mouse_mode_absolute_touch_swapped">Absolute touch (left/right click swapped)</string>
+    <string name="mouse_mode_right_stick">Right stick (Touchpad as analog)</string>
     <string name="keyboard_layout_set_1">Profile 1</string>
     <string name="keyboard_layout_set_2">Profile 2</string>
     <string name="keyboard_layout_set_3">Profile 3</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -330,6 +330,13 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="checkbox_touchpad_as_stick"
+            android:summary="@string/checkbox_touchpad_as_stick_summary"
+            android:title="@string/checkbox_touchpad_as_stick_title"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="checkbox_mouse_nav_buttons"
             android:summary="@string/summary_checkbox_mouse_nav_buttons"
             android:title="@string/title_checkbox_mouse_nav_buttons"


### PR DESCRIPTION
I was struggling with using the right analog stick for camera movement, so I implemented a new touchscreen mode that works like native Android games. You can now drag anywhere on the screen to control the camera. To enable it, just switch to touchscreen to stick  in touschscreen mode settings.

note : iam still new for pulling request pls check it before merging it the project works fine  i may  missed to upload files
enable the touchpad to right stick option  
other touch screen mode will not  work if this option still toggled on 
