### PR TITLE
Added support for max operating rate on all prefixes that support RFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ gen/
 
 # Local configuration file (sdk path, etc)
 local.properties
+key/
 
 # Windows thumbnail db
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
+--------------------------------------------------------------------------------------------------------------------
+# Hello, derflacco here  
+This fork is an attempt to reduce the infamous high decoding latency on MediaTek devices with Moonlight/Artemis.  
+Don’t expect miracles — my time (and coding skills) are limited.  
+
+## What to expect from the stable builds  
+- Noticeably lower **c2.mtk** decoding latency (in my tests: from ~20 ms down to ~6–8 ms on my Poco X6 Pro)  
+- Possible bugs with older **omx.mtk** decoders  
+
+## What to expect from the experimental builds  
+- Potentially huge reductions in **c2.mtk** decoding latency on newer devices  
+- Bugs… think the first edition of *TES II: Daggerfall*, or a badly modded *Skyrim*  
+- Some ChatGPT Plus–generated code: feel free to improve or clean it up!
+
+
+░░░░░░░░░▄░░░░░░░░░░░░░░▄░░░░
+░░░░░░░░▌▒█░░░░░░░░░░░▄▀▒▌░░░
+░░░░░░░░▌▒▒█░░░░░░░░▄▀▒▒▒▐░░░
+░░░░░░░▐▄▀▒▒▀▀▀▀▄▄▄▀▒▒▒▒▒▐░░░
+░░░░░▄▄▀▒░▒▒▒▒▒▒▒▒▒█▒▒▄█▒▐░░░
+░░░▄▀▒▒▒░░░▒▒▒░░░▒▒▒▀██▀▒▌░░░ 
+░░▐▒▒▒▄▄▒▒▒▒░░░▒▒▒▒▒▒▒▀▄▒▒▌░░
+░░▌░░▌█▀▒▒▒▒▒▄▀█▄▒▒▒▒▒▒▒█▒▐░░
+░▐░░░▒▒▒▒▒▒▒▒▌██▀▒▒░░░▒▒▒▀▄▌░
+░▌░▒▄██▄▒▒▒▒▒▒▒▒▒░░░░░░▒▒▒▒▌░
+▐▒▀▐▄█▄█▌▄░▀▒▒░░░░░░░░░░▒▒▒▐░
+▐▒▒▐▀▐▀▒░▄▄▒▄▒▒▒▒▒▒░▒░▒░▒▒▒▒▌
+▐▒▒▒▀▀▄▄▒▒▒▄▒▒▒▒▒▒▒▒░▒░▒░▒▒▐░
+░▌▒▒▒▒▒▒▀▀▀▒▒▒▒▒▒░▒░▒░▒░▒▒▒▌░
+░▐▒▒▒▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▒▄▒▒▐░░
+░░▀▄▒▒▒▒▒▒▒▒▒▒▒░▒░▒░▒▄▒▒▒▒▌░░
+░░░░▀▄▒▒▒▒▒▒▒▒▒▒▄▄▄▀▒▒▒▒▄▀░░░
+░░░░░░▀▄▄▄▄▄▄▀▀▀▒▒▒▒▒▄▄▀░░░░░
+░░░░░░░░░▒▒▒▒▒▒▒▒▒▒▀▀░░░░░░░░
+--------------------------------------------------------------------------------------------------------------------
+ASCII Art credits:https://emojicombos.com/doge-ascii-art
+
 # Artemis Android
 
 Previously named Moonlight Noir

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,7 +170,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.github.ByteHamster:SearchPreference:v2.5.1'
-
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     // Unit test dependencies
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.6.1'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -38,3 +38,7 @@
 # jMDNS
 -dontwarn javax.jmdns.impl.DNSCache
 -dontwarn org.slf4j.**
+
+# MPAndroidChart
+-keep class com.github.mikephil.charting.** { *; }
+-dontwarn com.github.mikephil.charting.**

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -635,7 +635,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
                         // We must use commit because the app will crash when we return from this function
                         tombstonePrefs.edit().putInt("CrashCount", tombstonePrefs.getInt("CrashCount", 0) + 1).commit();
-                        reportedCrash = true;
+                                 reportedCrash = true;
                     }
                 },
                 tombstonePrefs.getInt("CrashCount", 0),
@@ -644,6 +644,8 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 shouldInvertDecoderResolution,
                 glPrefs.glRenderer,
                 this);
+            try { decoderRenderer.setPreferLowerDelays(prefConfig != null ? prefConfig.preferLowerDelays : true); } catch (Throwable ignored) {}
+
 
         // Don't stream HDR if the decoder can't support it
         if (willStreamHdr && !decoderRenderer.isHevcMain10Hdr10Supported() && !decoderRenderer.isAv1Main10Supported()) {

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -644,15 +644,48 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 shouldInvertDecoderResolution,
                 glPrefs.glRenderer,
                 this);
-            try { decoderRenderer.setPreferLowerDelays(prefConfig != null ? prefConfig.preferLowerDelays : true); } catch (Throwable ignored) {}
 
+// --- Force tight thresholds (opzionale, via prefConfig.forceTightThresholds) ---
+        try {
+            boolean forceTight = false;
+            if (prefConfig != null) {
+                try {
+                    java.lang.reflect.Field f = prefConfig.getClass().getDeclaredField("forceTightThresholds");
+                    f.setAccessible(true);
+                    Object v = f.get(prefConfig);
+                    if (v instanceof Boolean) forceTight = (Boolean) v;
+                } catch (Throwable ignored) {}
+            }
+            try { decoderRenderer.setForceTightThresholds(forceTight);
+        applyLatencyPolicy(decoderRenderer, prefConfig);} catch (Throwable ignored) {}
+            if (forceTight) {
+                LimeLog.info("ForceTightThresholds enabled: using vsync-based thresholds on all devices");
+            }
+        } catch (Throwable ignored) {}
+
+// --- Selezione profilo latenza ---
+// Semantica: TRUE = gestito (usa timeout); FALSE = 0µs latest-only
+        try {
+             if (prefConfig != null && prefConfig.preferLowerDelays) {
+                // Intermedio: più reattivo di Balanced ma non 0 µs
+                decoderRenderer.setPreferLowerDelays(true);          // GESTITO
+                decoderRenderer.setPreferLowerDelaysTimeoutUs(500);  // 0.5 ms
+                prefConfig.framePacing = PreferenceConfiguration.FRAME_PACING_BALANCED;
+                LimeLog.info("PreferLowerDelays: preferLowerDelays=true, timeout=500us, pacing=BALANCED");
+            } else {
+                // Balanced default
+                decoderRenderer.setPreferLowerDelays(true);          // GESTITO
+                decoderRenderer.setPreferLowerDelaysTimeoutUs(2000); // 2 ms
+                prefConfig.framePacing = PreferenceConfiguration.FRAME_PACING_BALANCED;
+                LimeLog.info("Balanced: preferLowerDelays=true, timeout=2000us, pacing=BALANCED");
+            }
+        } catch (Throwable ignored) {}
 
         // Don't stream HDR if the decoder can't support it
         if (willStreamHdr && !decoderRenderer.isHevcMain10Hdr10Supported() && !decoderRenderer.isAv1Main10Supported()) {
             willStreamHdr = false;
             Toast.makeText(this, "Decoder does not support HDR10 profile", Toast.LENGTH_LONG).show();
         }
-
         // Display a message to the user if HEVC was forced on but we still didn't find a decoder
         if (prefConfig.videoFormat == PreferenceConfiguration.FormatOption.FORCE_HEVC && !decoderRenderer.isHevcSupported()) {
             Toast.makeText(this, "No HEVC decoder found", Toast.LENGTH_LONG).show();
@@ -4292,6 +4325,29 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             }
         }
         return null;
+    }
+
+
+    // Apply low-latency vs smooth policy to the decoder renderer
+    // Notes (EN):
+    // - In low-latency modes we enforce non-blocking dequeue (0 µs) and tight VSYNC pacing.
+    // - In smooth/balanced modes we allow a small timeout to stabilize pacing.
+    private void applyLatencyPolicy(com.limelight.binding.video.MediaCodecDecoderRenderer decoderRenderer,
+                                    com.limelight.preferences.PreferenceConfiguration prefConfig) {
+        try {
+            boolean isLowLatency = true;
+            if (prefConfig != null) {
+                // Consider Ultra/Reactive/ULL as low-latency, Balanced/Smooth as non-low-latency
+                int pacing = prefConfig.framePacing;
+                // Heuristic: if user selected Balanced/Smooth keep some timeout
+                isLowLatency = (pacing != com.limelight.preferences.PreferenceConfiguration.FRAME_PACING_BALANCED);
+            }
+            decoderRenderer.setPreferLowerDelays(isLowLatency);
+            decoderRenderer.setPreferLowerDelaysTimeoutUs(2000);
+            // Tighten thresholds to VSYNC when low-latency is requested
+            decoderRenderer.setForceTightThresholds(isLowLatency);
+        } catch (Throwable ignored) {
+        }
     }
 
 }

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -334,6 +334,8 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     @SuppressLint({"MissingInflatedId", "ClickableViewAccessibility"})
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        normalizeChartsOverlayPrefs();
+
         super.onCreate(savedInstanceState);
 
         instance = this;
@@ -4440,6 +4442,48 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             chart.setVisibleXRangeMaximum(240); // ~4s @60fps
             chart.moveViewToX(data.getEntryCount());
             chart.invalidate();
+        } catch (Throwable ignored) {}
+    }
+
+
+    // Ensure Charts & Overlay Lite invariants:
+    // - If Charts is enabled but Overlay Lite is off, auto-enable Overlay + Overlay Lite.
+    // - If Overlay Lite is turned off, auto-disable Charts.
+    private void normalizeChartsOverlayPrefs() {
+        try {
+            android.content.SharedPreferences prefs =
+                    androidx.preference.PreferenceManager.getDefaultSharedPreferences(this);
+            boolean charts = prefs.getBoolean("checkbox_enable_perf_charts", false);
+            boolean overlay = prefs.getBoolean("checkbox_enable_perf_overlay", false);
+            boolean overlayLite = prefs.getBoolean("checkbox_enable_perf_overlay_lite", false);
+
+            android.content.SharedPreferences.Editor e = null;
+
+            if (charts && !overlayLite) {
+                if (e == null) e = prefs.edit();
+                e.putBoolean("checkbox_enable_perf_overlay", true);
+                e.putBoolean("checkbox_enable_perf_overlay_lite", true);
+                overlay = true;
+                overlayLite = true;
+            }
+
+            if (!overlayLite && charts) {
+                if (e == null) e = prefs.edit();
+                e.putBoolean("checkbox_enable_perf_charts", false);
+                charts = false;
+            }
+
+            if (e != null) e.apply();
+
+            // Reflect to in-memory config if present
+            try {
+                if (prefConfig != null) {
+                    prefConfig.enablePerfCharts = charts;
+                    prefConfig.enablePerfOverlay = overlay;
+                    prefConfig.enablePerfOverlayLite = overlayLite;
+                }
+            } catch (Throwable ignored) {}
+
         } catch (Throwable ignored) {}
     }
 

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -635,7 +635,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
                         // We must use commit because the app will crash when we return from this function
                         tombstonePrefs.edit().putInt("CrashCount", tombstonePrefs.getInt("CrashCount", 0) + 1).commit();
-                                 reportedCrash = true;
+                        reportedCrash = true;
                     }
                 },
                 tombstonePrefs.getInt("CrashCount", 0),
@@ -645,7 +645,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 glPrefs.glRenderer,
                 this);
 
-// --- Force tight thresholds (opzionale, via prefConfig.forceTightThresholds) ---
+// --- Force tight thresholds (prefConfig.forceTightThresholds) ---
         try {
             boolean forceTight = false;
             if (prefConfig != null) {
@@ -656,32 +656,30 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                     if (v instanceof Boolean) forceTight = (Boolean) v;
                 } catch (Throwable ignored) {}
             }
-            try { decoderRenderer.setForceTightThresholds(forceTight);
-        applyLatencyPolicy(decoderRenderer, prefConfig);} catch (Throwable ignored) {}
+            try { decoderRenderer.setForceTightThresholds(forceTight); } catch (Throwable ignored) {}
             if (forceTight) {
                 LimeLog.info("ForceTightThresholds enabled: using vsync-based thresholds on all devices");
             }
         } catch (Throwable ignored) {}
 
-// --- Selezione profilo latenza ---
-// Semantica: TRUE = gestito (usa timeout); FALSE = 0µs latest-only
+// --- latency profile selection ---
         try {
-             if (prefConfig != null && prefConfig.preferLowerDelays) {
-                // Intermedio: più reattivo di Balanced ma non 0 µs
-                decoderRenderer.setPreferLowerDelays(true);          // GESTITO
+            if (prefConfig != null && prefConfig.preferLowerDelays) {
+                // Intermediate: more responsive than Balanced but not 0 µs
+                decoderRenderer.setPreferLowerDelays(true);
                 decoderRenderer.setPreferLowerDelaysTimeoutUs(500);  // 0.5 ms
                 prefConfig.framePacing = PreferenceConfiguration.FRAME_PACING_BALANCED;
                 LimeLog.info("PreferLowerDelays: preferLowerDelays=true, timeout=500us, pacing=BALANCED");
             } else {
                 // Balanced default
-                decoderRenderer.setPreferLowerDelays(true);          // GESTITO
+                decoderRenderer.setPreferLowerDelays(false);
                 decoderRenderer.setPreferLowerDelaysTimeoutUs(2000); // 2 ms
                 prefConfig.framePacing = PreferenceConfiguration.FRAME_PACING_BALANCED;
-                LimeLog.info("Balanced: preferLowerDelays=true, timeout=2000us, pacing=BALANCED");
+                LimeLog.info("Balanced: preferLowerDelays=false, timeout=2000us, pacing=BALANCED");
             }
         } catch (Throwable ignored) {}
 
-        // Don't stream HDR if the decoder can't support it
+// Don't stream HDR if the decoder can't support it
         if (willStreamHdr && !decoderRenderer.isHevcMain10Hdr10Supported() && !decoderRenderer.isAv1Main10Supported()) {
             willStreamHdr = false;
             Toast.makeText(this, "Decoder does not support HDR10 profile", Toast.LENGTH_LONG).show();
@@ -849,7 +847,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         overlayToggleButton = findViewById(R.id.overlayToggleZoomButton);
         setupOverlayToggleButton();
-    
+
         //fixed size + pacing without back-pressure on MTK
         try {
             View root = findViewById(android.R.id.content);
@@ -857,7 +855,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             SurfaceView streamSurfaceView = findFirstSurfaceViewFrom(root);
 
             if (streamSurfaceView != null) {
-                // 1) Evita resize/glitch che mandano in crisi il compositor
+                // Avoid resizes/glitches that break the compositor
                 int vw = (prefConfig != null && prefConfig.width > 0) ? prefConfig.width : displayWidth;
                 int vh = (prefConfig != null && prefConfig.height > 0) ? prefConfig.height : displayHeight;
                 try { streamSurfaceView.getHolder().setFixedSize(vw, vh); } catch (Throwable ignored) {}
@@ -895,7 +893,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 }
             }
         } catch (Throwable ignored) {}
-}
+    }
 
     @SuppressLint("ClickableViewAccessibility")
     private void setupOverlayToggleButton() {
@@ -965,7 +963,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         if (overlayToggleButton != null) {
             // Change background based on pan/zoom mode state
             overlayToggleButton.setBackgroundResource(isPanZoomMode ?
-                R.drawable.floating_menu_button_active : R.drawable.floating_menu_button);
+                    R.drawable.floating_menu_button_active : R.drawable.floating_menu_button);
             // No need for alpha changes since the color indicates the state
             overlayToggleButton.setAlpha(1.0f);
         }
@@ -1592,7 +1590,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         if (getPackageManager().hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
                 getPackageManager().hasSystemFeature(PackageManager.FEATURE_LEANBACK)
-            || isOnExternalDisplay()) {// TVs may take a few moments to switch refresh rates, and we can probably assume
+                || isOnExternalDisplay()) {// TVs may take a few moments to switch refresh rates, and we can probably assume
             // it will be eventually activated.
             // external displays cant be compared with displaymanager currents display refreshrate
             // TODO: Improve this
@@ -2848,11 +2846,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                         // Press & Hold / Double-Tap & Hold for Selection or Drag & Drop
                         double positionDelta = Math.sqrt(
                                 Math.pow(event.getX() - lastTouchDownX, 2) +
-                                Math.pow(event.getY() - lastTouchDownY, 2)
+                                        Math.pow(event.getY() - lastTouchDownY, 2)
                         );
 
                         if (synthClickPending &&
-                            event.getEventTime() - synthTouchDownTime >= prefConfig.trackpadDragDropThreshold) {
+                                event.getEventTime() - synthTouchDownTime >= prefConfig.trackpadDragDropThreshold) {
                             if (positionDelta > 50) {
                                 pendingDrag = false;
                             } else if (pendingDrag) {
@@ -4134,9 +4132,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private void applyMouseMode(int mode) {
         switch (mode) {
             case 0: // Multi-touch
-            prefConfig.enableMultiTouchScreen = true;
-            prefConfig.touchscreenTrackpad = false;
-            break;
+                prefConfig.enableMultiTouchScreen = true;
+                prefConfig.touchscreenTrackpad = false;
+                break;
             case 1: // Normal mouse
             case 5: // Normal mouse with swapped buttons
                 prefConfig.enableMultiTouchScreen = false;
@@ -4325,29 +4323,6 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             }
         }
         return null;
-    }
-
-
-    // Apply low-latency vs smooth policy to the decoder renderer
-    // Notes (EN):
-    // - In low-latency modes we enforce non-blocking dequeue (0 µs) and tight VSYNC pacing.
-    // - In smooth/balanced modes we allow a small timeout to stabilize pacing.
-    private void applyLatencyPolicy(com.limelight.binding.video.MediaCodecDecoderRenderer decoderRenderer,
-                                    com.limelight.preferences.PreferenceConfiguration prefConfig) {
-        try {
-            boolean isLowLatency = true;
-            if (prefConfig != null) {
-                // Consider Ultra/Reactive/ULL as low-latency, Balanced/Smooth as non-low-latency
-                int pacing = prefConfig.framePacing;
-                // Heuristic: if user selected Balanced/Smooth keep some timeout
-                isLowLatency = (pacing != com.limelight.preferences.PreferenceConfiguration.FRAME_PACING_BALANCED);
-            }
-            decoderRenderer.setPreferLowerDelays(isLowLatency);
-            decoderRenderer.setPreferLowerDelaysTimeoutUs(2000);
-            // Tighten thresholds to VSYNC when low-latency is requested
-            decoderRenderer.setForceTightThresholds(isLowLatency);
-        } catch (Throwable ignored) {
-        }
     }
 
 }

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -227,6 +227,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private TextView performanceOverlayLite;
 
     private TextView performanceOverlayBig;
+    private com.github.mikephil.charting.charts.LineChart perfChartLatency;
+    private com.github.mikephil.charting.charts.LineChart perfChartDecode;
+    private com.github.mikephil.charting.charts.LineChart perfChartFps;
 
     private MediaCodecDecoderRenderer decoderRenderer;
     private boolean reportedCrash;
@@ -498,6 +501,13 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         performanceOverlayLite = findViewById(R.id.performanceOverlayLite);
 
         performanceOverlayBig = findViewById(R.id.performanceOverlayBig);
+        // Charts
+        try {
+            perfChartLatency = findViewById(R.id.perfChartLatency);
+            perfChartDecode  = findViewById(R.id.perfChartDecode);
+            perfChartFps     = findViewById(R.id.perfChartFps);
+        } catch (Throwable ignored) {}
+
 
         inputCaptureProvider = InputCaptureManager.getInputCaptureProvider(this, this);
 
@@ -607,8 +617,30 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         }
 
         // Check if the user has enabled performance stats overlay
-        if (prefConfig.enablePerfOverlay) {
+        if (prefConfig.enablePerfOverlay || prefConfig.enablePerfCharts) {
             performanceOverlayView.setVisibility(View.VISIBLE);
+
+
+// Charts visibility (force)
+            if (prefConfig.enablePerfCharts || prefConfig.perfChartLatency || prefConfig.perfChartDecode || prefConfig.perfChartFps) {
+                if (perfChartLatency != null) perfChartLatency.setVisibility(prefConfig.perfChartLatency ? View.VISIBLE : View.GONE);
+                if (perfChartDecode  != null) perfChartDecode.setVisibility(prefConfig.perfChartDecode  ? View.VISIBLE : View.GONE);
+                if (perfChartFps     != null) perfChartFps.setVisibility(prefConfig.perfChartFps      ? View.VISIBLE : View.GONE);
+            } else {
+                if (perfChartLatency != null) perfChartLatency.setVisibility(View.GONE);
+                if (perfChartDecode  != null) perfChartDecode.setVisibility(View.GONE);
+                if (perfChartFps     != null) perfChartFps.setVisibility(View.GONE);
+            }
+// Charts visibility
+            if (prefConfig.enablePerfCharts) {
+                if (perfChartLatency != null) perfChartLatency.setVisibility(prefConfig.perfChartLatency ? View.VISIBLE : View.GONE);
+                if (perfChartDecode  != null) perfChartDecode.setVisibility(prefConfig.perfChartDecode  ? View.VISIBLE : View.GONE);
+                if (perfChartFps     != null) perfChartFps.setVisibility(prefConfig.perfChartFps      ? View.VISIBLE : View.GONE);
+            } else {
+                if (perfChartLatency != null) perfChartLatency.setVisibility(View.GONE);
+                if (perfChartDecode  != null) perfChartDecode.setVisibility(View.GONE);
+                if (perfChartFps     != null) perfChartFps.setVisibility(View.GONE);
+            }
             if (prefConfig.enablePerfOverlayLite) {
                 performanceOverlayLite.setVisibility(View.VISIBLE);
                 if(prefConfig.enablePerfOverlayLiteDialog){
@@ -1230,7 +1262,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                     keyBoardLayoutController.show();
                 }
 
-                if (prefConfig.enablePerfOverlay) {
+                if (prefConfig.enablePerfOverlay || prefConfig.enablePerfCharts || (prefConfig.perfChartLatency || prefConfig.perfChartDecode || prefConfig.perfChartFps)) {
                     performanceOverlayView.setVisibility(View.VISIBLE);
                 }
 
@@ -3913,6 +3945,62 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
+
+                /*__CHART_FEED__*/
+                try {
+                    if (prefConfig != null && (prefConfig.enablePerfCharts || prefConfig.perfChartLatency || prefConfig.perfChartDecode || prefConfig.perfChartFps)) {
+                        String t = text;
+                        java.util.regex.Matcher m;
+                        // Latency (prefer labeled)
+                        Float __lat = null;
+                        m = java.util.regex.Pattern.compile("Average network latency:\\s*(\\d+)\\s*ms").matcher(t);
+                        if (m.find()) { __lat = Float.parseFloat(m.group(1).replace(',', '.')); }
+                        if (__lat == null) {
+                            m = java.util.regex.Pattern.compile("\\b(\\d{1,4})\\s*ms\\b").matcher(t);
+                            if (m.find()) { __lat = Float.parseFloat(m.group(1).replace(',', '.')); }
+                        }
+                        if (__lat != null && prefConfig.perfChartLatency && perfChartLatency != null) {
+                            Game.this.addChartPoint(perfChartLatency, __lat);
+                        }
+
+                        // Decode (prefer labeled)
+                        Float __dec = null;
+                        m = java.util.regex.Pattern.compile("Average decoding time:\\s*([0-9]+(?:[\\.,][0-9]+)?)\\s*ms").matcher(t);
+                        if (m.find()) { __dec = Float.parseFloat(m.group(1).replace(',', '.')); }
+
+
+                        if (__dec == null) {
+                            // Lite overlay pattern: "<latency>ms / <decode>ms"
+                            try {
+                                java.util.regex.Matcher mm = java.util.regex.Pattern
+                                        .compile("(\\d{1,4})\\s*ms\\s*/\\s*([0-9]+(?:[\\.,][0-9]+)?)\\s*ms")
+                                        .matcher(t);
+                                if (mm.find()) {
+                                    __dec = Float.parseFloat(mm.group(2).replace(',', '.'));
+                                }
+                            } catch (Throwable ignored) {}
+                        }
+
+
+                        if (__dec != null && prefConfig.perfChartDecode && perfChartDecode != null) {
+                            Game.this.addChartPoint(perfChartDecode, __dec);
+                        }
+
+                        // FPS (prefer rendered FPS label)
+                        Float __fps = null;
+                        m = java.util.regex.Pattern.compile("Rendering frame rate:\\s*([0-9]+(?:\\.[0-9]+)?)\\s*FPS").matcher(t);
+                        if (m.find()) { __fps = Float.parseFloat(m.group(1).replace(',', '.')); }
+                        if (__fps == null) {
+                            m = java.util.regex.Pattern.compile("FPS[：: ]\\s*([0-9]+(?:\\.[0-9]+)?)").matcher(t);
+                            if (m.find()) { __fps = Float.parseFloat(m.group(1).replace(',', '.')); }
+                        }
+                        if (__fps != null && prefConfig.perfChartFps && perfChartFps != null) {
+                            Game.this.addChartPoint(perfChartFps, __fps);
+                        }
+                    }
+                } catch (Throwable ignored) {}
+                /*__CHART_FEED_END__*/
+
                 if(prefConfig.enablePerfOverlayLite){
                     performanceOverlayLite.setText(text);
                 }else{
@@ -4323,6 +4411,36 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             }
         }
         return null;
+    }
+
+
+
+    // --- Chart helper: push a point and keep a sliding window ---
+    private void addChartPoint(com.github.mikephil.charting.charts.LineChart chart, float y) {
+        if (chart == null) return;
+        try {
+            if (chart.getData() == null) {
+                chart.setData(new com.github.mikephil.charting.data.LineData());
+            }
+            com.github.mikephil.charting.data.LineData data = chart.getData();
+            com.github.mikephil.charting.interfaces.datasets.ILineDataSet set = data.getDataSetByIndex(0);
+            if (set == null) {
+                com.github.mikephil.charting.data.LineDataSet s =
+                        new com.github.mikephil.charting.data.LineDataSet(
+                                new java.util.ArrayList<>(), null);
+                s.setDrawCircles(false);
+                s.setDrawValues(false);
+                s.setLineWidth(1.1f);
+                data.addDataSet(s);
+                set = s;
+            }
+            data.addEntry(new com.github.mikephil.charting.data.Entry(set.getEntryCount(), y), 0);
+            data.notifyDataChanged();
+            chart.notifyDataSetChanged();
+            chart.setVisibleXRangeMaximum(240); // ~4s @60fps
+            chart.moveViewToX(data.getEntryCount());
+            chart.invalidate();
+        } catch (Throwable ignored) {}
     }
 
 }

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -133,6 +133,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import android.view.SurfaceView;
+import android.view.ViewGroup;
 
 
 public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
@@ -812,7 +814,53 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         overlayToggleButton = findViewById(R.id.overlayToggleZoomButton);
         setupOverlayToggleButton();
-    }
+    
+        //fixed size + pacing without back-pressure on MTK
+        try {
+            View root = findViewById(android.R.id.content);
+            // Niente getIdentifier: troviamo la prima SurfaceView nel layout
+            SurfaceView streamSurfaceView = findFirstSurfaceViewFrom(root);
+
+            if (streamSurfaceView != null) {
+                // 1) Evita resize/glitch che mandano in crisi il compositor
+                int vw = (prefConfig != null && prefConfig.width > 0) ? prefConfig.width : displayWidth;
+                int vh = (prefConfig != null && prefConfig.height > 0) ? prefConfig.height : displayHeight;
+                try { streamSurfaceView.getHolder().setFixedSize(vw, vh); } catch (Throwable ignored) {}
+                try { streamSurfaceView.setZOrderOnTop(false); } catch (Throwable ignored) {}
+                try { streamSurfaceView.setZOrderMediaOverlay(false); } catch (Throwable ignored) {}
+
+                // 2) setFrameRate via reflection (compat < 30)
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                    float displayHz = 60f;
+                    try {
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                            displayHz = currentDisplay.getMode().getRefreshRate();
+                        } else {
+                            displayHz = currentDisplay.getRefreshRate();
+                        }
+                    } catch (Throwable ignored) {}
+
+                    float targetFps = (prefConfig != null && prefConfig.fps > 0) ? prefConfig.fps : displayHz;
+
+                    boolean isMTKDevice;
+                    try {
+                        String sum = (android.os.Build.MANUFACTURER + " " + android.os.Build.HARDWARE + " " + android.os.Build.BOARD)
+                                .toLowerCase(java.util.Locale.US);
+                        isMTKDevice = sum.contains("mtk") || sum.contains("mediatek");
+                    } catch (Throwable t) { isMTKDevice = false; }
+
+                    int compat = isMTKDevice
+                            ? Surface.FRAME_RATE_COMPATIBILITY_DEFAULT
+                            : Surface.FRAME_RATE_COMPATIBILITY_FIXED_SOURCE;
+
+                    try {
+                        java.lang.reflect.Method m = SurfaceView.class.getMethod("setFrameRate", float.class, int.class);
+                        m.invoke(streamSurfaceView, Math.min(targetFps, displayHz), compat);
+                    } catch (Throwable ignored) {}
+                }
+            }
+        } catch (Throwable ignored) {}
+}
 
     @SuppressLint("ClickableViewAccessibility")
     private void setupOverlayToggleButton() {
@@ -4230,4 +4278,18 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             commitTextHandler.post(flushCommitTextQueue);
         }
     }
+
+    /** Helper ricorsivo per trovare la prima SurfaceView nel layout corrente */
+    private SurfaceView findFirstSurfaceViewFrom(View v) {
+        if (v instanceof SurfaceView) return (SurfaceView) v;
+        if (v instanceof ViewGroup) {
+            ViewGroup g = (ViewGroup) v;
+            for (int i = 0; i < g.getChildCount(); i++) {
+                SurfaceView found = findFirstSurfaceViewFrom(g.getChildAt(i));
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -42,6 +42,13 @@ import android.view.Choreographer;
 import android.view.Surface;
 
 public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements Choreographer.FrameCallback {
+    // Latency profile: favor minimal end-to-end delay over absolute smoothness.
+    // Set true to enable a 'latest-only' fast path in the render loop.
+    private boolean preferLowerDelays = false;
+
+    // Toggle at runtime if needed
+    public void setPreferLowerDelays(boolean v) { this.preferLowerDelays = v; }
+
 
     private static final boolean USE_FRAME_RENDER_TIME = false;
     private static final boolean FRAME_RENDER_TIME_ONLY = USE_FRAME_RENDER_TIME && false;
@@ -1110,6 +1117,43 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                 BufferInfo info = new BufferInfo();
                 long lastOutputNs = System.nanoTime();
                 while (!stopping) {
+                /* LATEST_ONLY_LOW_LATENCY */
+                if (preferLowerDelays) {
+                    try {
+                        android.media.MediaCodec.BufferInfo __tmpInfo = new android.media.MediaCodec.BufferInfo();
+                        int __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+                        int __last = -1;
+                        // Drain non-blocking; keep only the newest buffer
+                        while (__idx >= 0) {
+                            if (__last >= 0) {
+                                try { videoDecoder.releaseOutputBuffer(__last, false); } catch (Throwable ignored) {}
+                            }
+                            __last = __idx;
+                            __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+                        }
+                        if (__last >= 0) {
+                            // Simple pacing rule:
+                            // - MTK devices → present immediate (true)
+                            // - Others     → present at "now" timestamp
+                            boolean __isMTK = false;
+                            try {
+                                String sum2 = (android.os.Build.MANUFACTURER + " " + android.os.Build.HARDWARE + " " + android.os.Build.BOARD).toLowerCase(java.util.Locale.US);
+                                __isMTK = sum2.contains("mtk") || sum2.contains("mediatek");
+                            } catch (Throwable ignored) {}
+                            if (__isMTK) {
+                                videoDecoder.releaseOutputBuffer(__last, true);
+                            } else if (android.os.Build.VERSION.SDK_INT >= 21) {
+                                long __now = System.nanoTime();
+                                videoDecoder.releaseOutputBuffer(__last, __now);
+                            } else {
+                                videoDecoder.releaseOutputBuffer(__last, true);
+                            }
+                            continue; // handled this iteration
+                        }
+                    } catch (Throwable ignored) {}
+                }
+                /* /LATEST_ONLY_LOW_LATENCY */
+
                     try {
                         // Try to output a frame
                         int outIndex = videoDecoder.dequeueOutputBuffer(info, 0); // non-blocking fast path

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -26,6 +26,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.media.MediaCodec;
+import android.os.Bundle;
 import android.media.MediaCodecInfo;
 import android.media.MediaFormat;
 import android.media.MediaCodec.BufferInfo;
@@ -135,6 +136,8 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     private int numVpsIn;
     private int numFramesIn;
     private int numFramesOut;
+
+    private int targetFps = 0;
 
     private MediaCodecInfo findAvcDecoder() {
         MediaCodecInfo decoder = MediaCodecHelper.findProbableSafeDecoder("video/avc", MediaCodecInfo.CodecProfileLevel.AVCProfileHigh);
@@ -713,6 +716,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
     @Override
     public int setup(int format, int width, int height, int redrawRate) {
+        this.targetFps = (redrawRate > 0 ? redrawRate : 60);
         this.initialWidth = invertResolution ? height : width;
         this.initialHeight = invertResolution ? width : height;
         this.videoFormat = format;
@@ -1042,7 +1046,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         }
 
         // We use a separate thread to avoid any main thread delays from delaying rendering
-        choreographerHandlerThread = new HandlerThread("Video - Choreographer", Process.THREAD_PRIORITY_DEFAULT + Process.THREAD_PRIORITY_MORE_FAVORABLE);
+        choreographerHandlerThread = new HandlerThread("Video - Choreographer", Process.THREAD_PRIORITY_URGENT_DISPLAY);
         choreographerHandlerThread.start();
 
         // Start the frame callbacks
@@ -1060,25 +1064,93 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         rendererThread = new Thread() {
             @Override
             public void run() {
+                // Boost thread priority to reduce decoding latency
+                android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_DISPLAY);
+
+                // Compute display refresh and vsync period once (fallback 60 Hz if unavailable)
+                long vsyncPeriodNs;
+                float displayHz = 60f;
+                try {
+                    if (Build.VERSION.SDK_INT >= 17 && context != null) {
+                        android.view.Display d = ((android.view.WindowManager) context.getSystemService(android.content.Context.WINDOW_SERVICE)).getDefaultDisplay();
+                        if (d != null) displayHz = d.getRefreshRate();
+                    }
+                } catch (Throwable ignored) {}
+                if (displayHz <= 0f) displayHz = 60f;
+                vsyncPeriodNs = (long) (1_000_000_000L / displayHz);
+
+                // Stream cadence (targetFps set in setup(...))
+                final int tfps = (targetFps > 0 ? targetFps : 60);
+                final long streamPeriodNs = (long) (1_000_000_000L / Math.max(1, tfps));
+
+                boolean isC2Decoder = false;
+                try {
+                    String decName = videoDecoder.getName();
+                    if (decName != null) {
+                        isC2Decoder = decName.toLowerCase(java.util.Locale.US).startsWith("c2.");
+                    }
+                } catch (Throwable ignored) {}
+
+                // Aggressive/adaptive state
+                final double EWMA_ALPHA = 0.25;
+                final double MIN_FACTOR = 1.00;
+                final double MAX_FACTOR = 1.20;
+
+                long   lastDecoderPtsUs        = 0L;
+                long   lastPresentNs           = 0L;
+                long   lastDropNs              = 0L;
+                int    lateStreak              = 0;
+                int    tryAgainStreak          = 0;
+                int    recentDrops             = 0;
+
+                double ewmaInterArrivalNs      = (1_000_000_000.0 / Math.max(1, tfps));
+                double ewmaDecodeToPresentNs   = vsyncPeriodNs * 0.7;
+                double ewmaJitterNs            = vsyncPeriodNs * 0.1;
+
                 BufferInfo info = new BufferInfo();
+                long lastOutputNs = System.nanoTime();
                 while (!stopping) {
                     try {
                         // Try to output a frame
-                        int outIndex = videoDecoder.dequeueOutputBuffer(info, 50000);
+                        int outIndex = videoDecoder.dequeueOutputBuffer(info, 0); // non-blocking fast path
+
+                        if (outIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
+                            // backoff ridotto 0–500 µs
+                            tryAgainStreak++;
+                            int backoffUs = (tryAgainStreak <= 2) ? 250 : 500;
+                            outIndex = videoDecoder.dequeueOutputBuffer(info, backoffUs);
+                        } else {
+                            tryAgainStreak = 0;
+                        }
+
                         if (outIndex >= 0) {
+                            // --- flags per gestire le statistiche in modo robusto ---
+                            boolean statsUpdated = false;
+                            boolean frameDropped = false;
+
                             long presentationTimeUs = info.presentationTimeUs;
                             int lastIndex = outIndex;
 
                             numFramesOut++;
+
+                            // aggiorna inter-arrival
+                            if (lastDecoderPtsUs != 0L) {
+                                long interUs = presentationTimeUs - lastDecoderPtsUs;
+                                if (interUs > 0) {
+                                    double sample = interUs * 1000.0;
+                                    ewmaInterArrivalNs += EWMA_ALPHA * (sample - ewmaInterArrivalNs);
+                                }
+                            }
+                            lastDecoderPtsUs = presentationTimeUs;
 
                             // Render the latest frame now if frame pacing isn't in balanced mode
                             if (prefs.framePacing != PreferenceConfiguration.FRAME_PACING_BALANCED) {
                                 // Get the last output buffer in the queue
                                 while ((outIndex = videoDecoder.dequeueOutputBuffer(info, 0)) >= 0) {
                                     videoDecoder.releaseOutputBuffer(lastIndex, false);
+                                    frameDropped = true; // stiamo scartando il più vecchio
 
                                     numFramesOut++;
-
                                     lastIndex = outIndex;
                                     presentationTimeUs = info.presentationTimeUs;
                                 }
@@ -1087,21 +1159,116 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                         prefs.framePacing == PreferenceConfiguration.FRAME_PACING_CAP_FPS) {
                                     // In max smoothness or cap FPS mode, we want to never drop frames
                                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                        // Use a PTS that will cause this frame to never be dropped
-                                        videoDecoder.releaseOutputBuffer(lastIndex, 0);
-                                    }
-                                    else {
+                                        final long nowNs = System.nanoTime();
+                                        final long frameAgeNs = nowNs - (presentationTimeUs * 1000L);
+
+                                        // Smoothness: soglia più stretta 1.05..1.2×
+                                        double pressure = Math.min(1.0, (ewmaJitterNs / vsyncPeriodNs) + (recentDrops * 0.1));
+                                        double factorSmooth = 1.2 - 0.15 * (1.0 - pressure);
+                                        factorSmooth = Math.max(1.05, Math.min(1.2, factorSmooth));
+
+                                        long dropThresholdSmoothNs = (long)(vsyncPeriodNs * factorSmooth);
+
+                                        if (frameAgeNs >= dropThresholdSmoothNs) {
+                                            videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
+                                            frameDropped = true;
+                                            lastDropNs = nowNs;
+                                            recentDrops = Math.min(10, recentDrops + 1);
+                                            continue;
+                                        }
+
+                                        videoDecoder.releaseOutputBuffer(lastIndex, nowNs);
+                                        lastPresentNs = nowNs;
+                                        recentDrops = Math.max(0, recentDrops - 1);
+
+                                        // [STATS] update subito dopo il present
+                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
+                                        if (delta >= 0 && delta < 1000) {
+                                            activeWindowVideoStats.decoderTimeMs += delta;
+                                            if (!USE_FRAME_RENDER_TIME) {
+                                                activeWindowVideoStats.totalTimeMs += delta;
+                                            }
+                                        }
+                                        statsUpdated = true;
+
+                                    } else {
                                         videoDecoder.releaseOutputBuffer(lastIndex, true);
+
+                                        // [STATS] anche su pre-Lollipop, dopo presentazione
+                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
+                                        if (delta >= 0 && delta < 1000) {
+                                            activeWindowVideoStats.decoderTimeMs += delta;
+                                            if (!USE_FRAME_RENDER_TIME) {
+                                                activeWindowVideoStats.totalTimeMs += delta;
+                                            }
+                                        }
+                                        statsUpdated = true;
                                     }
                                 }
                                 else {
                                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                        // Use a PTS that will cause this frame to be dropped if another comes in within
-                                        // the same V-sync period
-                                        videoDecoder.releaseOutputBuffer(lastIndex, System.nanoTime());
-                                    }
-                                    else {
+                                        final long nowNs = System.nanoTime();
+                                        final long frameAgeNs = nowNs - (presentationTimeUs * 1000L);
+
+                                        // Latency: 1.0..1.15×, debounce = 1, cooldown = 0.5×
+                                        double backPressure = Math.min(1.0, (double)tryAgainStreak / 6.0);
+                                        double streamHz = Math.max(1.0, (double)tfps);
+                                        double mismatch = Math.abs((1_000_000_000.0 / streamHz) - (1_000_000_000.0 / Math.max(1.0, displayHz))) / vsyncPeriodNs;
+                                        mismatch = Math.min(2.0, mismatch);
+
+                                        double factorLatency = 1.02 + 0.13 * (0.5 * (ewmaJitterNs / vsyncPeriodNs)
+                                                + 0.3 * backPressure
+                                                + 0.2 * mismatch);
+                                        factorLatency = Math.max(MIN_FACTOR, Math.min(1.15, factorLatency));
+
+                                        long dropThresholdNs = (long)(vsyncPeriodNs * factorLatency);
+
+                                        final long sinceLastPresent = (lastPresentNs == 0L) ? Long.MAX_VALUE : (nowNs - lastPresentNs);
+                                        final boolean dropCooldownOk = (nowNs - lastDropNs) >= (vsyncPeriodNs / 2);
+                                        final boolean isLate = frameAgeNs > dropThresholdNs;
+                                        lateStreak = isLate ? (lateStreak + 1) : 0;
+
+                                        final boolean shouldDrop =
+                                                isLate &&
+                                                        (lateStreak >= 1) &&
+                                                        (sinceLastPresent < (long)(vsyncPeriodNs * 0.5)) &&
+                                                        dropCooldownOk;
+
+                                        if (shouldDrop) {
+                                            videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
+                                            frameDropped = true;
+                                            lastDropNs = nowNs;
+                                            recentDrops = Math.min(10, recentDrops + 1);
+                                            continue; // niente stats sui frame droppati
+                                        }
+
+                                        videoDecoder.releaseOutputBuffer(lastIndex, nowNs);
+                                        lastPresentNs = nowNs;
+                                        if (!isLate) lateStreak = 0;
+                                        recentDrops = Math.max(0, recentDrops - 1);
+
+                                        // [STATS] update subito dopo il present
+                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
+                                        if (delta >= 0 && delta < 1000) {
+                                            activeWindowVideoStats.decoderTimeMs += delta;
+                                            if (!USE_FRAME_RENDER_TIME) {
+                                                activeWindowVideoStats.totalTimeMs += delta;
+                                            }
+                                        }
+                                        statsUpdated = true;
+
+                                    } else {
                                         videoDecoder.releaseOutputBuffer(lastIndex, true);
+
+                                        // [STATS] anche su pre-Lollipop, dopo presentazione
+                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
+                                        if (delta >= 0 && delta < 1000) {
+                                            activeWindowVideoStats.decoderTimeMs += delta;
+                                            if (!USE_FRAME_RENDER_TIME) {
+                                                activeWindowVideoStats.totalTimeMs += delta;
+                                            }
+                                        }
+                                        statsUpdated = true;
                                     }
                                 }
 
@@ -1119,25 +1286,30 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                 if (outputBufferQueue.size() == OUTPUT_BUFFER_QUEUE_LIMIT) {
                                     try {
                                         videoDecoder.releaseOutputBuffer(outputBufferQueue.take(), false);
+                                        frameDropped = true;
                                     } catch (InterruptedException e) {
-                                        // We're shutting down, so we can just drop this buffer on the floor
-                                        // and it will be reclaimed when the codec is released.
                                         return;
                                     }
                                 }
 
                                 // Add this buffer
                                 outputBufferQueue.add(lastIndex);
+                                // NB: in BALANCED non presentiamo qui; lasciamo il fallback stats sotto
                             }
 
-                            // Add delta time to the totals (excluding probable outliers)
-                            long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
-                            if (delta >= 0 && delta < 1000) {
-                                activeWindowVideoStats.decoderTimeMs += delta;
-                                if (!USE_FRAME_RENDER_TIME) {
-                                    activeWindowVideoStats.totalTimeMs += delta;
+                            // --- Fallback stats update ---
+                            // Se non abbiamo aggiornato le stats in-branch e il frame non è stato droppato,
+                            // aggiorniamo ora (ripristina il comportamento classico, utile per BALANCED).
+                            if (!statsUpdated && !frameDropped) {
+                                long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
+                                if (delta >= 0 && delta < 1000) {
+                                    activeWindowVideoStats.decoderTimeMs += delta;
+                                    if (!USE_FRAME_RENDER_TIME) {
+                                        activeWindowVideoStats.totalTimeMs += delta;
+                                    }
                                 }
                             }
+
                         } else {
                             switch (outIndex) {
                                 case MediaCodec.INFO_TRY_AGAIN_LATER:
@@ -1157,13 +1329,29 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                         doCodecRecoveryIfRequired(CR_FLAG_RENDER_THREAD);
                     }
                 }
+
+                    /* WATCHDOG_C2_SLEEP */
+                    try {
+                        final long __nowNs = System.nanoTime();
+                        if (__nowNs - lastOutputNs > 1_200_000_000L) { // ~1.2s senza output → probabile C2 sleep
+                            LimeLog.warning("Decoder watchdog: no output >1.2s, flushing codec to recover...");
+                            try {
+                                videoDecoder.flush();
+                            } catch (Throwable ignored) {}
+                            try {
+                                android.os.Bundle __poke = new android.os.Bundle();
+                                __poke.putInt("priority", 0);
+                                videoDecoder.setParameters(__poke);
+                            } catch (Throwable ignored) {}
+                            lastOutputNs = __nowNs;
+                        }
+                    } catch (Throwable ignored) {}
             }
         };
         rendererThread.setName("Video - Renderer (MediaCodec)");
         rendererThread.setPriority(Thread.NORM_PRIORITY + 2);
         rendererThread.start();
     }
-
     private boolean fetchNextInputBuffer() {
         long startTime;
         boolean codecRecovered;

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -22,6 +22,7 @@ import com.limelight.preferences.PreferenceConfiguration;
 import com.limelight.utils.TrafficStatsHelper;
 
 import android.annotation.SuppressLint;
+import android.util.LongSparseArray;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
@@ -47,6 +48,31 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     private boolean preferLowerDelays = false;
 
     // Toggle at runtime if needed
+    // Decode latency tracking: map PTS(us) -> enqueue time (ns)
+    private final LongSparseArray<Long> enqueueNsByPtsUs = new LongSparseArray<>();
+
+    // When preferLowerDelays=true we force 0µs (non-blocking, latest-frame rendering).
+    // When preferLowerDelays=false we use this configurable timeout (µs) for output dequeue.
+    private volatile int preferLowerDelaysTimeoutUs = 2000;
+    public void setPreferLowerDelaysTimeoutUs(int us) { this.preferLowerDelaysTimeoutUs = Math.max(0, us); }
+
+    private int getOutputDequeueTimeoutUs(){ return preferLowerDelays ? 0 : preferLowerDelaysTimeoutUs; }
+
+    // Update stats using real decode time: enqueue->dequeue, instead of uptime - PTS
+    private void updateDecodeLatencyStats(long presentationTimeUs) {
+        Long enqNs = enqueueNsByPtsUs.get(presentationTimeUs);
+        if (enqNs != null) {
+            enqueueNsByPtsUs.delete(presentationTimeUs);
+            long decMs = (System.nanoTime() - enqNs) / 1_000_000L;
+            if (decMs >= 0 && decMs < 1000) {
+                activeWindowVideoStats.decoderTimeMs += decMs;
+                if (!USE_FRAME_RENDER_TIME) {
+                    activeWindowVideoStats.totalTimeMs += decMs;
+                }
+            }
+        }
+    }
+
     public void setPreferLowerDelays(boolean v) { this.preferLowerDelays = v; }
 
 
@@ -520,7 +546,8 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                 }
             }
         }
-        return videoFormat;
+
+return videoFormat;
     }
 
     private void configureAndStartDecoder(MediaFormat format) {
@@ -557,6 +584,15 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
         videoDecoder.configure(format, renderTarget, null, 0);
 
+try {
+    MediaCodecInfo __info = (android.os.Build.VERSION.SDK_INT >= 21) ? videoDecoder.getCodecInfo() : null;
+    String __name = (__info != null) ? __info.getName() : "<unknown>";
+    LimeLog.info("Decoder name: " + __name);
+} catch (Throwable t) {
+    LimeLog.info("Decoder name: <unavailable>");
+}
+
+
         configuredFormat = format;
 
         // After reconfiguration, we must resubmit CSD buffers
@@ -575,6 +611,17 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
         // Start the decoder
         videoDecoder.start();
+
+// Diagnostics: dump negotiated input/output formats and check vendor keys acceptance
+try {
+    MediaFormat __inF = videoDecoder.getInputFormat();
+    MediaFormat __outF = videoDecoder.getOutputFormat();
+    LimeLog.info("Decoder input format: " + (__inF != null ? __inF.toString() : "<null>"));
+    LimeLog.info("Decoder output format: " + (__outF != null ? __outF.toString() : "<null>"));
+} catch (Throwable t) {
+    LimeLog.info("Decoder formats unavailable after start");
+}
+
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             legacyInputBuffers = videoDecoder.getInputBuffers();
@@ -1020,7 +1067,12 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                         videoDecoder.releaseOutputBuffer(nextOutputBuffer, frameTimeNanos);
                     }
                     else {
-                        videoDecoder.releaseOutputBuffer(nextOutputBuffer, true);
+                        if (android.os.Build.VERSION.SDK_INT >= 21) {
+                long __ts = System.nanoTime();
+                videoDecoder.releaseOutputBuffer(nextOutputBuffer, __ts);
+            } else {
+                videoDecoder.releaseOutputBuffer(nextOutputBuffer, true);
+            }
                     }
 
                     lastRenderedFrameTimeNanos = frameTimeNanos;
@@ -1141,12 +1193,22 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                 __isMTK = sum2.contains("mtk") || sum2.contains("mediatek");
                             } catch (Throwable ignored) {}
                             if (__isMTK) {
-                                videoDecoder.releaseOutputBuffer(__last, true);
+                                if (android.os.Build.VERSION.SDK_INT >= 21) {
+                long __ts = System.nanoTime();
+                videoDecoder.releaseOutputBuffer(__last, __ts);
+            } else {
+                videoDecoder.releaseOutputBuffer(__last, true);
+            }
                             } else if (android.os.Build.VERSION.SDK_INT >= 21) {
                                 long __now = System.nanoTime();
                                 videoDecoder.releaseOutputBuffer(__last, __now);
                             } else {
-                                videoDecoder.releaseOutputBuffer(__last, true);
+                                if (android.os.Build.VERSION.SDK_INT >= 21) {
+                long __ts = System.nanoTime();
+                videoDecoder.releaseOutputBuffer(__last, __ts);
+            } else {
+                videoDecoder.releaseOutputBuffer(__last, true);
+            }
                             }
                             continue; // handled this iteration
                         }
@@ -1156,12 +1218,12 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
                     try {
                         // Try to output a frame
-                        int outIndex = videoDecoder.dequeueOutputBuffer(info, 0); // non-blocking fast path
+                        int outIndex = videoDecoder.dequeueOutputBuffer(info, getOutputDequeueTimeoutUs());
 
                         if (outIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
                             // backoff ridotto 0–500 µs
                             tryAgainStreak++;
-                            int backoffUs = (tryAgainStreak <= 2) ? 250 : 500;
+                            int backoffUs = Math.min(getOutputDequeueTimeoutUs(), (tryAgainStreak <= 2) ? 250 : 500);
                             outIndex = videoDecoder.dequeueOutputBuffer(info, backoffUs);
                         } else {
                             tryAgainStreak = 0;
@@ -1190,7 +1252,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                             // Render the latest frame now if frame pacing isn't in balanced mode
                             if (prefs.framePacing != PreferenceConfiguration.FRAME_PACING_BALANCED) {
                                 // Get the last output buffer in the queue
-                                while ((outIndex = videoDecoder.dequeueOutputBuffer(info, 0)) >= 0) {
+                                while ((outIndex = videoDecoder.dequeueOutputBuffer(info, getOutputDequeueTimeoutUs())) >= 0) {
                                     videoDecoder.releaseOutputBuffer(lastIndex, false);
                                     frameDropped = true; // stiamo scartando il più vecchio
 
@@ -1226,26 +1288,19 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                         recentDrops = Math.max(0, recentDrops - 1);
 
                                         // [STATS] update subito dopo il present
-                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
-                                        if (delta >= 0 && delta < 1000) {
-                                            activeWindowVideoStats.decoderTimeMs += delta;
-                                            if (!USE_FRAME_RENDER_TIME) {
-                                                activeWindowVideoStats.totalTimeMs += delta;
-                                            }
-                                        }
+                                        updateDecodeLatencyStats(presentationTimeUs);
                                         statsUpdated = true;
 
                                     } else {
-                                        videoDecoder.releaseOutputBuffer(lastIndex, true);
+                                        if (android.os.Build.VERSION.SDK_INT >= 21) {
+                long __ts = System.nanoTime();
+                videoDecoder.releaseOutputBuffer(lastIndex, __ts);
+            } else {
+                videoDecoder.releaseOutputBuffer(lastIndex, true);
+            }
 
                                         // [STATS] anche su pre-Lollipop, dopo presentazione
-                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
-                                        if (delta >= 0 && delta < 1000) {
-                                            activeWindowVideoStats.decoderTimeMs += delta;
-                                            if (!USE_FRAME_RENDER_TIME) {
-                                                activeWindowVideoStats.totalTimeMs += delta;
-                                            }
-                                        }
+                                        updateDecodeLatencyStats(presentationTimeUs);
                                         statsUpdated = true;
                                     }
                                 }
@@ -1292,26 +1347,19 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                         recentDrops = Math.max(0, recentDrops - 1);
 
                                         // [STATS] update subito dopo il present
-                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
-                                        if (delta >= 0 && delta < 1000) {
-                                            activeWindowVideoStats.decoderTimeMs += delta;
-                                            if (!USE_FRAME_RENDER_TIME) {
-                                                activeWindowVideoStats.totalTimeMs += delta;
-                                            }
-                                        }
+                                        updateDecodeLatencyStats(presentationTimeUs);
                                         statsUpdated = true;
 
                                     } else {
-                                        videoDecoder.releaseOutputBuffer(lastIndex, true);
+                                        if (android.os.Build.VERSION.SDK_INT >= 21) {
+                long __ts = System.nanoTime();
+                videoDecoder.releaseOutputBuffer(lastIndex, __ts);
+            } else {
+                videoDecoder.releaseOutputBuffer(lastIndex, true);
+            }
 
                                         // [STATS] anche su pre-Lollipop, dopo presentazione
-                                        long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
-                                        if (delta >= 0 && delta < 1000) {
-                                            activeWindowVideoStats.decoderTimeMs += delta;
-                                            if (!USE_FRAME_RENDER_TIME) {
-                                                activeWindowVideoStats.totalTimeMs += delta;
-                                            }
-                                        }
+                                        updateDecodeLatencyStats(presentationTimeUs);
                                         statsUpdated = true;
                                     }
                                 }
@@ -1345,13 +1393,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                             // Se non abbiamo aggiornato le stats in-branch e il frame non è stato droppato,
                             // aggiorniamo ora (ripristina il comportamento classico, utile per BALANCED).
                             if (!statsUpdated && !frameDropped) {
-                                long delta = SystemClock.uptimeMillis() - (presentationTimeUs / 1000);
-                                if (delta >= 0 && delta < 1000) {
-                                    activeWindowVideoStats.decoderTimeMs += delta;
-                                    if (!USE_FRAME_RENDER_TIME) {
-                                        activeWindowVideoStats.totalTimeMs += delta;
-                                    }
-                                }
+                                updateDecodeLatencyStats(presentationTimeUs);
                             }
 
                         } else {
@@ -1581,6 +1623,9 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
             videoDecoder.queueInputBuffer(nextInputBufferIndex,
                     0, nextInputBuffer.position(),
                     timestampUs, codecFlags);
+
+            // Track enqueue time for this PTS
+            try { enqueueNsByPtsUs.put(timestampUs, System.nanoTime()); } catch (Throwable ignored) {}
 
             // We need a new buffer now
             nextInputBufferIndex = -1;
@@ -2275,4 +2320,28 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
             return str;
         }
     }
+
+
+private void applySurfaceFrameRate(android.view.Surface surface, int targetFps) {
+    if (surface == null) return;
+    try {
+        // API 30+ supports Surface.setFrameRate; for older, attempt View-based call elsewhere.
+        if (android.os.Build.VERSION.SDK_INT >= 30) {
+            surface.setFrameRate((float) targetFps,
+                    android.view.Surface.FRAME_RATE_COMPATIBILITY_DEFAULT);
+            LimeLog.info("Applied Surface frame rate: " + targetFps + " Hz");
+        }
+    } catch (Throwable t) {
+        // best-effort
+    }
+}
+
+
+
+private boolean isMTKDecoderName(String name) {
+    if (name == null) return false;
+    String n = name.toLowerCase();
+    return n.startsWith("c2.mtk") || n.startsWith("omx.mtk");
+}
+
 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -752,20 +752,10 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         adaptivePlayback = MediaCodecHelper.decoderSupportsAdaptivePlayback(selectedDecoderInfo, mimeType);
         fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(selectedDecoderInfo, mimeType);
 
-        // Disable latest-only low latency path on NVIDIA decoders (pacing is solid; LFR not needed)
-        if (MediaCodecHelper.isNvidiaDecoder(selectedDecoderInfo.getName()) && preferLowerDelays) {
-            LimeLog.info("PreferLowerDelays overridden for NVIDIA decoder");
-            preferLowerDelays = false;
-        }
-
-
         for (int tryNumber = 0;; tryNumber++) {
             LimeLog.info("Decoder configuration try: "+tryNumber);
 
             MediaFormat mediaFormat = createBaseMediaFormat(mimeType);
-        // Apply vendor-specific extras (NVIDIA/Qualcomm)
-        MediaCodecHelper.applyExtraVendorOptions(mediaFormat, selectedDecoderInfo.getName());
-
             // This will try low latency options until we find one that works (or we give up).
             boolean newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(mediaFormat, selectedDecoderInfo, prefs.enableUltraLowLatency, tryNumber);
             //todo 色彩格式

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -584,6 +584,8 @@ return videoFormat;
 
         videoDecoder.configure(format, renderTarget, null, 0);
 
+        try { applySurfaceFrameRate(renderTarget, targetFps); } catch (Throwable ignored) {}
+
 try {
     MediaCodecInfo __info = (android.os.Build.VERSION.SDK_INT >= 21) ? videoDecoder.getCodecInfo() : null;
     String __name = (__info != null) ? __info.getName() : "<unknown>";
@@ -1071,7 +1073,12 @@ try {
                 long __ts = System.nanoTime();
                 videoDecoder.releaseOutputBuffer(nextOutputBuffer, __ts);
             } else {
-                videoDecoder.releaseOutputBuffer(nextOutputBuffer, true);
+                if (android.os.Build.VERSION.SDK_INT >= 21) {
+    long __ts = System.nanoTime();
+    videoDecoder.releaseOutputBuffer(nextOutputBuffer, __ts);
+} else {
+    videoDecoder.releaseOutputBuffer(nextOutputBuffer, true);
+}
             }
                     }
 
@@ -1197,7 +1204,12 @@ try {
                 long __ts = System.nanoTime();
                 videoDecoder.releaseOutputBuffer(__last, __ts);
             } else {
-                videoDecoder.releaseOutputBuffer(__last, true);
+                if (android.os.Build.VERSION.SDK_INT >= 21) {
+    long __ts = System.nanoTime();
+    videoDecoder.releaseOutputBuffer(__last, __ts);
+} else {
+    videoDecoder.releaseOutputBuffer(__last, true);
+}
             }
                             } else if (android.os.Build.VERSION.SDK_INT >= 21) {
                                 long __now = System.nanoTime();
@@ -1207,7 +1219,12 @@ try {
                 long __ts = System.nanoTime();
                 videoDecoder.releaseOutputBuffer(__last, __ts);
             } else {
-                videoDecoder.releaseOutputBuffer(__last, true);
+                if (android.os.Build.VERSION.SDK_INT >= 21) {
+    long __ts = System.nanoTime();
+    videoDecoder.releaseOutputBuffer(__last, __ts);
+} else {
+    videoDecoder.releaseOutputBuffer(__last, true);
+}
             }
                             }
                             continue; // handled this iteration
@@ -1296,7 +1313,12 @@ try {
                 long __ts = System.nanoTime();
                 videoDecoder.releaseOutputBuffer(lastIndex, __ts);
             } else {
-                videoDecoder.releaseOutputBuffer(lastIndex, true);
+                if (android.os.Build.VERSION.SDK_INT >= 21) {
+    long __ts = System.nanoTime();
+    videoDecoder.releaseOutputBuffer(lastIndex, __ts);
+} else {
+    videoDecoder.releaseOutputBuffer(lastIndex, true);
+}
             }
 
                                         // [STATS] anche su pre-Lollipop, dopo presentazione
@@ -1355,7 +1377,12 @@ try {
                 long __ts = System.nanoTime();
                 videoDecoder.releaseOutputBuffer(lastIndex, __ts);
             } else {
-                videoDecoder.releaseOutputBuffer(lastIndex, true);
+                if (android.os.Build.VERSION.SDK_INT >= 21) {
+    long __ts = System.nanoTime();
+    videoDecoder.releaseOutputBuffer(lastIndex, __ts);
+} else {
+    videoDecoder.releaseOutputBuffer(lastIndex, true);
+}
             }
 
                                         // [STATS] anche su pre-Lollipop, dopo presentazione

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -752,10 +752,20 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         adaptivePlayback = MediaCodecHelper.decoderSupportsAdaptivePlayback(selectedDecoderInfo, mimeType);
         fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(selectedDecoderInfo, mimeType);
 
+        // Disable latest-only low latency path on NVIDIA decoders (pacing is solid; LFR not needed)
+        if (MediaCodecHelper.isNvidiaDecoder(selectedDecoderInfo.getName()) && preferLowerDelays) {
+            LimeLog.info("PreferLowerDelays overridden for NVIDIA decoder");
+            preferLowerDelays = false;
+        }
+
+
         for (int tryNumber = 0;; tryNumber++) {
             LimeLog.info("Decoder configuration try: "+tryNumber);
 
             MediaFormat mediaFormat = createBaseMediaFormat(mimeType);
+        // Apply vendor-specific extras (NVIDIA/Qualcomm)
+        MediaCodecHelper.applyExtraVendorOptions(mediaFormat, selectedDecoderInfo.getName());
+
             // This will try low latency options until we find one that works (or we give up).
             boolean newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(mediaFormat, selectedDecoderInfo, prefs.enableUltraLowLatency, tryNumber);
             //todo 色彩格式

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -47,12 +47,12 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     // Set true to enable a 'latest-only' fast path in the render loop.
     private boolean preferLowerDelays = false;
 
-    
-// Force tight thresholds regardless of device refresh (use vsyncPeriodNs always)
-private volatile boolean forceTightThresholds = false;
-/** Toggle tight frame pacing thresholds globally. */
-public void setForceTightThresholds(boolean v) { this.forceTightThresholds = v; }
-// Toggle at runtime if needed
+
+    // Force tight thresholds regardless of device refresh (use vsyncPeriodNs always)
+    private volatile boolean forceTightThresholds = false;
+    /** Toggle tight frame pacing thresholds globally. */
+    public void setForceTightThresholds(boolean v) { this.forceTightThresholds = v; }
+    // Toggle at runtime if needed
     // Decode latency tracking: map PTS(us) -> enqueue time (ns)
     private final LongSparseArray<Long> enqueueNsByPtsUs = new LongSparseArray<>();
 
@@ -61,7 +61,25 @@ public void setForceTightThresholds(boolean v) { this.forceTightThresholds = v; 
     private volatile int preferLowerDelaysTimeoutUs = 2000;
     public void setPreferLowerDelaysTimeoutUs(int us) { this.preferLowerDelaysTimeoutUs = Math.max(0, us); }
 
-    private int getOutputDequeueTimeoutUs(){ return preferLowerDelays ? preferLowerDelaysTimeoutUs : 0; }
+
+    // Helper: release with low-latency policy (immediate only when very near to now)
+    private void releaseWithPolicy(int bufferIndex, long frameTimeNanos) {
+        try {
+            long now = System.nanoTime();
+            boolean immediate = preferLowerDelays && (frameTimeNanos <= now + 300_000L);
+            if (immediate) {
+                videoDecoder.releaseOutputBuffer(bufferIndex, true);
+            } else {
+                videoDecoder.releaseOutputBuffer(bufferIndex, frameTimeNanos);
+            }
+        } catch (Throwable t) {
+            try {
+                // Fallback to immediate if timestamped release fails for any reason
+                videoDecoder.releaseOutputBuffer(bufferIndex, true);
+            } catch (Throwable ignored) {}
+        }
+    }
+    private int getOutputDequeueTimeoutUs(){ return preferLowerDelays ? Math.max(250, preferLowerDelaysTimeoutUs) : preferLowerDelaysTimeoutUs; }
 
     // Update stats using real decode time: enqueue->dequeue, instead of uptime - PTS
     private void updateDecodeLatencyStats(long presentationTimeUs) {
@@ -552,7 +570,7 @@ public void setForceTightThresholds(boolean v) { this.forceTightThresholds = v; 
             }
         }
 
-return videoFormat;
+        return videoFormat;
     }
 
     private void configureAndStartDecoder(MediaFormat format) {
@@ -591,13 +609,13 @@ return videoFormat;
 
         try { applySurfaceFrameRate(renderTarget, targetFps); } catch (Throwable ignored) {}
 
-try {
-    MediaCodecInfo __info = (android.os.Build.VERSION.SDK_INT >= 21) ? videoDecoder.getCodecInfo() : null;
-    String __name = (__info != null) ? __info.getName() : "<unknown>";
-    LimeLog.info("Decoder name: " + __name);
-} catch (Throwable t) {
-    LimeLog.info("Decoder name: <unavailable>");
-}
+        try {
+            MediaCodecInfo __info = (android.os.Build.VERSION.SDK_INT >= 21) ? videoDecoder.getCodecInfo() : null;
+            String __name = (__info != null) ? __info.getName() : "<unknown>";
+            LimeLog.info("Decoder name: " + __name);
+        } catch (Throwable t) {
+            LimeLog.info("Decoder name: <unavailable>");
+        }
 
 
         configuredFormat = format;
@@ -620,14 +638,14 @@ try {
         videoDecoder.start();
 
 // Diagnostics: dump negotiated input/output formats and check vendor keys acceptance
-try {
-    MediaFormat __inF = videoDecoder.getInputFormat();
-    MediaFormat __outF = videoDecoder.getOutputFormat();
-    LimeLog.info("Decoder input format: " + (__inF != null ? __inF.toString() : "<null>"));
-    LimeLog.info("Decoder output format: " + (__outF != null ? __outF.toString() : "<null>"));
-} catch (Throwable t) {
-    LimeLog.info("Decoder formats unavailable after start");
-}
+        try {
+            MediaFormat __inF = videoDecoder.getInputFormat();
+            MediaFormat __outF = videoDecoder.getOutputFormat();
+            LimeLog.info("Decoder input format: " + (__inF != null ? __inF.toString() : "<null>"));
+            LimeLog.info("Decoder output format: " + (__outF != null ? __outF.toString() : "<null>"));
+        } catch (Throwable t) {
+            LimeLog.info("Decoder formats unavailable after start");
+        }
 
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
@@ -1071,20 +1089,23 @@ try {
             if (nextOutputBuffer != null) {
                 try {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        videoDecoder.releaseOutputBuffer(nextOutputBuffer, frameTimeNanos);
+                        if (preferLowerDelays) {
+                            // ULL: present at next VSYNC (no scheduling)
+                            releaseWithPolicy(nextOutputBuffer, System.nanoTime());} else {
+                            // Smooth/Balanced: keep timestamp scheduling
+                            videoDecoder.releaseOutputBuffer(nextOutputBuffer, frameTimeNanos);
+                        }
+
                     }
                     else {
                         if (android.os.Build.VERSION.SDK_INT >= 21) {
-                long __ts = System.nanoTime();
-                videoDecoder.releaseOutputBuffer(nextOutputBuffer, __ts);
-            } else {
-                if (android.os.Build.VERSION.SDK_INT >= 21) {
-    long __ts = System.nanoTime();
-    videoDecoder.releaseOutputBuffer(nextOutputBuffer, __ts);
-} else {
-    videoDecoder.releaseOutputBuffer(nextOutputBuffer, true);
-}
-            }
+                            long __ts = System.nanoTime();
+                            releaseWithPolicy(nextOutputBuffer, System.nanoTime());} else {
+                            if (android.os.Build.VERSION.SDK_INT >= 21) {
+                                long __ts = System.nanoTime();
+                                releaseWithPolicy(nextOutputBuffer, frameTimeNanos);} else {
+                                releaseWithPolicy(nextOutputBuffer, frameTimeNanos);}
+                        }
                     }
 
                     lastRenderedFrameTimeNanos = frameTimeNanos;
@@ -1154,15 +1175,13 @@ try {
                 final int tfps = (targetFps > 0 ? targetFps : 60);
                 final long streamPeriodNs = (long) (1_000_000_000L / Math.max(1, tfps));
 
-                
+
                 // Adaptive period selection to avoid added latency on high-refresh devices
                 final boolean highRefresh = displayHz >= 90f;
                 final boolean managedMode = (prefs != null && prefs.framePacing == PreferenceConfiguration.FRAME_PACING_BALANCED);
                 // Use stream-aligned thresholds only on lower-refresh screens while in Balanced.
-                final long periodNs = forceTightThresholds
-                        ? vsyncPeriodNs
-                        : ((managedMode && !highRefresh) ? Math.max(vsyncPeriodNs, streamPeriodNs) : vsyncPeriodNs);
-boolean isC2Decoder = false;
+                final long periodNs = (preferLowerDelays ? vsyncPeriodNs : Math.max(vsyncPeriodNs, streamPeriodNs));
+                boolean isC2Decoder = false;
                 try {
                     String decName = videoDecoder.getName();
                     if (decName != null) {
@@ -1189,44 +1208,42 @@ boolean isC2Decoder = false;
                 BufferInfo info = new BufferInfo();
                 long lastOutputNs = System.nanoTime();
                 while (!stopping) {
-                /* LATEST_ONLY_LOW_LATENCY */
-                if (!preferLowerDelays) {
-    try {
-        android.media.MediaCodec.BufferInfo __tmpInfo = new android.media.MediaCodec.BufferInfo();
-        int __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
-        int __last = -1;
-        long __lastPtsUs = -1L;
+                    /* LATEST_ONLY_LOW_LATENCY */
+                    if (!preferLowerDelays) {
+                        try {
+                            android.media.MediaCodec.BufferInfo __tmpInfo = new android.media.MediaCodec.BufferInfo();
+                            int __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+                            int __last = -1;
+                            long __lastPtsUs = -1L;
 
-        // Drain non-blocking; keep only the newest buffer
-        while (__idx >= 0) {
-            if (__last >= 0) {
-                try { videoDecoder.releaseOutputBuffer(__last, false); } catch (Throwable ignored) {}
-            }
-            __last = __idx;
-            __lastPtsUs = __tmpInfo.presentationTimeUs;
-            __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
-        }
+                            // Drain non-blocking; keep only the newest buffer
+                            while (__idx >= 0) {
+                                if (__last >= 0) {
+                                    try { videoDecoder.releaseOutputBuffer(__last, false); } catch (Throwable ignored) {}
+                                }
+                                __last = __idx;
+                                __lastPtsUs = __tmpInfo.presentationTimeUs;
+                                __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+                            }
 
-        if (__last >= 0) {
-            long __nowNs = System.nanoTime();
-            if (android.os.Build.VERSION.SDK_INT >= 21) {
-                videoDecoder.releaseOutputBuffer(__last, __nowNs);
-            } else {
-                videoDecoder.releaseOutputBuffer(__last, true);
-            }
+                            if (__last >= 0) {
+                                long __nowNs = System.nanoTime();
+                                if (android.os.Build.VERSION.SDK_INT >= 21) {
+                                    releaseWithPolicy(__last, System.nanoTime());} else {
+                                    releaseWithPolicy(__last, System.nanoTime());}
 
-            // Update decode->present EWMA and decode stats if we have a valid PTS
-            if (__lastPtsUs >= 0) {
-                long __d2pNs = __nowNs - (__lastPtsUs * 1000L);
-                ewmaDecodeToPresentNs += EWMA_ALPHA * (__d2pNs - ewmaDecodeToPresentNs);
-                try { updateDecodeLatencyStats(__lastPtsUs); } catch (Throwable ignored) {}
-            }
+                                // Update decode->present EWMA and decode stats if we have a valid PTS
+                                if (__lastPtsUs >= 0) {
+                                    long __d2pNs = __nowNs - (__lastPtsUs * 1000L);
+                                    ewmaDecodeToPresentNs += EWMA_ALPHA * (__d2pNs - ewmaDecodeToPresentNs);
+                                    try { updateDecodeLatencyStats(__lastPtsUs); } catch (Throwable ignored) {}
+                                }
 
-            continue; // handled this iteration
-        }
-    } catch (Throwable ignored) {}
-}
-/* /LATEST_ONLY_LOW_LATENCY */
+                                continue; // handled this iteration
+                            }
+                        } catch (Throwable ignored) {}
+                    }
+                    /* /LATEST_ONLY_LOW_LATENCY */
 
 
                     try {
@@ -1234,9 +1251,9 @@ boolean isC2Decoder = false;
                         int outIndex = videoDecoder.dequeueOutputBuffer(info, getOutputDequeueTimeoutUs());
 
                         if (outIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
-                            // backoff ridotto 0–500 µs
+                            // reduced backoff 0–500 µs
                             tryAgainStreak++;
-                            int backoffUs = Math.min(getOutputDequeueTimeoutUs(), (tryAgainStreak <= 2) ? 250 : 500);
+                            int backoffUs = (tryAgainStreak <= 2) ? 250 : 500;
                             outIndex = videoDecoder.dequeueOutputBuffer(info, backoffUs);
                         } else {
                             tryAgainStreak = 0;
@@ -1267,7 +1284,7 @@ boolean isC2Decoder = false;
                                 // Get the last output buffer in the queue
                                 while ((outIndex = videoDecoder.dequeueOutputBuffer(info, getOutputDequeueTimeoutUs())) >= 0) {
                                     videoDecoder.releaseOutputBuffer(lastIndex, false);
-                                    frameDropped = true; // stiamo scartando il più vecchio
+                                    frameDropped = true; // we're discarding the oldest one
 
                                     numFramesOut++;
                                     lastIndex = outIndex;
@@ -1281,7 +1298,7 @@ boolean isC2Decoder = false;
                                         final long nowNs = System.nanoTime();
                                         final long frameAgeNs = nowNs - (presentationTimeUs * 1000L);
 
-                                        // Smoothness: soglia più stretta 1.05..1.2×
+                                        // Smoothness: tighter threshold 1.05..1.2×
                                         double pressure = Math.min(1.0, (ewmaJitterNs / vsyncPeriodNs) + (recentDrops * 0.1));
                                         double factorSmooth = 1.2 - 0.15 * (1.0 - pressure);
                                         factorSmooth = Math.max(1.05, Math.min(1.2, factorSmooth));
@@ -1289,14 +1306,26 @@ boolean isC2Decoder = false;
                                         long dropThresholdSmoothNs = (long)(periodNs * factorSmooth);
 
                                         if (frameAgeNs >= dropThresholdSmoothNs) {
-                                            videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
+                                            if (preferLowerDelays) {
+                                                // ULL: present at next VSYNC (no scheduling)
+                                                releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                                // Smooth/Balanced: keep timestamp scheduling
+                                                videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
+                                            }
+
                                             frameDropped = true;
                                             lastDropNs = nowNs;
                                             recentDrops = Math.min(10, recentDrops + 1);
                                             continue;
                                         }
 
-                                        videoDecoder.releaseOutputBuffer(lastIndex, nowNs);
+                                        if (preferLowerDelays) {
+                                            // ULL: present at next VSYNC (no scheduling)
+                                            releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                            // Smooth/Balanced: keep timestamp scheduling
+                                            videoDecoder.releaseOutputBuffer(lastIndex, nowNs);
+                                        }
+
                                         lastPresentNs = nowNs;
                                         recentDrops = Math.max(0, recentDrops - 1);
 
@@ -1306,16 +1335,14 @@ boolean isC2Decoder = false;
 
                                     } else {
                                         if (android.os.Build.VERSION.SDK_INT >= 21) {
-                long __ts = System.nanoTime();
-                videoDecoder.releaseOutputBuffer(lastIndex, __ts);
-            } else {
-                if (android.os.Build.VERSION.SDK_INT >= 21) {
-    long __ts = System.nanoTime();
-    videoDecoder.releaseOutputBuffer(lastIndex, __ts);
-} else {
-    videoDecoder.releaseOutputBuffer(lastIndex, false);
-}
-            }
+                                            long __ts = System.nanoTime();
+                                            releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                            if (android.os.Build.VERSION.SDK_INT >= 21) {
+                                                long __ts = System.nanoTime();
+                                                releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                                videoDecoder.releaseOutputBuffer(lastIndex, false);
+                                            }
+                                        }
 
                                         // [STATS] anche su pre-Lollipop, dopo presentazione
                                         updateDecodeLatencyStats(presentationTimeUs);
@@ -1352,14 +1379,26 @@ boolean isC2Decoder = false;
                                                         dropCooldownOk;
 
                                         if (shouldDrop) {
-                                            videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
+                                            if (preferLowerDelays) {
+                                                // ULL: present at next VSYNC (no scheduling)
+                                                releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                                // Smooth/Balanced: keep timestamp scheduling
+                                                videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
+                                            }
+
                                             frameDropped = true;
                                             lastDropNs = nowNs;
                                             recentDrops = Math.min(10, recentDrops + 1);
                                             continue; // niente stats sui frame droppati
                                         }
 
-                                        videoDecoder.releaseOutputBuffer(lastIndex, nowNs);
+                                        if (preferLowerDelays) {
+                                            // ULL: present at next VSYNC (no scheduling)
+                                            releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                            // Smooth/Balanced: keep timestamp scheduling
+                                            videoDecoder.releaseOutputBuffer(lastIndex, nowNs);
+                                        }
+
                                         lastPresentNs = nowNs;
                                         if (!isLate) lateStreak = 0;
                                         recentDrops = Math.max(0, recentDrops - 1);
@@ -1370,16 +1409,14 @@ boolean isC2Decoder = false;
 
                                     } else {
                                         if (android.os.Build.VERSION.SDK_INT >= 21) {
-                long __ts = System.nanoTime();
-                videoDecoder.releaseOutputBuffer(lastIndex, __ts);
-            } else {
-                if (android.os.Build.VERSION.SDK_INT >= 21) {
-    long __ts = System.nanoTime();
-    videoDecoder.releaseOutputBuffer(lastIndex, __ts);
-} else {
-    videoDecoder.releaseOutputBuffer(lastIndex, false);
-}
-            }
+                                            long __ts = System.nanoTime();
+                                            releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                            if (android.os.Build.VERSION.SDK_INT >= 21) {
+                                                long __ts = System.nanoTime();
+                                                releaseWithPolicy(lastIndex, System.nanoTime());} else {
+                                                videoDecoder.releaseOutputBuffer(lastIndex, false);
+                                            }
+                                        }
 
                                         // [STATS] anche su pre-Lollipop, dopo presentazione
                                         updateDecodeLatencyStats(presentationTimeUs);
@@ -1413,8 +1450,7 @@ boolean isC2Decoder = false;
                             }
 
                             // --- Fallback stats update ---
-                            // Se non abbiamo aggiornato le stats in-branch e il frame non è stato droppato,
-                            // aggiorniamo ora (ripristina il comportamento classico, utile per BALANCED).
+                            // If we didn't update the stats in-branch and the frame wasn't dropped,
                             if (!statsUpdated && !frameDropped) {
                                 updateDecodeLatencyStats(presentationTimeUs);
                             }
@@ -1439,22 +1475,22 @@ boolean isC2Decoder = false;
                     }
                 }
 
-                    /* WATCHDOG_C2_SLEEP */
-                    try {
-                        final long __nowNs = System.nanoTime();
-                        if (__nowNs - lastOutputNs > 1_200_000_000L) { // ~1.2s senza output → probabile C2 sleep
-                            LimeLog.warning("Decoder watchdog: no output >1.2s, flushing codec to recover...");
-                            try {
-                                videoDecoder.flush();
-                            } catch (Throwable ignored) {}
-                            try {
-                                android.os.Bundle __poke = new android.os.Bundle();
-                                __poke.putInt("priority", 0);
-                                videoDecoder.setParameters(__poke);
-                            } catch (Throwable ignored) {}
-                            lastOutputNs = __nowNs;
-                        }
-                    } catch (Throwable ignored) {}
+                /* WATCHDOG_C2_SLEEP */
+                try {
+                    final long __nowNs = System.nanoTime();
+                    if (__nowNs - lastOutputNs > 1_200_000_000L) { // ~1.2s without output → likely C2 sleep
+                        LimeLog.warning("Decoder watchdog: no output >1.2s, flushing codec to recover...");
+                        try {
+                            videoDecoder.flush();
+                        } catch (Throwable ignored) {}
+                        try {
+                            android.os.Bundle __poke = new android.os.Bundle();
+                            __poke.putInt("priority", 0);
+                            videoDecoder.setParameters(__poke);
+                        } catch (Throwable ignored) {}
+                        lastOutputNs = __nowNs;
+                    }
+                } catch (Throwable ignored) {}
             }
         };
         rendererThread.setName("Video - Renderer (MediaCodec)");
@@ -2345,26 +2381,26 @@ boolean isC2Decoder = false;
     }
 
 
-private void applySurfaceFrameRate(android.view.Surface surface, int targetFps) {
-    if (surface == null) return;
-    try {
-        // API 30+ supports Surface.setFrameRate; for older, attempt View-based call elsewhere.
-        if (android.os.Build.VERSION.SDK_INT >= 30) {
-            surface.setFrameRate((float) targetFps,
-                    android.view.Surface.FRAME_RATE_COMPATIBILITY_DEFAULT);
-            LimeLog.info("Applied Surface frame rate: " + targetFps + " Hz");
+    private void applySurfaceFrameRate(android.view.Surface surface, int targetFps) {
+        if (surface == null) return;
+        try {
+            // API 30+ supports Surface.setFrameRate; for older, attempt View-based call elsewhere.
+            if (android.os.Build.VERSION.SDK_INT >= 30) {
+                surface.setFrameRate((float) targetFps,
+                        android.view.Surface.FRAME_RATE_COMPATIBILITY_DEFAULT);
+                LimeLog.info("Applied Surface frame rate: " + targetFps + " Hz");
+            }
+        } catch (Throwable t) {
+            // best-effort
         }
-    } catch (Throwable t) {
-        // best-effort
     }
-}
 
 
 
-private boolean isMTKDecoderName(String name) {
-    if (name == null) return false;
-    String n = name.toLowerCase();
-    return n.startsWith("c2.mtk") || n.startsWith("omx.mtk");
-}
+    private boolean isMTKDecoderName(String name) {
+        if (name == null) return false;
+        String n = name.toLowerCase();
+        return n.startsWith("c2.mtk") || n.startsWith("omx.mtk");
+    }
 
 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -47,16 +47,21 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     // Set true to enable a 'latest-only' fast path in the render loop.
     private boolean preferLowerDelays = false;
 
-    // Toggle at runtime if needed
+    
+// Force tight thresholds regardless of device refresh (use vsyncPeriodNs always)
+private volatile boolean forceTightThresholds = false;
+/** Toggle tight frame pacing thresholds globally. */
+public void setForceTightThresholds(boolean v) { this.forceTightThresholds = v; }
+// Toggle at runtime if needed
     // Decode latency tracking: map PTS(us) -> enqueue time (ns)
     private final LongSparseArray<Long> enqueueNsByPtsUs = new LongSparseArray<>();
 
-    // When preferLowerDelays=true we force 0µs (non-blocking, latest-frame rendering).
-    // When preferLowerDelays=false we use this configurable timeout (µs) for output dequeue.
+    // When preferLowerDelays=true we use this configurable timeout (µs) for output dequeue.
+// When preferLowerDelays=false we force 0µs (non-blocking, latest-frame rendering).
     private volatile int preferLowerDelaysTimeoutUs = 2000;
     public void setPreferLowerDelaysTimeoutUs(int us) { this.preferLowerDelaysTimeoutUs = Math.max(0, us); }
 
-    private int getOutputDequeueTimeoutUs(){ return preferLowerDelays ? 0 : preferLowerDelaysTimeoutUs; }
+    private int getOutputDequeueTimeoutUs(){ return preferLowerDelays ? preferLowerDelaysTimeoutUs : 0; }
 
     // Update stats using real decode time: enqueue->dequeue, instead of uptime - PTS
     private void updateDecodeLatencyStats(long presentationTimeUs) {
@@ -1149,7 +1154,15 @@ try {
                 final int tfps = (targetFps > 0 ? targetFps : 60);
                 final long streamPeriodNs = (long) (1_000_000_000L / Math.max(1, tfps));
 
-                boolean isC2Decoder = false;
+                
+                // Adaptive period selection to avoid added latency on high-refresh devices
+                final boolean highRefresh = displayHz >= 90f;
+                final boolean managedMode = (prefs != null && prefs.framePacing == PreferenceConfiguration.FRAME_PACING_BALANCED);
+                // Use stream-aligned thresholds only on lower-refresh screens while in Balanced.
+                final long periodNs = forceTightThresholds
+                        ? vsyncPeriodNs
+                        : ((managedMode && !highRefresh) ? Math.max(vsyncPeriodNs, streamPeriodNs) : vsyncPeriodNs);
+boolean isC2Decoder = false;
                 try {
                     String decName = videoDecoder.getName();
                     if (decName != null) {
@@ -1170,68 +1183,51 @@ try {
                 int    recentDrops             = 0;
 
                 double ewmaInterArrivalNs      = (1_000_000_000.0 / Math.max(1, tfps));
-                double ewmaDecodeToPresentNs   = vsyncPeriodNs * 0.7;
-                double ewmaJitterNs            = vsyncPeriodNs * 0.1;
+                double ewmaDecodeToPresentNs   = periodNs * 0.7;
+                double ewmaJitterNs            = periodNs * 0.1;
 
                 BufferInfo info = new BufferInfo();
                 long lastOutputNs = System.nanoTime();
                 while (!stopping) {
                 /* LATEST_ONLY_LOW_LATENCY */
-                if (preferLowerDelays) {
-                    try {
-                        android.media.MediaCodec.BufferInfo __tmpInfo = new android.media.MediaCodec.BufferInfo();
-                        int __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
-                        int __last = -1;
-                        // Drain non-blocking; keep only the newest buffer
-                        while (__idx >= 0) {
-                            if (__last >= 0) {
-                                try { videoDecoder.releaseOutputBuffer(__last, false); } catch (Throwable ignored) {}
-                            }
-                            __last = __idx;
-                            __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
-                        }
-                        if (__last >= 0) {
-                            // Simple pacing rule:
-                            // - MTK devices → present immediate (true)
-                            // - Others     → present at "now" timestamp
-                            boolean __isMTK = false;
-                            try {
-                                String sum2 = (android.os.Build.MANUFACTURER + " " + android.os.Build.HARDWARE + " " + android.os.Build.BOARD).toLowerCase(java.util.Locale.US);
-                                __isMTK = sum2.contains("mtk") || sum2.contains("mediatek");
-                            } catch (Throwable ignored) {}
-                            if (__isMTK) {
-                                if (android.os.Build.VERSION.SDK_INT >= 21) {
-                long __ts = System.nanoTime();
-                videoDecoder.releaseOutputBuffer(__last, __ts);
-            } else {
-                if (android.os.Build.VERSION.SDK_INT >= 21) {
-    long __ts = System.nanoTime();
-    videoDecoder.releaseOutputBuffer(__last, __ts);
-} else {
-    videoDecoder.releaseOutputBuffer(__last, true);
-}
+                if (!preferLowerDelays) {
+    try {
+        android.media.MediaCodec.BufferInfo __tmpInfo = new android.media.MediaCodec.BufferInfo();
+        int __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+        int __last = -1;
+        long __lastPtsUs = -1L;
+
+        // Drain non-blocking; keep only the newest buffer
+        while (__idx >= 0) {
+            if (__last >= 0) {
+                try { videoDecoder.releaseOutputBuffer(__last, false); } catch (Throwable ignored) {}
             }
-                            } else if (android.os.Build.VERSION.SDK_INT >= 21) {
-                                long __now = System.nanoTime();
-                                videoDecoder.releaseOutputBuffer(__last, __now);
-                            } else {
-                                if (android.os.Build.VERSION.SDK_INT >= 21) {
-                long __ts = System.nanoTime();
-                videoDecoder.releaseOutputBuffer(__last, __ts);
+            __last = __idx;
+            __lastPtsUs = __tmpInfo.presentationTimeUs;
+            __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+        }
+
+        if (__last >= 0) {
+            long __nowNs = System.nanoTime();
+            if (android.os.Build.VERSION.SDK_INT >= 21) {
+                videoDecoder.releaseOutputBuffer(__last, __nowNs);
             } else {
-                if (android.os.Build.VERSION.SDK_INT >= 21) {
-    long __ts = System.nanoTime();
-    videoDecoder.releaseOutputBuffer(__last, __ts);
-} else {
-    videoDecoder.releaseOutputBuffer(__last, true);
-}
+                videoDecoder.releaseOutputBuffer(__last, true);
             }
-                            }
-                            continue; // handled this iteration
-                        }
-                    } catch (Throwable ignored) {}
-                }
-                /* /LATEST_ONLY_LOW_LATENCY */
+
+            // Update decode->present EWMA and decode stats if we have a valid PTS
+            if (__lastPtsUs >= 0) {
+                long __d2pNs = __nowNs - (__lastPtsUs * 1000L);
+                ewmaDecodeToPresentNs += EWMA_ALPHA * (__d2pNs - ewmaDecodeToPresentNs);
+                try { updateDecodeLatencyStats(__lastPtsUs); } catch (Throwable ignored) {}
+            }
+
+            continue; // handled this iteration
+        }
+    } catch (Throwable ignored) {}
+}
+/* /LATEST_ONLY_LOW_LATENCY */
+
 
                     try {
                         // Try to output a frame
@@ -1290,7 +1286,7 @@ try {
                                         double factorSmooth = 1.2 - 0.15 * (1.0 - pressure);
                                         factorSmooth = Math.max(1.05, Math.min(1.2, factorSmooth));
 
-                                        long dropThresholdSmoothNs = (long)(vsyncPeriodNs * factorSmooth);
+                                        long dropThresholdSmoothNs = (long)(periodNs * factorSmooth);
 
                                         if (frameAgeNs >= dropThresholdSmoothNs) {
                                             videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
@@ -1317,7 +1313,7 @@ try {
     long __ts = System.nanoTime();
     videoDecoder.releaseOutputBuffer(lastIndex, __ts);
 } else {
-    videoDecoder.releaseOutputBuffer(lastIndex, true);
+    videoDecoder.releaseOutputBuffer(lastIndex, false);
 }
             }
 
@@ -1342,17 +1338,17 @@ try {
                                                 + 0.2 * mismatch);
                                         factorLatency = Math.max(MIN_FACTOR, Math.min(1.15, factorLatency));
 
-                                        long dropThresholdNs = (long)(vsyncPeriodNs * factorLatency);
+                                        long dropThresholdNs = (long)(periodNs * factorLatency);
 
                                         final long sinceLastPresent = (lastPresentNs == 0L) ? Long.MAX_VALUE : (nowNs - lastPresentNs);
-                                        final boolean dropCooldownOk = (nowNs - lastDropNs) >= (vsyncPeriodNs / 2);
+                                        final boolean dropCooldownOk = (nowNs - lastDropNs) >= (periodNs / 2);
                                         final boolean isLate = frameAgeNs > dropThresholdNs;
                                         lateStreak = isLate ? (lateStreak + 1) : 0;
 
                                         final boolean shouldDrop =
                                                 isLate &&
                                                         (lateStreak >= 1) &&
-                                                        (sinceLastPresent < (long)(vsyncPeriodNs * 0.5)) &&
+                                                        (sinceLastPresent < (long)(periodNs * 0.5)) &&
                                                         dropCooldownOk;
 
                                         if (shouldDrop) {
@@ -1381,7 +1377,7 @@ try {
     long __ts = System.nanoTime();
     videoDecoder.releaseOutputBuffer(lastIndex, __ts);
 } else {
-    videoDecoder.releaseOutputBuffer(lastIndex, true);
+    videoDecoder.releaseOutputBuffer(lastIndex, false);
 }
             }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -596,11 +596,55 @@ public class MediaCodecHelper {
             //ALONSOJR1980
             else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
                 if (tryNumber < 4) {
-
-                    videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode.value", 2);
+                    //  Enable general CPU boost during decoding
+                    videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode", 2);
+                    //  Dolby Vision may use this; can also impact H.264/H.265
                     videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1);
+                    //  Minimum buffer fetch timeout
+                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);
+                    //  Video decoder’s internal buffer queue
                     videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time.value", 2);
-                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 2);
+
+            //DERFLACCO
+
+            //  Limit input queue depth
+                    videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", 2);
+
+            //  Apply aggressive frame-drop policy
+                    videoFormat.setInteger("vendor.mtk.vdec.frame-drop.policy", 1);
+
+            //  Disable idle mode between frames to reduce latency
+                    videoFormat.setInteger("vendor.mtk.vdec.disable-idle", 1);
+
+            //  Enable official low-latency mode
+                    videoFormat.setInteger("vendor.mtk.vdec.low-latency.mode", 1);
+
+            //  TEST – set preload frame count to 0
+                    videoFormat.setInteger("vendor.mtk.vdec.preload.frame.count", 0);
+
+            //  TEST – ultra-low latency mode (not supported on all SoCs)
+                    videoFormat.setInteger("vendor.mtk.vdec.ultra-low-latency", 1);
+
+            //  Skip NVOP frames (empty frames)
+                    videoFormat.setInteger("vendor.mtk.vdec.nvop.skip", 1);
+
+            //  Skip frame policy (can improve HEVC stream playback)
+                    videoFormat.setInteger("vendor.mtk.vdec.skip.mode", 1);
+
+            //  Drop non-reference frames to optimize performance
+                    videoFormat.setInteger("vendor.mtk.vdec.drop.nonref.frame", 1);
+
+            //  Boost parser thread priority
+                    videoFormat.setInteger("vendor.mtk.vdec.parser.boost", 1);
+
+            //  Force high DVFS (Dynamic Voltage/Frequency Scaling)
+                    videoFormat.setInteger("vendor.mtk.vdec.dvfs.mode", 1);
+
+            //  Set decoding thread to high priority (99 = max for user-space)
+                    videoFormat.setInteger("vendor.mtk.vdec.thread.priority", 99);
+
+            //  Disable V-Sync correction (reduces latency, may introduce tearing)
+                    //videoFormat.setInteger("vendor.mtk.vdec.vsync.adjust.enable", 0);
 
                     setNewOption = true;
                 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -638,6 +638,7 @@ public class MediaCodecHelper {
                     // --- PRESET: MTK Low-Latency (safe & balanced, no duplicates) ---
 
                     // Boost/DVFS: moderate profile
+                    safeSet(videoFormat, "vdec-lowlatency", 1);
                     safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 1);
                     safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode.value", 1);
                     safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -505,7 +505,8 @@ public class MediaCodecHelper {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 (
                         isDecoderInList(qualcommDecoderPrefixes, decoderName)
-                        || isDecoderInList(refFrameInvalidationHevcPrefixes, decoderName)
+                        || isDecoderInList(refFrameInvalidationHevcPrefixes, decoderName) ||
+                           isDecoderInList(refFrameInvalidationAvcPrefixes,  decoderName)
                 ) && !isAdreno620;
     }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -40,6 +40,7 @@ public class MediaCodecHelper {
     private static final List<String> refFrameInvalidationHevcPrefixes;
     private static final List<String> useFourSlicesPrefixes;
     private static final List<String> qualcommDecoderPrefixes;
+    private static final List<String> mtkDecoderPrefixes; //ALONSOJR1980
     private static final List<String> kirinDecoderPrefixes;
     private static final List<String> exynosDecoderPrefixes;
     private static final List<String> amlogicDecoderPrefixes;
@@ -228,6 +229,13 @@ public class MediaCodecHelper {
 
         qualcommDecoderPrefixes.add("omx.qcom");
         qualcommDecoderPrefixes.add("c2.qti");
+    }
+
+    //ALONSOJR1980
+    static {
+        mtkDecoderPrefixes = new LinkedList<>();
+
+        mtkDecoderPrefixes.add("c2.mtk");
     }
 
     static {
@@ -579,6 +587,18 @@ public class MediaCodecHelper {
                     videoFormat.setInteger("vendor.qti-ext-output-fence.enable", 1); // Snapdragon 8s Gen 3 and Elite
                     videoFormat.setInteger("vendor.qti-ext-output-fence.fence_type", 1); // Snapdragon 8s Gen 3 and ELite / 0 = none, 1 = sw, 2 = hw, 3 = hybrid. Best option = 1
                     ////////////////////////////////////////////////////////////////////////////////
+
+                    setNewOption = true;
+                }
+            }
+            //ALONSOJR1980
+            else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
+                if (tryNumber < 4) {
+
+                    videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode.value", 2);
+                    videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1);
+                    videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time.value", 2);
+                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 2);
 
                     setNewOption = true;
                 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -693,9 +693,12 @@ public class MediaCodecHelper {
                              safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 1);                     // Light skip on for backlog prevention
                              safeSet(videoFormat, "vendor.mtk.vdec.drop.nonref.frame", 1);             // Allow dropping non-ref frames
                              safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);             // Default policy; app decides pacing
+                             safeSet(videoFormat, MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE);
+                             try { videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE); } catch (Throwable ignored) {}
+                             safeSet(videoFormat, MediaFormat.KEY_PRIORITY, 0);
+                             }
 
 
-                     }
                         setNewOption = true;
                     }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -372,6 +372,8 @@ public class MediaCodecHelper {
                 refFrameInvalidationHevcPrefixes.add("omx.qcom");
                 refFrameInvalidationAvcPrefixes.add("c2.qti");
                 refFrameInvalidationHevcPrefixes.add("c2.qti");
+                refFrameInvalidationAvcPrefixes.add("c2.mtk");
+                refFrameInvalidationHevcPrefixes.add("c2.mtk");
             }
 
             // Qualcomm's early HEVC decoders break hard on our HEVC stream. The best check to
@@ -488,8 +490,10 @@ public class MediaCodecHelper {
         // NB: Even on Android 10, this optimization still provides significant
         // performance gains on Pixel 2.
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                isDecoderInList(qualcommDecoderPrefixes, decoderName) &&
-                !isAdreno620;
+                (
+                        isDecoderInList(qualcommDecoderPrefixes, decoderName)
+                        || isDecoderInList(refFrameInvalidationHevcPrefixes, decoderName)
+                ) && !isAdreno620;
     }
 
     public static boolean setDecoderLowLatencyOptions(MediaFormat videoFormat, MediaCodecInfo decoderInfo, boolean ultraLowLatency, int tryNumber) {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -606,7 +606,10 @@ if (tryNumber < 1) {
                 //
                 // We will first try both, then try vendor.qti-ext-dec-low-latency.enable alone if that fails
                 if (tryNumber < 4) {
-                    videoFormat.setInteger("vendor.qti-ext-dec-picture-order.enable", 1);
+                    // Adjust picture-order flag: 0 for OMX.qcom (disable reordering), 1 for C2.*
+                    boolean __isOmxQcom = decoderInfo.getName() != null &&
+                            decoderInfo.getName().toLowerCase(java.util.Locale.US).startsWith("omx.qcom");
+                    safeSet(videoFormat, "vendor.qti-ext-dec-picture-order.enable", __isOmxQcom ? 0 : 1);
                     setNewOption = true;
                 }
                 if (tryNumber < 5) {
@@ -1188,7 +1191,7 @@ if (tryNumber < 1) {
             // Reduce DPB output delay on older OMX stacks
             safeSet(videoFormat, "vendor.qti-ext-dec-dpb-output-delay.enable", 0);
             // Prefer IDR when possible
-            safeSet(videoFormat, "vendor.qti-ext-dec-picture-type.enable", 1);
+            safeSet(videoFormat, "vendor.qti-ext-dec-picture-type.enable", 0); //ignored in logs
             // Generic AOSP scheduling hints
             try { videoFormat.setInteger(android.media.MediaFormat.KEY_OPERATING_RATE, (int)Short.MAX_VALUE); } catch (Throwable ignored) {}
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -212,6 +212,8 @@ public class MediaCodecHelper {
         useFourSlicesPrefixes.add("omx.ffmpeg");
         useFourSlicesPrefixes.add("c2.android");
 
+
+
         // Old Qualcomm decoders are detected at runtime
     }
 
@@ -593,25 +595,32 @@ public class MediaCodecHelper {
                     setNewOption = true;
                 }
             }
-            //ALONSOJR1980
+            // ALONSOJR1980
             else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
-                if (tryNumber < 4) {
-                    //  Enable general CPU boost during decoding
-                    videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode", 2);
-                    //  Dolby Vision may use this; can also impact H.264/H.265
-                    videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1);
-                    //  Minimum buffer fetch timeout
-                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);
-                    //  Video decoder’s internal buffer queue
-                    videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time.value", 2);
+                {
+                    // If the decoder supports LowLatency, we can assume it's a recent mtk cpu with decent decoding capability -DerFlacco
+                    boolean supportsLowLatency = decoderInfo.getName().toLowerCase().contains("low_latency")
+                            || decoderInfo.getName().toLowerCase().contains("c2.mtk");
 
-            //DERFLACCO
+                    if (supportsLowLatency) {
+                        // Aggressive profile for MTK low-latency decoders
 
-            //  Limit input queue depth
-                    videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", 2);
+                        //  Enable general CPU boost during decoding (sembra passare con logcat, su poco x6 pro funziona)
+                        videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode", 2);
 
-            //  Apply aggressive frame-drop policy
-                    videoFormat.setInteger("vendor.mtk.vdec.frame-drop.policy", 1);
+                        //  Dolby Vision may use this; can also impact H.264/H.265
+                        //  (non credo serva, ma magari in qualche tv android, tipo TCL)
+                        // videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1);
+
+                        //  Minimum buffer fetch timeout
+                        videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);
+
+                        //  Video decoder’s internal buffer queue (senza .value)
+                        videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time", 2);
+
+                        //  Limit input/output queue depth (a 120/144 Hz spesso è più fluido con 2)
+                        videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", 4);
+                        videoFormat.setInteger("vendor.mtk.vdec.output.max.queue.depth", 4); // 1 se vuoi latenza assoluta
 
             //  Disable idle mode between frames to reduce latency
                     videoFormat.setInteger("vendor.mtk.vdec.disable-idle", 1);
@@ -619,32 +628,65 @@ public class MediaCodecHelper {
             //  Enable official low-latency mode
                     videoFormat.setInteger("vendor.mtk.vdec.low-latency.mode", 1);
 
-            //  TEST – set preload frame count to 0
-                    videoFormat.setInteger("vendor.mtk.vdec.preload.frame.count", 0);
+                        //  set preload frame count to 0 (meglio 0 per evitare prebuffer)
+                        videoFormat.setInteger("vendor.mtk.vdec.preload.frame.count", 0);
 
-            //  TEST – ultra-low latency mode (not supported on all SoCs)
-                    videoFormat.setInteger("vendor.mtk.vdec.ultra-low-latency", 1);
+                        //  ultra-low latency mode (not supported on all SoCs)
+                         videoFormat.setInteger("vendor.mtk.vdec.ultra-low-latency", 0); // sconsigliato su X6 Pro (jitter)
 
             //  Skip NVOP frames (empty frames)
                     videoFormat.setInteger("vendor.mtk.vdec.nvop.skip", 1);
 
-            //  Skip frame policy (can improve HEVC stream playback)
-                    videoFormat.setInteger("vendor.mtk.vdec.skip.mode", 1);
+                        //  Drop non-reference frames to optimize performance (catch-up leggero)
+                        videoFormat.setInteger("vendor.mtk.vdec.drop.nonref.frame", 1);
 
-            //  Drop non-reference frames to optimize performance
-                    videoFormat.setInteger("vendor.mtk.vdec.drop.nonref.frame", 1);
+                        //  Evita doppio drop con l’age-drop lato app
+                        videoFormat.setInteger("vendor.mtk.vdec.skip.mode", 0);
+                        videoFormat.setInteger("vendor.mtk.vdec.frame-drop.policy", 0);
 
-            //  Boost parser thread priority
-                    videoFormat.setInteger("vendor.mtk.vdec.parser.boost", 1);
+                        //  Boost parser thread priority
+                        videoFormat.setInteger("vendor.mtk.vdec.parser.boost", 1);
 
             //  Force high DVFS (Dynamic Voltage/Frequency Scaling)
                     videoFormat.setInteger("vendor.mtk.vdec.dvfs.mode", 1);
 
-            //  Set decoding thread to high priority (99 = max for user-space)
-                    videoFormat.setInteger("vendor.mtk.vdec.thread.priority", 99);
+                        //  Disable V-Sync correction (reduces latency, may introduce tearing)
+                        videoFormat.setInteger("vendor.mtk.vdec.vsync.adjust.enable", 0);
+                    }
+                    else {
+                        // Conservative profile for MTK decoders without low-latency support (e.g., MTK G99)
 
-            //  Disable V-Sync correction (reduces latency, may introduce tearing)
-                    //videoFormat.setInteger("vendor.mtk.vdec.vsync.adjust.enable", 0);
+                        //  Give the decoder more relaxed timing to avoid stutter
+                        videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", 4); // 3–5
+                        videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time", 4);  // 3–5
+
+                        //  Deeper queue to avoid under-runs
+                        videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", 2);
+                        videoFormat.setInteger("vendor.mtk.vdec.output.max.queue.depth", 2);
+
+                        //  Keep DVFS boost but avoid ultra-low-latency flags
+                        videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode", 1);
+                        videoFormat.setInteger("vendor.mtk.vdec.dvfs.mode", 1);
+
+                        //  Keep parser boost
+                        videoFormat.setInteger("vendor.mtk.vdec.parser.boost", 1);
+
+                        //  Disable V-Sync adjust (still helps with latency)
+                        videoFormat.setInteger("vendor.mtk.vdec.vsync.adjust.enable", 0);
+
+                        //  Skip NVOP frames (empty frames)
+                        videoFormat.setInteger("vendor.mtk.vdec.nvop.skip", 1);
+
+                        //  Disable idle mode between frames to reduce latency
+                        videoFormat.setInteger("vendor.mtk.vdec.disable-idle", 1);
+
+                        //  Faster catch up su SoC lenti: tieni entrambi
+                        videoFormat.setInteger("vendor.mtk.vdec.drop.nonref.frame", 1);
+                        videoFormat.setInteger("vendor.mtk.vdec.skip.mode", 1);
+
+                        //  Fast preload
+                        videoFormat.setInteger("vendor.mtk.vdec.preload.frame.count", 0);
+                    }
 
                     setNewOption = true;
                 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -1178,6 +1178,23 @@ if (tryNumber < 1) {
             safeSet(videoFormat, "vendor.qti-ext-dec-picture-order.enable", 0);
             safeSet(videoFormat, "vendor.qti-ext-dec-frame-drop.enable", 1);
         }
-    }
+    
+        // Legacy Qualcomm OMX decoders: apply vendor keys + AOSP knobs
+        if (decoderName != null && decoderName.toLowerCase(java.util.Locale.US).startsWith("omx.qcom")) {
+            // Low latency & reordering off
+            safeSet(videoFormat, "vendor.qti-ext-dec-low-latency.enable", 1);
+            safeSet(videoFormat, "vendor.qti-ext-dec-picture-order.enable", 0);
+            safeSet(videoFormat, "vendor.qti-ext-dec-frame-drop.enable", 1);
+            // Reduce DPB output delay on older OMX stacks
+            safeSet(videoFormat, "vendor.qti-ext-dec-dpb-output-delay.enable", 0);
+            // Prefer IDR when possible
+            safeSet(videoFormat, "vendor.qti-ext-dec-picture-type.enable", 1);
+            // Generic AOSP scheduling hints
+            try { videoFormat.setInteger(android.media.MediaFormat.KEY_OPERATING_RATE, (int)Short.MAX_VALUE); } catch (Throwable ignored) {}
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                try { videoFormat.setInteger(android.media.MediaFormat.KEY_PRIORITY, 0); } catch (Throwable ignored) {}
+            }
+        }
+}
     
 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -372,8 +372,12 @@ public class MediaCodecHelper {
                 refFrameInvalidationHevcPrefixes.add("omx.qcom");
                 refFrameInvalidationAvcPrefixes.add("c2.qti");
                 refFrameInvalidationHevcPrefixes.add("c2.qti");
+
+                //derflacco
                 refFrameInvalidationAvcPrefixes.add("c2.mtk");
                 refFrameInvalidationHevcPrefixes.add("c2.mtk");
+                refFrameInvalidationAvcPrefixes.add("omx.mtk");
+                refFrameInvalidationHevcPrefixes.add("omx.mtk");
             }
 
             // Qualcomm's early HEVC decoders break hard on our HEVC stream. The best check to

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -1140,4 +1140,40 @@ public class MediaCodecHelper {
         
         return false;
     }
+
+
+    // --- Helpers to safely set vendor-specific flags without crashing ---
+
+    private static void safeSet(MediaFormat format, String key, int value) {
+        try {
+            format.setInteger(key, value);
+        } catch (Throwable ignored) {
+            // key not supported, ignore
+        }
+    }
+
+    private static void safeSet(MediaFormat format, String key, boolean value) {
+        try {
+            format.setInteger(key, value ? 1 : 0);
+        } catch (Throwable ignored) {
+            // key not supported, ignore
+        }
+    }
+
+    private static void safeSet(MediaFormat format, String key, long value) {
+        try {
+            format.setLong(key, value);
+        } catch (Throwable ignored) {
+            // key not supported, ignore
+        }
+    }
+
+    private static void safeSet(MediaFormat format, String key, String value) {
+        try {
+            format.setString(key, value);
+        } catch (Throwable ignored) {
+            // key not supported, ignore
+        }
+    }
+
 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -40,6 +40,8 @@ public class MediaCodecHelper {
     private static final List<String> refFrameInvalidationHevcPrefixes;
     private static final List<String> useFourSlicesPrefixes;
     private static final List<String> qualcommDecoderPrefixes;
+    private static final List<String> tegraDecoderPrefixes;
+
     private static final List<String> mtkDecoderPrefixes; //ALONSOJR1980
     private static final List<String> kirinDecoderPrefixes;
     private static final List<String> exynosDecoderPrefixes;
@@ -229,6 +231,14 @@ public class MediaCodecHelper {
 
         qualcommDecoderPrefixes.add("omx.qcom");
         qualcommDecoderPrefixes.add("c2.qti");
+        qualcommDecoderPrefixes.add("c2.qcom");
+           }
+
+    static {
+        tegraDecoderPrefixes = new LinkedList<>();
+
+        tegraDecoderPrefixes.add("omx.nvidia");
+        tegraDecoderPrefixes.add("c2.nvidia");
     }
 
     //ALONSOJR1980
@@ -259,6 +269,16 @@ public class MediaCodecHelper {
         amlogicDecoderPrefixes.add("omx.amlogic");
         amlogicDecoderPrefixes.add("c2.amlogic"); // Unconfirmed
     }
+
+//derflacco
+    public static boolean isNvidiaDecoder(String decoderName) {
+        return isDecoderInList(tegraDecoderPrefixes, decoderName);
+    }
+
+    public static boolean isQualcommDecoder(String decoderName) {
+        return isDecoderInList(qualcommDecoderPrefixes, decoderName);
+    }
+
 
     private static boolean isPowerVR(String glRenderer) {
         return glRenderer.toLowerCase().contains("powervr");
@@ -386,6 +406,7 @@ public class MediaCodecHelper {
                 refFrameInvalidationHevcPrefixes.add("c2.mtk"); //derflacco
                 refFrameInvalidationAvcPrefixes.add("omx.mtk"); //derflacco
                 refFrameInvalidationHevcPrefixes.add("omx.mtk"); //derflacco
+                refFrameInvalidationHevcPrefixes.add("c2.qcom"); //derflacco
             }
 
             // Qualcomm's early HEVC decoders break hard on our HEVC stream. The best check to
@@ -515,7 +536,16 @@ public class MediaCodecHelper {
 
         boolean setNewOption = false;
 
-        if (tryNumber < 1) {
+//derflacco
+        // NVIDIA Tegra extra low-latency toggles
+        if (isNvidiaDecoder(decoderInfo.getName())) {
+            safeSet(videoFormat, "media.low-latency.enable", 1);
+            safeSet(videoFormat, "vendor.low-latency.enable", 1);
+            safeSet(videoFormat, "disable-output-reorder", 1);
+            safeSet(videoFormat, "vendor.nvidia.disable-output-reorder", 1);
+            setNewOption = true;
+        }
+if (tryNumber < 1) {
             // Official Android 11+ low latency option (KEY_LOW_LATENCY).
             videoFormat.setInteger("low-latency", 1);
             setNewOption = true;
@@ -1132,4 +1162,22 @@ public class MediaCodecHelper {
         }
     }
 
+//derflacco
+    public static void applyExtraVendorOptions(MediaFormat videoFormat, String decoderName) {
+        if (videoFormat == null || decoderName == null) return;
+        // NVIDIA Tegra (Shield TV): enable generic low-latency + disable frame reordering
+        if (isNvidiaDecoder(decoderName)) {
+            safeSet(videoFormat, "media.low-latency.enable", 1);
+            safeSet(videoFormat, "vendor.low-latency.enable", 1); // fallback generic vendor key
+            safeSet(videoFormat, "disable-output-reorder", 1);
+            safeSet(videoFormat, "vendor.nvidia.disable-output-reorder", 1); // in case vendor namespace is required
+        }
+        // Qualcomm: ensure vendor low latency and frame-order tweaks
+        if (isQualcommDecoder(decoderName)) {
+            safeSet(videoFormat, "vendor.qti-ext-dec-low-latency.enable", 1);
+            safeSet(videoFormat, "vendor.qti-ext-dec-picture-order.enable", 0);
+            safeSet(videoFormat, "vendor.qti-ext-dec-frame-drop.enable", 1);
+        }
+    }
+    
 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -634,73 +634,42 @@ public class MediaCodecHelper {
 //                    videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time.value", 2);
 //                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 2);
             else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
-                // If the decoder supports LowLatency, we can assume it's a recent mtk cpu with decent decoding capability
-                boolean supportsLowLatency = decoderInfo.getName().toLowerCase().contains("low_latency")
-                        || decoderInfo.getName().toLowerCase().contains("c2.mtk");
+                if (tryNumber < 4) {
+                    // --- PRESET: MTK Low-Latency (safe & balanced, no duplicates) ---
 
-                         if (supportsLowLatency) {
-                             // --- PRESET: Low-Latency (tight queues, short timeouts, boost on) ---
+                    // Boost/DVFS: moderate profile
+                    safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 1);
+                    safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode.value", 1);
+                    safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);
+                    safeSet(videoFormat, "vendor.mtk.vdec.dvfs.level", 1);
 
-                             // Pipeline depth: keep queues shallow to reduce buffering latency
-                             // Aggressive profile for MTK low-latency decoders
-                             safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 2);           // Stronger CPU boost for decoder threads
-                             safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost", 1);    // Extra CPU boost when Dolby Vision paths are used
-                             safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);  // Internal buffer-fetch timeout (ms); lower can cut stalls
-                             safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 2);   // Guard interval for decoder buffer queue; smaller = tighter pacing
-                             safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 2);    // Max input queue depth; lower = less pipeline buffering
-                             safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 2);   // Max output queue depth; lower = lower display latency
-                             safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);             // Keep decoder from idling to avoid clock drop/sleep
-                             safeSet(videoFormat, "vendor.mtk.vdec.low-latency.mode", 1);         // Enable decoder low-latency path
-                             safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);      // Preload 0 frames; no prebuffering for latency
-                             safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 0);        // Toggle ultra-low-latency path (0=off, 1=on)
-                             safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                // Skip NVOP/no-op frames to reduce overhead
-                             safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 0);                // Frame-skip policy (0=off/conservative)
-                             safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);        // Frame-drop policy (0=default/no forced drops)
-                             safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);             // Boost bitstream parser workload
-                             safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);                // DVFS bias toward performance
-                             safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);        // Default drop policy; app controls pacing
-                         } else {
-                             // --- PRESET: Conservative (deeper queues, longer timeouts, still brisk) ---
+                    // Pipeline / code path
+                    safeSet(videoFormat, "vendor.mtk.vdec.low-latency.mode", 1);    // Enable low-latency path
+                    safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 0);   // ULL off for stability
+                    safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);        // Prevent clock downscaling
+                    safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 1); // Light prebuffering
 
-                             // Pipeline depth: slightly deeper to absorb jitter
-                             safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 4);         // Input queue depth: stability > raw latency
-                             safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth.value", 4);   // Explicit *.value
-                             safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 4);        // Output queue depth: fewer underruns
-                             safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth.value", 4);  // Explicit *.value
-                             safeSet(videoFormat, "vendor.mtk.vdec.queue.depth", 4);                   // Global queue depth
+                    // Queue / timeouts (moderate)
+                    safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 4);
+                    safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 4);
+                    safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 3);
+                    safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 3);
 
-                             // Timeouts: a bit longer to reduce false timeouts on slower paths
-                             safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 4);       // Fetch timeout (ms): stability-focused
-                             safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 4); // Explicit *.value
-                             safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 4);        // Wider guard interval
-                             safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time.value", 4);  // Explicit *.value
+                    // Pacing: controlled by the app
+                    safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);
 
-                             // Boost: mild but persistent performance bias
-                             safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 1);                // Mild decoder CPU boost
-                             safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode.value", 1);          // Explicit *.value
-                             safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost", 1);         // Keep DV boost available
-                             safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost.value", 1);   // Explicit *.value
-                             safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);                  // Keep parser boosted
-                             safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);                     // DVFS performance bias
-                             safeSet(videoFormat, "vendor.mtk.vdec.dvfs.level", 1);                    // Minimum DVFS level
+                    // Skip/drop: only NVOP
+                    safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);
+                    safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 0);
+                    safeSet(videoFormat, "vendor.mtk.vdec.drop.nonref.frame", 0);
+                    safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);
 
-                             // Preload & LL hints maintained, but with safer pacing
-                             safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 1);             // Keep ULL path on when available
-                             safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);           // No prebuffering
-
-                             // Drop/skip: enable light skip to prevent runaway latency under load
-                             safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                     // Skip NVOP frames
-                             safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 1);                     // Light skip on for backlog prevention
-                             safeSet(videoFormat, "vendor.mtk.vdec.drop.nonref.frame", 1);             // Allow dropping non-ref frames
-                             safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);             // Default policy; app decides pacing
-                             safeSet(videoFormat, MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE);
-                             try { videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE); } catch (Throwable ignored) {}
-                             safeSet(videoFormat, MediaFormat.KEY_PRIORITY, 0);
-                             }
-
-
-                        setNewOption = true;
-                    }
+                    // Standard Android hints
+                    safeSet(videoFormat, MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE);
+                    safeSet(videoFormat, MediaFormat.KEY_PRIORITY, 0);
+                }
+                setNewOption = true;
+            }
 
             else if (isDecoderInList(kirinDecoderPrefixes, decoderInfo.getName())) {
                 if (tryNumber < 4) {

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -235,6 +235,7 @@ public class MediaCodecHelper {
     static {
         mtkDecoderPrefixes = new LinkedList<>();
 
+        mtkDecoderPrefixes.add("omx.mtk");
         mtkDecoderPrefixes.add("c2.mtk");
     }
 

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -26,7 +26,7 @@ import com.limelight.LimeLog;
 import com.limelight.preferences.PreferenceConfiguration;
 
 public class MediaCodecHelper {
-    
+
     private static final List<String> preferredDecoders;
 
     private static final List<String> blacklistedDecoderPrefixes;
@@ -86,7 +86,7 @@ public class MediaCodecHelper {
     static {
         preferredDecoders = new LinkedList<>();
     }
-    
+
     static {
         blacklistedDecoderPrefixes = new LinkedList<>();
 
@@ -110,7 +110,7 @@ public class MediaCodecHelper {
         blacklistedDecoderPrefixes.add("OMX.qcom.video.decoder.hevcswvdec");
         blacklistedDecoderPrefixes.add("OMX.SEC.hevc.sw.dec");
     }
-    
+
     static {
         // If a decoder qualifies for reference frame invalidation,
         // these entries will be ignored for those decoders.
@@ -232,7 +232,7 @@ public class MediaCodecHelper {
         qualcommDecoderPrefixes.add("omx.qcom");
         qualcommDecoderPrefixes.add("c2.qti");
         qualcommDecoderPrefixes.add("c2.qcom");
-           }
+    }
 
     static {
         tegraDecoderPrefixes = new LinkedList<>();
@@ -270,7 +270,7 @@ public class MediaCodecHelper {
         amlogicDecoderPrefixes.add("c2.amlogic"); // Unconfirmed
     }
 
-//derflacco
+    //derflacco
     public static boolean isNvidiaDecoder(String decoderName) {
         return isDecoderInList(tegraDecoderPrefixes, decoderName);
     }
@@ -463,7 +463,7 @@ public class MediaCodecHelper {
                 }
             }
         }
-        
+
         return false;
     }
 
@@ -525,8 +525,8 @@ public class MediaCodecHelper {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 (
                         isDecoderInList(qualcommDecoderPrefixes, decoderName)
-                        || isDecoderInList(refFrameInvalidationHevcPrefixes, decoderName) ||
-                           isDecoderInList(refFrameInvalidationAvcPrefixes,  decoderName)
+                                || isDecoderInList(refFrameInvalidationHevcPrefixes, decoderName) ||
+                                isDecoderInList(refFrameInvalidationAvcPrefixes,  decoderName)
                 ) && !isAdreno620;
     }
 
@@ -545,7 +545,7 @@ public class MediaCodecHelper {
             safeSet(videoFormat, "vendor.nvidia.disable-output-reorder", 1);
             setNewOption = true;
         }
-if (tryNumber < 1) {
+        if (tryNumber < 1) {
             // Official Android 11+ low latency option (KEY_LOW_LATENCY).
             videoFormat.setInteger("low-latency", 1);
             setNewOption = true;
@@ -634,51 +634,70 @@ if (tryNumber < 1) {
 //                    videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time.value", 2);
 //                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 2);
             else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
-                //derflacco
-                if (ultraLowLatency) {
-                {
-                    // If the decoder supports LowLatency, we can assume it's a recent mtk cpu with decent decoding capability
-                    boolean supportsLowLatency = decoderInfo.getName().toLowerCase().contains("low_latency")
-                            || decoderInfo.getName().toLowerCase().contains("c2.mtk");
+                // If the decoder supports LowLatency, we can assume it's a recent mtk cpu with decent decoding capability
+                boolean supportsLowLatency = decoderInfo.getName().toLowerCase().contains("low_latency")
+                        || decoderInfo.getName().toLowerCase().contains("c2.mtk");
 
-                    if (supportsLowLatency) {
-                    // Aggressive profile for MTK low-latency decoders
-                        safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 2);           // Stronger CPU boost for decoder threads
-                        safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost", 1);    // Extra CPU boost when Dolby Vision paths are used
-                        safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);  // Internal buffer-fetch timeout (ms); lower can cut stalls
-                        safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 2);   // Guard interval for decoder buffer queue; smaller = tighter pacing
-                        safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 2);    // Max input queue depth; lower = less pipeline buffering
-                        safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 2);   // Max output queue depth; lower = lower display latency
-                        safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);             // Keep decoder from idling to avoid clock drop/sleep
-                        safeSet(videoFormat, "vendor.mtk.vdec.low-latency.mode", 1);         // Enable decoder low-latency path
-                        safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);      // Preload 0 frames; no prebuffering for latency
-                        safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 0);        // Toggle ultra-low-latency path (0=off, 1=on)
-                        safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                // Skip NVOP/no-op frames to reduce overhead
-                        safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 0);                // Frame-skip policy (0=off/conservative)
-                        safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);        // Frame-drop policy (0=default/no forced drops)
-                        safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);             // Boost bitstream parser workload
-                        safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);                // DVFS bias toward performance
-                        safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);      // Disable decoder vsync pacing/adjust to avoid interference
+                         if (supportsLowLatency) {
+                             // --- PRESET: Low-Latency (tight queues, short timeouts, boost on) ---
 
-                     // Conservative profile for MTK decoders without low-latency support (e.g., G99 , Dimensity 7200)
+                             // Pipeline depth: keep queues shallow to reduce buffering latency
+                             // Aggressive profile for MTK low-latency decoders
+                             safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 2);           // Stronger CPU boost for decoder threads
+                             safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost", 1);    // Extra CPU boost when Dolby Vision paths are used
+                             safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);  // Internal buffer-fetch timeout (ms); lower can cut stalls
+                             safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 2);   // Guard interval for decoder buffer queue; smaller = tighter pacing
+                             safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 2);    // Max input queue depth; lower = less pipeline buffering
+                             safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 2);   // Max output queue depth; lower = lower display latency
+                             safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);             // Keep decoder from idling to avoid clock drop/sleep
+                             safeSet(videoFormat, "vendor.mtk.vdec.low-latency.mode", 1);         // Enable decoder low-latency path
+                             safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);      // Preload 0 frames; no prebuffering for latency
+                             safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 0);        // Toggle ultra-low-latency path (0=off, 1=on)
+                             safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                // Skip NVOP/no-op frames to reduce overhead
+                             safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 0);                // Frame-skip policy (0=off/conservative)
+                             safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);        // Frame-drop policy (0=default/no forced drops)
+                             safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);             // Boost bitstream parser workload
+                             safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);                // DVFS bias toward performance
+                             safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);        // Default drop policy; app controls pacing
+                         } else {
+                             // --- PRESET: Conservative (deeper queues, longer timeouts, still brisk) ---
 
-                        safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 4);  // Slightly longer fetch timeout for stability
-                        safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 4);   // Wider guard interval; reduce contention
-                        safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 4);    // Deeper input queue; smoother under load
-                        safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 4);   // Deeper output queue; fewer underruns
-                        safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 1);           // Mild CPU boost
-                        safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);             // Keep parser boosted even in conservative mode
-                        safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);      // Keep vsync adjust off
-                        safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                // Skip NVOP frames
-                        safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);             // Prevent idle to avoid wake-up penalties
-                        safeSet(videoFormat, "vendor.mtk.vdec.drop.nonref.frame", 1);        // Allow dropping non-reference frames under stress
-                        safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 1);                // Light/controlled frame skipping enabled
-                        safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);      // No preloaded frames
+                             // Pipeline depth: slightly deeper to absorb jitter
+                             safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 4);         // Input queue depth: stability > raw latency
+                             safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth.value", 4);   // Explicit *.value
+                             safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 4);        // Output queue depth: fewer underruns
+                             safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth.value", 4);  // Explicit *.value
+                             safeSet(videoFormat, "vendor.mtk.vdec.queue.depth", 4);                   // Global queue depth
+
+                             // Timeouts: a bit longer to reduce false timeouts on slower paths
+                             safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 4);       // Fetch timeout (ms): stability-focused
+                             safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 4); // Explicit *.value
+                             safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 4);        // Wider guard interval
+                             safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time.value", 4);  // Explicit *.value
+
+                             // Boost: mild but persistent performance bias
+                             safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 1);                // Mild decoder CPU boost
+                             safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode.value", 1);          // Explicit *.value
+                             safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost", 1);         // Keep DV boost available
+                             safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost.value", 1);   // Explicit *.value
+                             safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);                  // Keep parser boosted
+                             safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);                     // DVFS performance bias
+                             safeSet(videoFormat, "vendor.mtk.vdec.dvfs.level", 1);                    // Minimum DVFS level
+
+                             // Preload & LL hints maintained, but with safer pacing
+                             safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 1);             // Keep ULL path on when available
+                             safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);           // No prebuffering
+
+                             // Drop/skip: enable light skip to prevent runaway latency under load
+                             safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                     // Skip NVOP frames
+                             safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 1);                     // Light skip on for backlog prevention
+                             safeSet(videoFormat, "vendor.mtk.vdec.drop.nonref.frame", 1);             // Allow dropping non-ref frames
+                             safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);             // Default policy; app decides pacing
+
+
+                     }
+                        setNewOption = true;
                     }
-                }
-                    setNewOption = true;
-                }
-            }
 
             else if (isDecoderInList(kirinDecoderPrefixes, decoderInfo.getName())) {
                 if (tryNumber < 4) {
@@ -754,7 +773,7 @@ if (tryNumber < 1) {
     public static boolean decoderCanDirectSubmit(String decoderName) {
         return isDecoderInList(directSubmitPrefixes, decoderName) && !isExynos4Device();
     }
-    
+
     public static boolean decoderNeedsSpsBitstreamRestrictions(String decoderName) {
         return isDecoderInList(spsFixupBitstreamFixupDecoderPrefixes, decoderName);
     }
@@ -892,7 +911,7 @@ if (tryNumber < 1) {
 
         return infoList;
     }
-    
+
     @SuppressWarnings("RedundantThrows")
     public static String dumpDecoders() throws Exception {
         String str = "";
@@ -901,12 +920,12 @@ if (tryNumber < 1) {
             if (codecInfo.isEncoder()) {
                 continue;
             }
-            
+
             str += "Decoder: "+codecInfo.getName()+"\n";
             for (String type : codecInfo.getSupportedTypes()) {
                 str += "\t"+type+"\n";
                 CodecCapabilities caps = codecInfo.getCapabilitiesForType(type);
-                
+
                 for (CodecProfileLevel profile : caps.profileLevels) {
                     str += "\t\t"+profile.profile+" "+profile.level+"\n";
                 }
@@ -914,7 +933,7 @@ if (tryNumber < 1) {
         }
         return str;
     }
-    
+
     private static MediaCodecInfo findPreferredDecoder() {
         // This is a different algorithm than the other findXXXDecoder functions,
         // because we want to evaluate the decoders in our list's order
@@ -923,14 +942,14 @@ if (tryNumber < 1) {
         if (!initialized) {
             throw new IllegalStateException("MediaCodecHelper must be initialized before use");
         }
-        
+
         for (String preferredDecoder : preferredDecoders) {
             for (MediaCodecInfo codecInfo : getMediaCodecList()) {
                 // Skip encoders
                 if (codecInfo.isEncoder()) {
                     continue;
                 }
-                
+
                 // Check for preferred decoders
                 if (preferredDecoder.equalsIgnoreCase(codecInfo.getName())) {
                     LimeLog.info("Preferred decoder choice is "+codecInfo.getName());
@@ -938,7 +957,7 @@ if (tryNumber < 1) {
                 }
             }
         }
-        
+
         return null;
     }
 
@@ -959,7 +978,7 @@ if (tryNumber < 1) {
 
         return false;
     }
-    
+
     public static MediaCodecInfo findFirstDecoder(String mimeType) {
         for (MediaCodecInfo codecInfo : getMediaCodecList()) {
             // Skip encoders
@@ -973,7 +992,7 @@ if (tryNumber < 1) {
                     continue;
                 }
             }
-            
+
             // Find a decoder that supports the specified video format
             for (String mime : codecInfo.getSupportedTypes()) {
                 if (mime.equalsIgnoreCase(mimeType)) {
@@ -987,17 +1006,17 @@ if (tryNumber < 1) {
                 }
             }
         }
-        
+
         return null;
     }
-    
+
     public static MediaCodecInfo findProbableSafeDecoder(String mimeType, int requiredProfile) {
         // First look for a preferred decoder by name
         MediaCodecInfo info = findPreferredDecoder();
         if (info != null) {
             return info;
         }
-        
+
         // Now look for decoders we know are safe
         try {
             // If this function completes, it will determine if the decoder is safe
@@ -1070,10 +1089,10 @@ if (tryNumber < 1) {
                 }
             }
         }
-        
+
         return null;
     }
-    
+
     public static String readCpuinfo() throws Exception {
         StringBuilder cpuInfo = new StringBuilder();
         try (final BufferedReader br = new BufferedReader(new FileReader(new File("/proc/cpuinfo")))) {
@@ -1087,22 +1106,22 @@ if (tryNumber < 1) {
             return cpuInfo.toString();
         }
     }
-    
+
     private static boolean stringContainsIgnoreCase(String string, String substring) {
         return string.toLowerCase(Locale.ENGLISH).contains(substring.toLowerCase(Locale.ENGLISH));
     }
-    
+
     public static boolean isExynos4Device() {
         try {
             // Try reading CPU info too look for 
             String cpuInfo = readCpuinfo();
-            
+
             // SMDK4xxx is Exynos 4 
             if (stringContainsIgnoreCase(cpuInfo, "SMDK4")) {
                 LimeLog.info("Found SMDK4 in /proc/cpuinfo");
                 return true;
             }
-            
+
             // If we see "Exynos 4" also we'll count it
             if (stringContainsIgnoreCase(cpuInfo, "Exynos 4")) {
                 LimeLog.info("Found Exynos 4 in /proc/cpuinfo");
@@ -1111,7 +1130,7 @@ if (tryNumber < 1) {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        
+
         try {
             File systemDir = new File("/sys/devices/system");
             File[] files = systemDir.listFiles();
@@ -1126,7 +1145,7 @@ if (tryNumber < 1) {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        
+
         return false;
     }
 
@@ -1165,7 +1184,7 @@ if (tryNumber < 1) {
         }
     }
 
-//derflacco
+    //derflacco
     public static void applyExtraVendorOptions(MediaFormat videoFormat, String decoderName) {
         if (videoFormat == null || decoderName == null) return;
         // NVIDIA Tegra (Shield TV): enable generic low-latency + disable frame reordering
@@ -1181,7 +1200,7 @@ if (tryNumber < 1) {
             safeSet(videoFormat, "vendor.qti-ext-dec-picture-order.enable", 0);
             safeSet(videoFormat, "vendor.qti-ext-dec-frame-drop.enable", 1);
         }
-    
+
         // Legacy Qualcomm OMX decoders: apply vendor keys + AOSP knobs
         if (decoderName != null && decoderName.toLowerCase(java.util.Locale.US).startsWith("omx.qcom")) {
             // Low latency & reordering off
@@ -1198,6 +1217,6 @@ if (tryNumber < 1) {
                 try { videoFormat.setInteger(android.media.MediaFormat.KEY_PRIORITY, 0); } catch (Throwable ignored) {}
             }
         }
-}
-    
+    }
+
 }

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -212,8 +212,6 @@ public class MediaCodecHelper {
         useFourSlicesPrefixes.add("omx.ffmpeg");
         useFourSlicesPrefixes.add("c2.android");
 
-
-
         // Old Qualcomm decoders are detected at runtime
     }
 
@@ -384,11 +382,10 @@ public class MediaCodecHelper {
                 refFrameInvalidationAvcPrefixes.add("c2.qti");
                 refFrameInvalidationHevcPrefixes.add("c2.qti");
 
-                //derflacco
-                refFrameInvalidationAvcPrefixes.add("c2.mtk");
-                refFrameInvalidationHevcPrefixes.add("c2.mtk");
-                refFrameInvalidationAvcPrefixes.add("omx.mtk");
-                refFrameInvalidationHevcPrefixes.add("omx.mtk");
+                refFrameInvalidationAvcPrefixes.add("c2.mtk"); //derflacco
+                refFrameInvalidationHevcPrefixes.add("c2.mtk"); //derflacco
+                refFrameInvalidationAvcPrefixes.add("omx.mtk"); //derflacco
+                refFrameInvalidationHevcPrefixes.add("omx.mtk"); //derflacco
             }
 
             // Qualcomm's early HEVC decoders break hard on our HEVC stream. The best check to
@@ -596,101 +593,60 @@ public class MediaCodecHelper {
                 }
             }
             // ALONSOJR1980
+//            else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
+//                if (tryNumber < 4) {
+//
+//                    videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode.value", 2);
+//                    videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1);
+//                    videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time.value", 2);
+//                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 2);
             else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
+                //derflacco
+                if (ultraLowLatency) {
                 {
-                    // If the decoder supports LowLatency, we can assume it's a recent mtk cpu with decent decoding capability -DerFlacco
+                    // If the decoder supports LowLatency, we can assume it's a recent mtk cpu with decent decoding capability
                     boolean supportsLowLatency = decoderInfo.getName().toLowerCase().contains("low_latency")
                             || decoderInfo.getName().toLowerCase().contains("c2.mtk");
 
                     if (supportsLowLatency) {
-                        // Aggressive profile for MTK low-latency decoders
+                    // Aggressive profile for MTK low-latency decoders
+                        safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 2);           // Stronger CPU boost for decoder threads
+                        safeSet(videoFormat, "vendor.mtk.ext.dolby.vision.cpu-boost", 1);    // Extra CPU boost when Dolby Vision paths are used
+                        safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);  // Internal buffer-fetch timeout (ms); lower can cut stalls
+                        safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 2);   // Guard interval for decoder buffer queue; smaller = tighter pacing
+                        safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 2);    // Max input queue depth; lower = less pipeline buffering
+                        safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 2);   // Max output queue depth; lower = lower display latency
+                        safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);             // Keep decoder from idling to avoid clock drop/sleep
+                        safeSet(videoFormat, "vendor.mtk.vdec.low-latency.mode", 1);         // Enable decoder low-latency path
+                        safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);      // Preload 0 frames; no prebuffering for latency
+                        safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 0);        // Toggle ultra-low-latency path (0=off, 1=on)
+                        safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                // Skip NVOP/no-op frames to reduce overhead
+                        safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 0);                // Frame-skip policy (0=off/conservative)
+                        safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);        // Frame-drop policy (0=default/no forced drops)
+                        safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);             // Boost bitstream parser workload
+                        safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);                // DVFS bias toward performance
+                        safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);      // Disable decoder vsync pacing/adjust to avoid interference
 
-                        //  Enable general CPU boost during decoding (sembra passare con logcat, su poco x6 pro funziona)
-                        videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode", 2);
+                     // Conservative profile for MTK decoders without low-latency support (e.g., G99 , Dimensity 7200)
 
-                        //  Dolby Vision may use this; can also impact H.264/H.265
-                        //  (non credo serva, ma magari in qualche tv android, tipo TCL)
-                        // videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1);
-
-                        //  Minimum buffer fetch timeout
-                        videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", 2);
-
-                        //  Video decoder’s internal buffer queue (senza .value)
-                        videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time", 2);
-
-                        //  Limit input/output queue depth (a 120/144 Hz spesso è più fluido con 2)
-                        videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", 4);
-                        videoFormat.setInteger("vendor.mtk.vdec.output.max.queue.depth", 4); // 1 se vuoi latenza assoluta
-
-            //  Disable idle mode between frames to reduce latency
-                    videoFormat.setInteger("vendor.mtk.vdec.disable-idle", 1);
-
-            //  Enable official low-latency mode
-                    videoFormat.setInteger("vendor.mtk.vdec.low-latency.mode", 1);
-
-                        //  set preload frame count to 0 (meglio 0 per evitare prebuffer)
-                        videoFormat.setInteger("vendor.mtk.vdec.preload.frame.count", 0);
-
-                        //  ultra-low latency mode (not supported on all SoCs)
-                         videoFormat.setInteger("vendor.mtk.vdec.ultra-low-latency", 0); // sconsigliato su X6 Pro (jitter)
-
-            //  Skip NVOP frames (empty frames)
-                    videoFormat.setInteger("vendor.mtk.vdec.nvop.skip", 1);
-
-                        //  Drop non-reference frames to optimize performance (catch-up leggero)
-                        videoFormat.setInteger("vendor.mtk.vdec.drop.nonref.frame", 1);
-
-                        //  Evita doppio drop con l’age-drop lato app
-                        videoFormat.setInteger("vendor.mtk.vdec.skip.mode", 0);
-                        videoFormat.setInteger("vendor.mtk.vdec.frame-drop.policy", 0);
-
-                        //  Boost parser thread priority
-                        videoFormat.setInteger("vendor.mtk.vdec.parser.boost", 1);
-
-            //  Force high DVFS (Dynamic Voltage/Frequency Scaling)
-                    videoFormat.setInteger("vendor.mtk.vdec.dvfs.mode", 1);
-
-                        //  Disable V-Sync correction (reduces latency, may introduce tearing)
-                        videoFormat.setInteger("vendor.mtk.vdec.vsync.adjust.enable", 0);
+                        safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 4);  // Slightly longer fetch timeout for stability
+                        safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 4);   // Wider guard interval; reduce contention
+                        safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 4);    // Deeper input queue; smoother under load
+                        safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 4);   // Deeper output queue; fewer underruns
+                        safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 1);           // Mild CPU boost
+                        safeSet(videoFormat, "vendor.mtk.vdec.parser.boost", 1);             // Keep parser boosted even in conservative mode
+                        safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);      // Keep vsync adjust off
+                        safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);                // Skip NVOP frames
+                        safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);             // Prevent idle to avoid wake-up penalties
+                        safeSet(videoFormat, "vendor.mtk.vdec.drop.nonref.frame", 1);        // Allow dropping non-reference frames under stress
+                        safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 1);                // Light/controlled frame skipping enabled
+                        safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 0);      // No preloaded frames
                     }
-                    else {
-                        // Conservative profile for MTK decoders without low-latency support (e.g., MTK G99)
-
-                        //  Give the decoder more relaxed timing to avoid stutter
-                        videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms", 4); // 3–5
-                        videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time", 4);  // 3–5
-
-                        //  Deeper queue to avoid under-runs
-                        videoFormat.setInteger("vendor.mtk.vdec.input.max.queue.depth", 2);
-                        videoFormat.setInteger("vendor.mtk.vdec.output.max.queue.depth", 2);
-
-                        //  Keep DVFS boost but avoid ultra-low-latency flags
-                        videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode", 1);
-                        videoFormat.setInteger("vendor.mtk.vdec.dvfs.mode", 1);
-
-                        //  Keep parser boost
-                        videoFormat.setInteger("vendor.mtk.vdec.parser.boost", 1);
-
-                        //  Disable V-Sync adjust (still helps with latency)
-                        videoFormat.setInteger("vendor.mtk.vdec.vsync.adjust.enable", 0);
-
-                        //  Skip NVOP frames (empty frames)
-                        videoFormat.setInteger("vendor.mtk.vdec.nvop.skip", 1);
-
-                        //  Disable idle mode between frames to reduce latency
-                        videoFormat.setInteger("vendor.mtk.vdec.disable-idle", 1);
-
-                        //  Faster catch up su SoC lenti: tieni entrambi
-                        videoFormat.setInteger("vendor.mtk.vdec.drop.nonref.frame", 1);
-                        videoFormat.setInteger("vendor.mtk.vdec.skip.mode", 1);
-
-                        //  Fast preload
-                        videoFormat.setInteger("vendor.mtk.vdec.preload.frame.count", 0);
-                    }
-
+                }
                     setNewOption = true;
                 }
             }
+
             else if (isDecoderInList(kirinDecoderPrefixes, decoderInfo.getName())) {
                 if (tryNumber < 4) {
                     // Kirin low latency options

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -83,6 +83,7 @@ public class PreferenceConfiguration {
 //    static final String TOUCHSCREEN_TRACKPAD_PREF_STRING = "checkbox_touchscreen_trackpad";
     private static final String LATENCY_TOAST_PREF_STRING = "checkbox_enable_post_stream_toast";
     private static final String FRAME_PACING_PREF_STRING = "frame_pacing";
+    private static final String LOW_LATENCY_FRAME_BALANCE_PREF_STRING = "pref_low_latency_frame_balance";
     private static final String ABSOLUTE_MOUSE_MODE_PREF_STRING = "checkbox_absolute_mouse_mode";
     private static final String ENABLE_AUDIO_FX_PREF_STRING = "checkbox_enable_audiofx";
     private static final String REDUCE_REFRESH_RATE_PREF_STRING = "checkbox_reduce_refresh_rate";
@@ -340,6 +341,8 @@ public class PreferenceConfiguration {
     public AnalogStickForScrolling analogStickForScrolling;
     public boolean mouseNavButtons;
     public boolean unlockFps;
+    public boolean preferLowerDelays;
+
     public boolean vibrateOsc;
     public boolean vibrateFallbackToDevice;
     public int vibrateFallbackToDeviceStrength;
@@ -601,7 +604,13 @@ public class PreferenceConfiguration {
         return prefs.getString(FRAME_PACING_PREF_STRING, DEFAULT_FRAME_PACING);
     }
 
-    private static int getFramePacingValue(Context context) {
+    
+    public static boolean getPreferLowerDelays(Context context) {
+        SharedPreferences prefs = ProfilesManager.getInstance().getOverlayingSharedPreferences(context);
+        // default true: favor lower delay unless user opts out
+        return prefs.getBoolean(LOW_LATENCY_FRAME_BALANCE_PREF_STRING, false);
+    }
+private static int getFramePacingValue(Context context) {
         SharedPreferences prefs = ProfilesManager.getInstance().getOverlayingSharedPreferences(context);
 
         // Migrate legacy never drop frames option to the new location
@@ -824,6 +833,8 @@ public class PreferenceConfiguration {
 
         config.videoFormat = getVideoFormatValue(context);
         config.framePacing = getFramePacingValue(context);
+        config.preferLowerDelays = getPreferLowerDelays(context);
+
 
         String warpFactorStr = prefs.getString(FRAME_PACING_PREF_STRING, "");
         if (warpFactorStr.equals("warp")) {

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -70,6 +70,10 @@ public class PreferenceConfiguration {
     private static final String ENABLE_HDR_PREF_STRING = "checkbox_enable_hdr";
     private static final String ENABLE_PIP_PREF_STRING = "checkbox_enable_pip";
     private static final String ENABLE_PERF_OVERLAY_STRING = "checkbox_enable_perf_overlay";
+    private static final String ENABLE_PERF_CHARTS_STRING = "checkbox_enable_perf_charts";
+    private static final String PERF_CHART_LATENCY_STRING = "checkbox_perf_chart_latency";
+    private static final String PERF_CHART_DECODE_STRING = "checkbox_perf_chart_decode";
+    private static final String PERF_CHART_FPS_STRING = "checkbox_perf_chart_fps";
     private static final String ENABLE_PERF_LOGGING = "checkbox_enable_perf_logging";
     private static final String BIND_ALL_USB_STRING = "checkbox_usb_bind_all";
     private static final String MOUSE_EMULATION_STRING = "checkbox_mouse_emulation";
@@ -80,7 +84,7 @@ public class PreferenceConfiguration {
     private static final String VIBRATE_FALLBACK_PREF_STRING = "checkbox_vibrate_fallback";
     private static final String VIBRATE_FALLBACK_STRENGTH_PREF_STRING = "seekbar_vibrate_fallback_strength";
     private static final String FLIP_FACE_BUTTONS_PREF_STRING = "checkbox_flip_face_buttons";
-//    static final String TOUCHSCREEN_TRACKPAD_PREF_STRING = "checkbox_touchscreen_trackpad";
+    //    static final String TOUCHSCREEN_TRACKPAD_PREF_STRING = "checkbox_touchscreen_trackpad";
     private static final String LATENCY_TOAST_PREF_STRING = "checkbox_enable_post_stream_toast";
     private static final String FRAME_PACING_PREF_STRING = "frame_pacing";
     private static final String LOW_LATENCY_FRAME_BALANCE_PREF_STRING = "pref_low_latency_frame_balance";
@@ -220,7 +224,7 @@ public class PreferenceConfiguration {
 
     public int width, height, bitrate;
     public float fps;
-//    public String customBitrate;
+    //    public String customBitrate;
     public boolean forceTightThresholds = false; // default off
     public boolean enableUltraLowLatency;
     public String customResolution;
@@ -258,6 +262,10 @@ public class PreferenceConfiguration {
     public boolean enablePerfLogging;
     //简化版性能信息
     public boolean enablePerfOverlayLite;
+    public boolean enablePerfCharts;
+    public boolean perfChartLatency;
+    public boolean perfChartDecode;
+    public boolean perfChartFps;
 
     public boolean enablePerfOverlayLiteDialog;
 
@@ -484,22 +492,22 @@ public class PreferenceConfiguration {
         // TODO: Collect some empirical data to see if these defaults make sense.
         // We're just using the values that the Shield used, as we have for years.
         int[] pixelVals = {
-            640 * 360,
-            854 * 480,
-            1280 * 720,
-            1920 * 1080,
-            2560 * 1440,
-            3840 * 2160,
-            -1,
+                640 * 360,
+                854 * 480,
+                1280 * 720,
+                1920 * 1080,
+                2560 * 1440,
+                3840 * 2160,
+                -1,
         };
         int[] factorVals = {
-            1,
-            2,
-            5,
-            10,
-            20,
-            40,
-            -1
+                1,
+                2,
+                5,
+                10,
+                20,
+                40,
+                -1
         };
 
         // Calculate the resolution factor by linear interpolation of the resolution table
@@ -605,13 +613,13 @@ public class PreferenceConfiguration {
         return prefs.getString(FRAME_PACING_PREF_STRING, DEFAULT_FRAME_PACING);
     }
 
-    
+
     public static boolean getPreferLowerDelays(Context context) {
         SharedPreferences prefs = ProfilesManager.getInstance().getOverlayingSharedPreferences(context);
         // default true: favor lower delay unless user opts out
         return prefs.getBoolean(LOW_LATENCY_FRAME_BALANCE_PREF_STRING, false);
     }
-private static int getFramePacingValue(Context context) {
+    private static int getFramePacingValue(Context context) {
         SharedPreferences prefs = ProfilesManager.getInstance().getOverlayingSharedPreferences(context);
 
         // Migrate legacy never drop frames option to the new location
@@ -895,6 +903,10 @@ private static int getFramePacingValue(Context context) {
         config.enablePerfOverlay = prefs.getBoolean(ENABLE_PERF_OVERLAY_STRING, DEFAULT_ENABLE_PERF_OVERLAY);
         config.enablePerfLogging = prefs.getBoolean(ENABLE_PERF_LOGGING, DEFAULT_ENABLE_PERF_LOGGING);
         config.enablePerfOverlayLite = prefs.getBoolean("checkbox_enable_perf_overlay_lite",DEFAULT_ENABLE_PERF_OVERLAY);
+        config.enablePerfCharts = prefs.getBoolean(ENABLE_PERF_CHARTS_STRING, false);
+        config.perfChartLatency = prefs.getBoolean(PERF_CHART_LATENCY_STRING, true);
+        config.perfChartDecode  = prefs.getBoolean(PERF_CHART_DECODE_STRING, true);
+        config.perfChartFps     = prefs.getBoolean(PERF_CHART_FPS_STRING, true);
         config.enablePerfOverlayBottom = prefs.getBoolean("checkbox_enable_perf_overlay_bottom",DEFAULT_PERF_OVERLAY_BOTTOM);
         config.bindAllUsb = prefs.getBoolean(BIND_ALL_USB_STRING, DEFAULT_BIND_ALL_USB);
         config.mouseEmulation = prefs.getBoolean(MOUSE_EMULATION_STRING, DEFAULT_MOUSE_EMULATION);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -221,6 +221,7 @@ public class PreferenceConfiguration {
     public int width, height, bitrate;
     public float fps;
 //    public String customBitrate;
+    public boolean forceTightThresholds = false; // default off
     public boolean enableUltraLowLatency;
     public String customResolution;
     public String customRefreshRate;

--- a/app/src/main/res/layout/activity_game.xml
+++ b/app/src/main/res/layout/activity_game.xml
@@ -87,7 +87,43 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 
-    </LinearLayout>
+
+
+<!-- Performance Charts (MPAndroidChart) -->
+<com.github.mikephil.charting.charts.LineChart
+    android:id="@+id/perfChartLatency"
+    android:layout_width="match_parent"
+    android:layout_height="130dp"
+    android:layout_marginStart="10dp"
+    android:layout_marginEnd="10dp"
+    android:layout_marginTop="6dp"
+    android:background="#80000000"
+    android:visibility="gone"
+    android:contentDescription="@string/desc_chart_latency"/>
+
+<com.github.mikephil.charting.charts.LineChart
+    android:id="@+id/perfChartDecode"
+    android:layout_width="match_parent"
+    android:layout_height="130dp"
+    android:layout_marginStart="10dp"
+    android:layout_marginEnd="10dp"
+    android:layout_marginTop="6dp"
+    android:background="#80000000"
+    android:visibility="gone"
+    android:contentDescription="@string/desc_chart_decode"/>
+
+<com.github.mikephil.charting.charts.LineChart
+    android:id="@+id/perfChartFps"
+    android:layout_width="match_parent"
+    android:layout_height="130dp"
+    android:layout_marginStart="10dp"
+    android:layout_marginEnd="10dp"
+    android:layout_marginTop="6dp"
+    android:layout_marginBottom="6dp"
+    android:background="#80000000"
+    android:visibility="gone"
+    android:contentDescription="@string/desc_chart_fps"/>
+</LinearLayout>
 
     <!-- Floating Menu Button -->
     <ImageButton

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -701,4 +701,6 @@
     <string name="profile_manager_active_profile">Active profile: %s</string>
     <string name="rename">Rename</string>
     <string name="save">Save</string>
+    <string name="title_low_latency_frame_balance">Latest-Frame Rendering (Experimental)</string>
+    <string name="summary_low_latency_frame_balance">Minimizes delay by dropping queued frames.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -543,7 +543,7 @@
     <string name="summary_checkbox_enforce_display_mode">Force surface to use the optimal display mode.\nRequired by some systems (such as ColorOS) to set refresh rate/resolution properly.\nDo not enable on ChromeCast 4K as it might lead to bugs.</string>
     <string name="title_checkbox_ultra_low_latency">Ultra Low Latency (experimental)</string>
     <string name="summary_checkbox_ultra_low_latency">Only effective for SD8Gen2/8(s)Gen3/8Elite and MTK devices.</string>
-   	<string name="title_checkbox_forceTightThresholds">Tight Vsync (Experimental)</string>
+    <string name="title_checkbox_forceTightThresholds">Tight Vsync (Experimental)</string>
     <string name="summary_checkbox_forceTightThresholds">Tighter VSYNC thresholds for lower latency; may increase drops.</string>
     <string name="title_checkbox_use_virtual_display">Use Virtual Display</string>
     <string name="summary_checkbox_use_virtual_display">Use Virtual Display by default.\nVirtual Display can automatically match your client side resolution and frame rate settings, giving you a seamless streaming experience.\nRequires Apollo as host streaming software.</string>
@@ -705,4 +705,16 @@
     <string name="save">Save</string>
     <string name="title_low_latency_frame_balance">LFR (Experimental)</string>
     <string name="summary_low_latency_frame_balance">Minimizes delay by dropping queued frames.</string>
+    <string name="category_perf_charts">Performance Charts</string>
+    <string name="desc_chart_latency">Network latency chart</string>
+    <string name="desc_chart_decode">Decode time chart</string>
+    <string name="desc_chart_fps">FPS chart</string>
+    <string name="title_enable_perf_charts">Enable performance charts</string>
+    <string name="summary_enable_perf_charts">Show time-series charts in the in-game performance overlay</string>
+    <string name="title_perf_chart_latency">Chart: Network latency</string>
+    <string name="summary_perf_chart_latency">Plot average network latency (ms)</string>
+    <string name="title_perf_chart_decode">Chart: Decode time</string>
+    <string name="summary_perf_chart_decode">Plot video decoder time per frame (ms)</string>
+    <string name="title_perf_chart_fps">Chart: FPS</string>
+    <string name="summary_perf_chart_fps">Plot incoming/rendered frames per second</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -543,8 +543,8 @@
     <string name="summary_checkbox_enforce_display_mode">Force surface to use the optimal display mode.\nRequired by some systems (such as ColorOS) to set refresh rate/resolution properly.\nDo not enable on ChromeCast 4K as it might lead to bugs.</string>
     <string name="title_checkbox_ultra_low_latency">Ultra Low Latency (experimental)</string>
     <string name="summary_checkbox_ultra_low_latency">Only effective for SD8Gen2/8(s)Gen3/8Elite and MTK devices.</string>
-   	<string name="title_checkbox_forceTightThresholds">forceTightThresholds</string>
-    <string name="summary_checkbox_forceTightThresholds"> (vsync-based) Thresholds</string>
+   	<string name="title_checkbox_forceTightThresholds">Tight Vsync (Experimental)</string>
+    <string name="summary_checkbox_forceTightThresholds">Tighter VSYNC thresholds for lower latency; may increase drops.</string>
     <string name="title_checkbox_use_virtual_display">Use Virtual Display</string>
     <string name="summary_checkbox_use_virtual_display">Use Virtual Display by default.\nVirtual Display can automatically match your client side resolution and frame rate settings, giving you a seamless streaming experience.\nRequires Apollo as host streaming software.</string>
     <string name="title_checkbox_resume_without_confirm">Quick Resume</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,7 +542,7 @@
     <string name="title_checkbox_enforce_display_mode">Enforce Display Mode</string>
     <string name="summary_checkbox_enforce_display_mode">Force surface to use the optimal display mode.\nRequired by some systems (such as ColorOS) to set refresh rate/resolution properly.\nDo not enable on ChromeCast 4K as it might lead to bugs.</string>
     <string name="title_checkbox_ultra_low_latency">Ultra Low Latency (experimental)</string>
-    <string name="summary_checkbox_ultra_low_latency">Only effective for SD8Gen2/8(s)Gen3/8Elite.</string>
+    <string name="summary_checkbox_ultra_low_latency">Only effective for SD8Gen2/8(s)Gen3/8Elite and MTK devices.</string>
    	<string name="title_checkbox_forceTightThresholds">forceTightThresholds</string>
     <string name="summary_checkbox_forceTightThresholds"> (vsync-based) Thresholds</string>
     <string name="title_checkbox_use_virtual_display">Use Virtual Display</string>
@@ -703,6 +703,6 @@
     <string name="profile_manager_active_profile">Active profile: %s</string>
     <string name="rename">Rename</string>
     <string name="save">Save</string>
-    <string name="title_low_latency_frame_balance">Latest-Frame Rendering (Experimental)</string>
+    <string name="title_low_latency_frame_balance">LFR (Experimental)</string>
     <string name="summary_low_latency_frame_balance">Minimizes delay by dropping queued frames.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -543,6 +543,8 @@
     <string name="summary_checkbox_enforce_display_mode">Force surface to use the optimal display mode.\nRequired by some systems (such as ColorOS) to set refresh rate/resolution properly.\nDo not enable on ChromeCast 4K as it might lead to bugs.</string>
     <string name="title_checkbox_ultra_low_latency">Ultra Low Latency (experimental)</string>
     <string name="summary_checkbox_ultra_low_latency">Only effective for SD8Gen2/8(s)Gen3/8Elite.</string>
+   	<string name="title_checkbox_forceTightThresholds">forceTightThresholds</string>
+    <string name="summary_checkbox_forceTightThresholds"> (vsync-based) Thresholds</string>
     <string name="title_checkbox_use_virtual_display">Use Virtual Display</string>
     <string name="summary_checkbox_use_virtual_display">Use Virtual Display by default.\nVirtual Display can automatically match your client side resolution and frame rate settings, giving you a seamless streaming experience.\nRequires Apollo as host streaming software.</string>
     <string name="title_checkbox_resume_without_confirm">Quick Resume</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -58,6 +58,12 @@
             android:summary="@string/summary_frame_pacing"
             android:title="@string/title_frame_pacing"
             app:iconSpaceReserved="false" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="pref_low_latency_frame_balance"
+        android:title="@string/title_low_latency_frame_balance"
+        android:summary="@string/summary_low_latency_frame_balance"
+        app:iconSpaceReserved="false" />
 
         <CheckBoxPreference
             android:defaultValue="false"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -71,7 +71,12 @@
             android:summary="@string/summary_checkbox_ultra_low_latency"
             android:title="@string/title_checkbox_ultra_low_latency"
             app:iconSpaceReserved="false" />
-
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="checkbox_forceTightThresholds"
+            android:summary="@string/summary_checkbox_forceTightThresholds"
+            android:title="@string/title_checkbox_forceTightThresholds"
+            app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="checkbox_use_virtual_display"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -465,51 +465,7 @@
             android:title="@string/title_hide_clipboard_content"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
-
-
-    <PreferenceCategory
-        android:key="category_perf_charts"
-        android:title="@string/category_perf_charts"
-        app:iconSpaceReserved="false">
-
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="checkbox_enable_perf_charts"
-            android:summary="@string/summary_enable_perf_charts"
-            android:title="@string/title_enable_perf_charts"
-            android:shouldDisableView="false"
-            android:enabled="true"
-            app:iconSpaceReserved="false" />
-
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:dependency="checkbox_enable_perf_charts"
-            android:key="checkbox_perf_chart_latency"
-            android:summary="@string/summary_perf_chart_latency"
-            android:title="@string/title_perf_chart_latency"
-            android:shouldDisableView="false"
-            app:iconSpaceReserved="false" />
-
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:dependency="checkbox_enable_perf_charts"
-            android:key="checkbox_perf_chart_decode"
-            android:summary="@string/summary_perf_chart_decode"
-            android:title="@string/title_perf_chart_decode"
-            android:shouldDisableView="false"
-            app:iconSpaceReserved="false" />
-
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:dependency="checkbox_enable_perf_charts"
-            android:key="checkbox_perf_chart_fps"
-            android:summary="@string/summary_perf_chart_fps"
-            android:title="@string/title_perf_chart_fps"
-            android:shouldDisableView="false"
-            app:iconSpaceReserved="false" />
-
-    </PreferenceCategory>
-
+	
     <PreferenceCategory
         android:key="category_ui_settings"
         android:title="@string/category_ui_settings"
@@ -622,6 +578,41 @@
             android:title="@string/title_checkbox_enable_perf_overlay_bottom"
             app:iconSpaceReserved="false" />
 
+       <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="checkbox_enable_perf_charts"
+            android:summary="@string/summary_enable_perf_charts"
+            android:title="@string/title_enable_perf_charts"
+            android:shouldDisableView="false"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="checkbox_enable_perf_charts"
+            android:key="checkbox_perf_chart_latency"
+            android:summary="@string/summary_perf_chart_latency"
+            android:title="@string/title_perf_chart_latency"
+            android:shouldDisableView="false"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="checkbox_enable_perf_charts"
+            android:key="checkbox_perf_chart_decode"
+            android:summary="@string/summary_perf_chart_decode"
+            android:title="@string/title_perf_chart_decode"
+            android:shouldDisableView="false"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="checkbox_enable_perf_charts"
+            android:key="checkbox_perf_chart_fps"
+            android:summary="@string/summary_perf_chart_fps"
+            android:title="@string/title_perf_chart_fps"
+            android:shouldDisableView="false"
+            app:iconSpaceReserved="false" />
+			
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="checkbox_show_overlay_zoom_toggle_button"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -58,12 +58,12 @@
             android:summary="@string/summary_frame_pacing"
             android:title="@string/title_frame_pacing"
             app:iconSpaceReserved="false" />
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="pref_low_latency_frame_balance"
-        android:title="@string/title_low_latency_frame_balance"
-        android:summary="@string/summary_low_latency_frame_balance"
-        app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_low_latency_frame_balance"
+            android:title="@string/title_low_latency_frame_balance"
+            android:summary="@string/summary_low_latency_frame_balance"
+            app:iconSpaceReserved="false" />
 
         <CheckBoxPreference
             android:defaultValue="false"
@@ -464,6 +464,50 @@
             android:summary="@string/summary_hide_clipboard_content"
             android:title="@string/title_hide_clipboard_content"
             app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+
+    <PreferenceCategory
+        android:key="category_perf_charts"
+        android:title="@string/category_perf_charts"
+        app:iconSpaceReserved="false">
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="checkbox_enable_perf_charts"
+            android:summary="@string/summary_enable_perf_charts"
+            android:title="@string/title_enable_perf_charts"
+            android:shouldDisableView="false"
+            android:enabled="true"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="checkbox_enable_perf_charts"
+            android:key="checkbox_perf_chart_latency"
+            android:summary="@string/summary_perf_chart_latency"
+            android:title="@string/title_perf_chart_latency"
+            android:shouldDisableView="false"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="checkbox_enable_perf_charts"
+            android:key="checkbox_perf_chart_decode"
+            android:summary="@string/summary_perf_chart_decode"
+            android:title="@string/title_perf_chart_decode"
+            android:shouldDisableView="false"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="checkbox_enable_perf_charts"
+            android:key="checkbox_perf_chart_fps"
+            android:summary="@string/summary_perf_chart_fps"
+            android:title="@string/title_perf_chart_fps"
+            android:shouldDisableView="false"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
added c2.mtk to prefixes supporting RFI

Fix to achieve sub 10ms decoding latency for mtk g99 and MediaTekDimensity 8300 Ultra.
Tested with an Alldocube iplay 50 mini pro (hvec/h264), and Poco X6 pro (hvec).
Before i was getting about 15ms on the g99, and 20ms with the Poco.
Maybe can be useful for others mtk devices.