### PR TITLE
Allowing Toolbar in Profile Editing page to be focusable with controller

### DIFF
--- a/app/src/main/res/layout/activity_edit_profile.xml
+++ b/app/src/main/res/layout/activity_edit_profile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -9,7 +8,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:focusable="true" />
+        android:touchscreenBlocksFocus="false"/>
 
     <FrameLayout
         android:id="@+id/preferences_container"

--- a/app/src/main/res/layout/activity_edit_profile.xml
+++ b/app/src/main/res/layout/activity_edit_profile.xml
@@ -8,7 +8,8 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize" />
+        android:layout_height="?attr/actionBarSize"
+        android:focusable="true" />
 
     <FrameLayout
         android:id="@+id/preferences_container"

--- a/app/src/main/res/layout/row_profile.xml
+++ b/app/src/main/res/layout/row_profile.xml
@@ -5,13 +5,15 @@
     android:orientation="horizontal"
     android:padding="16dp"
     android:background="?android:attr/selectableItemBackground"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    android:focusable="false">
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:focusable="false">
 
         <TextView
             android:id="@+id/profileName"


### PR DESCRIPTION
In using Artemis on my Odin 2 Portal docked to a TV, I found it extremely frustrating that I could save any tweaks I made in the TV profile I'd set up without getting up and using the touch screen to hit the save icon.

Seems the Toolbar widget was defaulting to block focus on it if the app is running on a touch enabled device. Adding this property allowed me to use the D-Pad to navigate up to the Toolbar icons.