### PR TITLE
Add microphone streaming support for Apollo-compatible hosts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "app/src/main/jni/moonlight-core/moonlight-common-c"]
 	path = app/src/main/jni/moonlight-core/moonlight-common-c
-	url = https://github.com/ClassicOldSong/moonlight-common-c
+	url = https://github.com/logabell/moonlight-common-c

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,9 +96,9 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".noirdebug"
-            resValue "string", "app_label", "Diana"
-            resValue "string", "app_label_root", "Diana (Root)"
-            resValue "string", "app_label_game", "Diana (Game)"
+            resValue "string", "app_label", "Artemis-mic"
+            resValue "string", "app_label_root", "Artemis-mic (Root)"
+            resValue "string", "app_label_game", "Artemis-mic"
 
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -135,9 +135,9 @@ android {
             //
             // TL;DR: Leave the following line alone!
             applicationIdSuffix ".noir"
-            resValue "string", "app_label", "Artemis"
-            resValue "string", "app_label_root", "Artemis (Root)"
-            resValue "string", "app_label_game", "Artemis (Game)"
+            resValue "string", "app_label", "Artemis-mic"
+            resValue "string", "app_label_root", "Artemis-mic (Root)"
+            resValue "string", "app_label_game", "Artemis-mic"
 
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REORDER_TASKS" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
@@ -18,6 +19,9 @@
 
     <uses-feature
         android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.microphone"
         android:required="false" />
     <uses-feature
         android:name="android.hardware.wifi"

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -10,6 +10,7 @@ import static com.limelight.utils.ServerHelper.getSecondaryDisplay;
 
 import com.limelight.binding.PlatformBinding;
 import com.limelight.binding.audio.AndroidAudioRenderer;
+import com.limelight.binding.audio.MicrophoneCaptureManager;
 import com.limelight.binding.input.ControllerHandler;
 import com.limelight.binding.input.GameInputDevice;
 import com.limelight.binding.input.KeyboardTranslator;
@@ -232,6 +233,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     private MediaCodecDecoderRenderer decoderRenderer;
     private boolean reportedCrash;
+    private MicrophoneCaptureManager microphoneCaptureManager;
 
     private WifiManager.WifiLock highPerfWifiLock;
     private WifiManager.WifiLock lowLatencyWifiLock;
@@ -796,6 +798,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 .setAttachedGamepadMask(gamepadMask)
                 .setClientRefreshRateX100((int)(displayRefreshRate * 100))
                 .setAudioConfiguration(prefConfig.audioConfiguration)
+                .setEnableMicrophone(prefConfig.enableMicrophone)
                 .setColorSpace(decoderRenderer.getPreferredColorSpace())
                 .setColorRange(decoderRenderer.getPreferredColorRange())
                 .setPersistGamepadsAfterDisconnect(!prefConfig.multiController)
@@ -1700,6 +1703,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     @Override
     protected void onDestroy() {
+        stopMicrophoneCapture();
         super.onDestroy();
 
         instance = null;
@@ -3437,6 +3441,8 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     private void stopConnection() {
+        stopMicrophoneCapture();
+
         if (connecting || connected) {
             connecting = connected = false;
             updatePipAutoEnter();
@@ -3465,6 +3471,42 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                     }
                 }
             }.start();
+        }
+    }
+
+    private void stopMicrophoneCapture() {
+        if (microphoneCaptureManager != null) {
+            microphoneCaptureManager.stop();
+        }
+    }
+
+    private void startMicrophoneCapture() {
+        if (!prefConfig.enableMicrophone) {
+            return;
+        }
+
+        if (!MicrophoneCaptureManager.hasRecordAudioPermission(this)) {
+            LimeLog.info("Skipping microphone capture because RECORD_AUDIO permission is missing");
+            displayTransientMessage(getString(R.string.microphone_stream_permission_revoked));
+            return;
+        }
+
+        if (!MoonBridge.isMicrophoneStreamActive()) {
+            LimeLog.info("Host did not negotiate microphone streaming");
+            displayTransientMessage(getString(R.string.microphone_host_not_negotiated));
+            return;
+        }
+
+        if (microphoneCaptureManager == null) {
+            microphoneCaptureManager = new MicrophoneCaptureManager(this);
+        }
+
+        LimeLog.info("Starting microphone streaming on device id " + prefConfig.microphoneDeviceId +
+                " (encrypted=" + MoonBridge.isMicrophoneEncryptionEnabled() + ")");
+
+        if (!microphoneCaptureManager.startStreaming(prefConfig.microphoneDeviceId, null)) {
+            LimeLog.warning("Unable to start local microphone capture for the current stream");
+            displayTransientMessage(getString(R.string.microphone_stream_start_failed));
         }
     }
 
@@ -3697,6 +3739,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 setupOverlayToggleButton();
 
                 hideSystemUi(1000);
+                startMicrophoneCapture();
 
                 if (prefConfig.preventPacketLoss) {
                     timerHandler.postDelayed(backgroundPing, 1000);

--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneCaptureManager.java
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneCaptureManager.java
@@ -1,0 +1,436 @@
+package com.limelight.binding.audio;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.media.AudioDeviceInfo;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioRecord;
+import android.media.MediaRecorder;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+
+import androidx.core.content.ContextCompat;
+
+import com.limelight.LimeLog;
+import com.limelight.R;
+import com.limelight.nvstream.jni.MoonBridge;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class MicrophoneCaptureManager {
+    public interface LevelListener {
+        void onLevelUpdate(double level, boolean signalDetected, String status);
+    }
+
+    public static final class InputDeviceEntry {
+        public final int id;
+        public final String label;
+
+        public InputDeviceEntry(int id, String label) {
+            this.id = id;
+            this.label = label;
+        }
+    }
+
+    private static final int SAMPLE_RATE = 48000;
+    private static final int CHANNEL_COUNT = 1;
+    private static final int FRAME_SIZE = 960;
+    private static final int DEFAULT_BITRATE = 24000;
+    private static final int LEVEL_UPDATE_INTERVAL_MS = 50;
+    private static final int SIGNAL_THRESHOLD = 700;
+
+    private final Context context;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    private AudioRecord audioRecord;
+    private Thread captureThread;
+    private volatile boolean running;
+    private boolean streamingToHost;
+    private LevelListener levelListener;
+    private String currentStatus;
+    private double currentLevel;
+    private boolean signalDetected;
+
+    public MicrophoneCaptureManager(Context context) {
+        this.context = context.getApplicationContext();
+        this.currentStatus = string(R.string.microphone_preview_inactive);
+    }
+
+    public static boolean hasRecordAudioPermission(Context context) {
+        return ContextCompat.checkSelfPermission(context, android.Manifest.permission.RECORD_AUDIO) ==
+                PackageManager.PERMISSION_GRANTED;
+    }
+
+    public static List<InputDeviceEntry> getAvailableInputDevices(Context context) {
+        List<InputDeviceEntry> entries = new ArrayList<>();
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return entries;
+        }
+
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager == null) {
+            return entries;
+        }
+
+        for (AudioDeviceInfo deviceInfo : audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
+            entries.add(new InputDeviceEntry(deviceInfo.getId(), describeDevice(deviceInfo)));
+        }
+
+        return entries;
+    }
+
+    public boolean startPreview(int preferredDeviceId, LevelListener listener) {
+        return startCapture(preferredDeviceId, listener, false);
+    }
+
+    public boolean startStreaming(int preferredDeviceId, LevelListener listener) {
+        return startCapture(preferredDeviceId, listener, true);
+    }
+
+    public void stop() {
+        AudioRecord recordToRelease;
+        Thread threadToJoin;
+        boolean wasStreaming;
+
+        running = false;
+        recordToRelease = audioRecord;
+        threadToJoin = captureThread;
+        wasStreaming = streamingToHost;
+
+        if (recordToRelease != null) {
+            try {
+                recordToRelease.stop();
+            }
+            catch (IllegalStateException ignored) {
+            }
+        }
+
+        if (threadToJoin != null) {
+            try {
+                threadToJoin.join(2000);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        captureThread = null;
+        audioRecord = null;
+        if (recordToRelease != null) {
+            recordToRelease.release();
+        }
+
+        if (wasStreaming) {
+            MoonBridge.stopMicrophoneStreaming();
+            MoonBridge.cleanupMicrophoneEncoder();
+        }
+        streamingToHost = false;
+
+        currentLevel = 0.0;
+        signalDetected = false;
+        dispatchStatus(string(R.string.microphone_preview_inactive), 0.0, false);
+    }
+
+    private boolean startCapture(int preferredDeviceId, LevelListener listener, boolean streamToHost) {
+        CaptureConfig config;
+        AudioRecord newRecord;
+        final int bufferSamples;
+
+        stop();
+        levelListener = listener;
+
+        if (!hasRecordAudioPermission(context)) {
+            dispatchStatus(string(R.string.microphone_preview_permission_required), 0.0, false);
+            return false;
+        }
+
+        if (streamToHost && !MoonBridge.isMicrophoneStreamActive()) {
+            dispatchStatus(string(R.string.microphone_host_not_negotiated), 0.0, false);
+            return false;
+        }
+
+        config = createCaptureConfig(preferredDeviceId);
+        if (config == null) {
+            dispatchStatus(string(R.string.microphone_preview_open_failed), 0.0, false);
+            return false;
+        }
+
+        newRecord = config.record;
+        bufferSamples = config.bufferSamples;
+
+        if (streamToHost && MoonBridge.setupMicrophoneEncoder(SAMPLE_RATE, CHANNEL_COUNT, DEFAULT_BITRATE) != 0) {
+            newRecord.release();
+            dispatchStatus(string(R.string.microphone_encoder_setup_failed), 0.0, false);
+            return false;
+        }
+
+        try {
+            newRecord.startRecording();
+        }
+        catch (IllegalStateException e) {
+            if (streamToHost) {
+                MoonBridge.cleanupMicrophoneEncoder();
+            }
+            newRecord.release();
+            dispatchStatus(string(R.string.microphone_capture_start_failed), 0.0, false);
+            return false;
+        }
+
+        if (newRecord.getRecordingState() != AudioRecord.RECORDSTATE_RECORDING) {
+            if (streamToHost) {
+                MoonBridge.cleanupMicrophoneEncoder();
+            }
+            newRecord.release();
+            dispatchStatus(string(R.string.microphone_capture_start_failed), 0.0, false);
+            return false;
+        }
+
+        LimeLog.info(String.format((Locale) null,
+                "Microphone capture active using source %s, device %s, buffer %d samples",
+                config.sourceName,
+                config.deviceLabel,
+                bufferSamples));
+
+        audioRecord = newRecord;
+        streamingToHost = streamToHost;
+        currentStatus = config.statusMessage;
+        currentLevel = 0.0;
+        signalDetected = false;
+        running = true;
+
+        if (streamToHost) {
+            MoonBridge.startMicrophoneStreaming();
+        }
+
+        captureThread = new Thread(() -> runCaptureLoop(bufferSamples), streamToHost ? "MicStreamCapture" : "MicPreviewCapture");
+        captureThread.start();
+        dispatchStatus(config.statusMessage, 0.0, false);
+        return true;
+    }
+
+    private void runCaptureLoop(int bufferSamples) {
+        short[] readBuffer = new short[bufferSamples];
+        int pendingPeak = 0;
+        long lastUpdateTime = SystemClock.elapsedRealtime();
+
+        while (running && audioRecord != null) {
+            int samplesRead;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                samplesRead = audioRecord.read(readBuffer, 0, readBuffer.length, AudioRecord.READ_BLOCKING);
+            }
+            else {
+                samplesRead = audioRecord.read(readBuffer, 0, readBuffer.length);
+            }
+
+            if (samplesRead <= 0) {
+                continue;
+            }
+
+            int peak = calculatePeak(readBuffer, samplesRead);
+            if (peak > pendingPeak) {
+                pendingPeak = peak;
+            }
+
+            if (streamingToHost) {
+                int queued = MoonBridge.queueMicrophonePcm(readBuffer, samplesRead);
+                if (queued < 0) {
+                    LimeLog.warning("Failed to queue microphone PCM data for native encoding");
+                }
+            }
+
+            long now = SystemClock.elapsedRealtime();
+            if (now - lastUpdateTime >= LEVEL_UPDATE_INTERVAL_MS) {
+                double instantaneousLevel = pendingPeak / 32767.0;
+                double nextLevel = Math.max(instantaneousLevel, currentLevel * 0.72);
+                boolean nextSignalDetected = pendingPeak >= SIGNAL_THRESHOLD;
+                pendingPeak = 0;
+                lastUpdateTime = now;
+                currentLevel = nextLevel;
+                signalDetected = nextSignalDetected;
+                dispatchStatus(currentStatus, nextLevel, nextSignalDetected);
+            }
+        }
+    }
+
+    private CaptureConfig createCaptureConfig(int preferredDeviceId) {
+        int[] preferredSources = new int[] {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ? MediaRecorder.AudioSource.UNPROCESSED : -1,
+                MediaRecorder.AudioSource.VOICE_RECOGNITION,
+                MediaRecorder.AudioSource.MIC
+        };
+        int minBufferSizeBytes = AudioRecord.getMinBufferSize(SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT);
+        if (minBufferSizeBytes <= 0) {
+            minBufferSizeBytes = FRAME_SIZE * 4 * 2;
+        }
+        int bufferSizeBytes = Math.max(minBufferSizeBytes, FRAME_SIZE * 4 * 2);
+        int bufferSamples = Math.max(FRAME_SIZE, bufferSizeBytes / 2);
+        boolean missingSelectedDevice = false;
+        AudioDeviceInfo preferredDevice = null;
+        String preferredDeviceLabel = string(R.string.microphone_device_default);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && preferredDeviceId != 0) {
+            preferredDevice = findInputDevice(preferredDeviceId);
+            if (preferredDevice != null) {
+                preferredDeviceLabel = describeDevice(preferredDevice);
+            }
+            else {
+                missingSelectedDevice = true;
+            }
+        }
+
+        for (int source : preferredSources) {
+            AudioRecord candidate;
+
+            if (source < 0) {
+                continue;
+            }
+
+            candidate = buildAudioRecord(source, bufferSizeBytes);
+            if (candidate == null) {
+                continue;
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && preferredDevice != null) {
+                boolean preferredApplied = candidate.setPreferredDevice(preferredDevice);
+                if (!preferredApplied) {
+                    LimeLog.info("Preferred microphone device selection was rejected by AudioRecord");
+                }
+            }
+
+            if (candidate.getState() != AudioRecord.STATE_INITIALIZED) {
+                candidate.release();
+                continue;
+            }
+
+            CaptureConfig config = new CaptureConfig();
+            config.record = candidate;
+            config.bufferSamples = bufferSamples;
+            config.sourceName = audioSourceToString(source);
+            config.deviceLabel = preferredDevice != null ? preferredDeviceLabel : string(R.string.microphone_device_default);
+            config.statusMessage = missingSelectedDevice ?
+                    string(R.string.microphone_preview_selected_missing) :
+                    (preferredDevice != null ?
+                            string(R.string.microphone_preview_selected_active) :
+                            string(R.string.microphone_preview_default_active));
+            return config;
+        }
+
+        return null;
+    }
+
+    private AudioRecord buildAudioRecord(int audioSource, int bufferSizeBytes) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return new AudioRecord.Builder()
+                    .setAudioSource(audioSource)
+                    .setAudioFormat(new AudioFormat.Builder()
+                            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                            .setSampleRate(SAMPLE_RATE)
+                            .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+                            .build())
+                    .setBufferSizeInBytes(bufferSizeBytes)
+                    .build();
+        }
+
+        return new AudioRecord(audioSource,
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                bufferSizeBytes);
+    }
+
+    private AudioDeviceInfo findInputDevice(int deviceId) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return null;
+        }
+
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager == null) {
+            return null;
+        }
+
+        for (AudioDeviceInfo deviceInfo : audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
+            if (deviceInfo.getId() == deviceId) {
+                return deviceInfo;
+            }
+        }
+
+        return null;
+    }
+
+    private void dispatchStatus(String status, double level, boolean detected) {
+        currentStatus = status;
+        mainHandler.post(() -> {
+            if (levelListener != null) {
+                levelListener.onLevelUpdate(level, detected, status);
+            }
+        });
+    }
+
+    private String string(int resId) {
+        return context.getString(resId);
+    }
+
+    private static int calculatePeak(short[] samples, int sampleCount) {
+        int peak = 0;
+
+        for (int i = 0; i < sampleCount; i++) {
+            int sample = Math.abs(samples[i]);
+            if (sample > peak) {
+                peak = sample;
+            }
+        }
+
+        return peak;
+    }
+
+    private static String audioSourceToString(int audioSource) {
+        if (audioSource == MediaRecorder.AudioSource.VOICE_RECOGNITION) {
+            return "VOICE_RECOGNITION";
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+                audioSource == MediaRecorder.AudioSource.UNPROCESSED) {
+            return "UNPROCESSED";
+        }
+        return "MIC";
+    }
+
+    private static String describeDevice(AudioDeviceInfo deviceInfo) {
+        CharSequence productName = deviceInfo.getProductName();
+        if (productName != null && productName.length() > 0) {
+            return productName.toString();
+        }
+
+        switch (deviceInfo.getType()) {
+            case AudioDeviceInfo.TYPE_BUILTIN_MIC:
+                return "Built-in microphone";
+            case AudioDeviceInfo.TYPE_BLUETOOTH_SCO:
+                return "Bluetooth headset microphone";
+            case AudioDeviceInfo.TYPE_BLUETOOTH_A2DP:
+                return "Bluetooth audio input";
+            case AudioDeviceInfo.TYPE_WIRED_HEADSET:
+                return "Wired headset microphone";
+            case AudioDeviceInfo.TYPE_USB_DEVICE:
+            case AudioDeviceInfo.TYPE_USB_HEADSET:
+                return "USB microphone";
+            default:
+                return "Input device " + deviceInfo.getId();
+        }
+    }
+
+    private static final class CaptureConfig {
+        AudioRecord record;
+        int bufferSamples;
+        String sourceName;
+        String deviceLabel;
+        String statusMessage;
+    }
+}

--- a/app/src/main/java/com/limelight/binding/audio/MicrophoneCaptureManager.java
+++ b/app/src/main/java/com/limelight/binding/audio/MicrophoneCaptureManager.java
@@ -19,8 +19,10 @@ import com.limelight.R;
 import com.limelight.nvstream.jni.MoonBridge;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class MicrophoneCaptureManager {
     public interface LevelListener {
@@ -42,7 +44,12 @@ public class MicrophoneCaptureManager {
     private static final int FRAME_SIZE = 960;
     private static final int DEFAULT_BITRATE = 24000;
     private static final int LEVEL_UPDATE_INTERVAL_MS = 50;
-    private static final int SIGNAL_THRESHOLD = 700;
+    private static final int SIGNAL_PEAK_THRESHOLD = 250;
+    private static final double SIGNAL_RMS_THRESHOLD = 90.0;
+    private static final double PREVIEW_RMS_FLOOR = 40.0;
+    private static final double PREVIEW_RMS_CEILING = 4000.0;
+    private static final double PREVIEW_PEAK_CEILING = 12000.0;
+    private static final double PREVIEW_DECAY_FACTOR = 0.84;
 
     private final Context context;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
@@ -67,22 +74,25 @@ public class MicrophoneCaptureManager {
     }
 
     public static List<InputDeviceEntry> getAvailableInputDevices(Context context) {
-        List<InputDeviceEntry> entries = new ArrayList<>();
+        Map<String, InputDeviceEntry> uniqueEntries = new LinkedHashMap<>();
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            return entries;
+            return new ArrayList<>();
         }
 
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         if (audioManager == null) {
-            return entries;
+            return new ArrayList<>();
         }
 
         for (AudioDeviceInfo deviceInfo : audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
-            entries.add(new InputDeviceEntry(deviceInfo.getId(), describeDevice(deviceInfo)));
+            String label = describeDevice(deviceInfo);
+            if (!uniqueEntries.containsKey(label)) {
+                uniqueEntries.put(label, new InputDeviceEntry(deviceInfo.getId(), label));
+            }
         }
 
-        return entries;
+        return new ArrayList<>(uniqueEntries.values());
     }
 
     public boolean startPreview(int preferredDeviceId, LevelListener listener) {
@@ -217,6 +227,7 @@ public class MicrophoneCaptureManager {
     private void runCaptureLoop(int bufferSamples) {
         short[] readBuffer = new short[bufferSamples];
         int pendingPeak = 0;
+        double pendingRms = 0.0;
         long lastUpdateTime = SystemClock.elapsedRealtime();
 
         while (running && audioRecord != null) {
@@ -233,9 +244,12 @@ public class MicrophoneCaptureManager {
                 continue;
             }
 
-            int peak = calculatePeak(readBuffer, samplesRead);
-            if (peak > pendingPeak) {
-                pendingPeak = peak;
+            SignalStats signalStats = calculateSignalStats(readBuffer, samplesRead);
+            if (signalStats.peak > pendingPeak) {
+                pendingPeak = signalStats.peak;
+            }
+            if (signalStats.rms > pendingRms) {
+                pendingRms = signalStats.rms;
             }
 
             if (streamingToHost) {
@@ -247,10 +261,12 @@ public class MicrophoneCaptureManager {
 
             long now = SystemClock.elapsedRealtime();
             if (now - lastUpdateTime >= LEVEL_UPDATE_INTERVAL_MS) {
-                double instantaneousLevel = pendingPeak / 32767.0;
-                double nextLevel = Math.max(instantaneousLevel, currentLevel * 0.72);
-                boolean nextSignalDetected = pendingPeak >= SIGNAL_THRESHOLD;
+                double instantaneousLevel = calculatePreviewLevel(pendingPeak, pendingRms);
+                double nextLevel = Math.max(instantaneousLevel, currentLevel * PREVIEW_DECAY_FACTOR);
+                boolean nextSignalDetected = pendingPeak >= SIGNAL_PEAK_THRESHOLD ||
+                        pendingRms >= SIGNAL_RMS_THRESHOLD;
                 pendingPeak = 0;
+                pendingRms = 0.0;
                 lastUpdateTime = now;
                 currentLevel = nextLevel;
                 signalDetected = nextSignalDetected;
@@ -379,17 +395,30 @@ public class MicrophoneCaptureManager {
         return context.getString(resId);
     }
 
-    private static int calculatePeak(short[] samples, int sampleCount) {
+    private static SignalStats calculateSignalStats(short[] samples, int sampleCount) {
         int peak = 0;
+        double sumSquares = 0.0;
 
         for (int i = 0; i < sampleCount; i++) {
             int sample = Math.abs(samples[i]);
             if (sample > peak) {
                 peak = sample;
             }
+            sumSquares += (double) sample * sample;
         }
 
-        return peak;
+        SignalStats signalStats = new SignalStats();
+        signalStats.peak = peak;
+        signalStats.rms = sampleCount > 0 ? Math.sqrt(sumSquares / sampleCount) : 0.0;
+        return signalStats;
+    }
+
+    private static double calculatePreviewLevel(int peak, double rms) {
+        double rmsLevel = (Math.log10(Math.max(rms, PREVIEW_RMS_FLOOR)) -
+                Math.log10(PREVIEW_RMS_FLOOR)) /
+                (Math.log10(PREVIEW_RMS_CEILING) - Math.log10(PREVIEW_RMS_FLOOR));
+        double peakLevel = Math.min(1.0, peak / PREVIEW_PEAK_CEILING);
+        return Math.max(0.0, Math.min(1.0, Math.max(rmsLevel, peakLevel)));
     }
 
     private static String audioSourceToString(int audioSource) {
@@ -404,11 +433,6 @@ public class MicrophoneCaptureManager {
     }
 
     private static String describeDevice(AudioDeviceInfo deviceInfo) {
-        CharSequence productName = deviceInfo.getProductName();
-        if (productName != null && productName.length() > 0) {
-            return productName.toString();
-        }
-
         switch (deviceInfo.getType()) {
             case AudioDeviceInfo.TYPE_BUILTIN_MIC:
                 return "Built-in microphone";
@@ -422,8 +446,17 @@ public class MicrophoneCaptureManager {
             case AudioDeviceInfo.TYPE_USB_HEADSET:
                 return "USB microphone";
             default:
+                CharSequence productName = deviceInfo.getProductName();
+                if (productName != null && productName.length() > 0) {
+                    return productName.toString();
+                }
                 return "Input device " + deviceInfo.getId();
         }
+    }
+
+    private static final class SignalStats {
+        int peak;
+        double rms;
     }
 
     private static final class CaptureConfig {

--- a/app/src/main/java/com/limelight/nvstream/NvConnection.java
+++ b/app/src/main/java/com/limelight/nvstream/NvConnection.java
@@ -454,31 +454,40 @@ public class NvConnection {
 
                 // Moonlight-core is not thread-safe with respect to connection start and stop, so
                 // we must not invoke that functionality in parallel.
-                synchronized (MoonBridge.class) {
-                    MoonBridge.setupBridge(videoDecoderRenderer, audioRenderer, connectionListener);
-                    int ret = MoonBridge.startConnection(context.serverAddress.address,
-                            context.serverAppVersion, context.serverGfeVersion, context.rtspSessionUrl,
-                            context.serverCodecModeSupport,
-                            context.negotiatedWidth, context.negotiatedHeight,
-                            context.streamConfig.getRefreshRate(), context.streamConfig.getBitrate(),
-                            context.negotiatedPacketSize, context.negotiatedRemoteStreaming,
-                            context.streamConfig.getAudioConfiguration().toInt(),
-                            context.streamConfig.getSupportedVideoFormats(),
-                            context.streamConfig.getClientRefreshRateX100(),
-                            context.riKey.getEncoded(), ib.array(),
-                            context.videoCapabilities,
-                            context.streamConfig.getColorSpace(),
-                            context.streamConfig.getColorRange());
-                    if (ret != 0) {
-                        // LiStartConnection() failed, so the caller is not expected
-                        // to stop the connection themselves. We need to release their
-                        // semaphore count for them.
-                        connectionAllowed.release();
-                        return;
-                    }
+                int ret = startBridgeConnection(context, ib.array(),
+                        audioRenderer, videoDecoderRenderer, connectionListener);
+                if (ret != 0) {
+                    // LiStartConnection() failed, so the caller is not expected
+                    // to stop the connection themselves. We need to release their
+                    // semaphore count for them.
+                    connectionAllowed.release();
+                    return;
                 }
             }
         }).start();
+    }
+
+    static int startBridgeConnection(ConnectionContext context, byte[] riAesIv,
+                                     AudioRenderer audioRenderer,
+                                     VideoDecoderRenderer videoDecoderRenderer,
+                                     NvConnectionListener connectionListener) {
+        synchronized (MoonBridge.class) {
+            MoonBridge.setupBridge(videoDecoderRenderer, audioRenderer, connectionListener);
+            return MoonBridge.startConnection(context.serverAddress.address,
+                    context.serverAppVersion, context.serverGfeVersion, context.rtspSessionUrl,
+                    context.serverCodecModeSupport,
+                    context.negotiatedWidth, context.negotiatedHeight,
+                    context.streamConfig.getRefreshRate(), context.streamConfig.getBitrate(),
+                    context.negotiatedPacketSize, context.negotiatedRemoteStreaming,
+                    context.streamConfig.getAudioConfiguration().toInt(),
+                    context.streamConfig.getSupportedVideoFormats(),
+                    context.streamConfig.getClientRefreshRateX100(),
+                    context.riKey.getEncoded(), riAesIv,
+                    context.videoCapabilities,
+                    context.streamConfig.getColorSpace(),
+                    context.streamConfig.getColorRange(),
+                    context.streamConfig.getEnableMicrophone());
+        }
     }
 
     public void sendExecServerCmd(final int cmdId) {

--- a/app/src/main/java/com/limelight/nvstream/StreamConfiguration.java
+++ b/app/src/main/java/com/limelight/nvstream/StreamConfiguration.java
@@ -31,6 +31,7 @@ public class StreamConfiguration {
     private int colorSpace;
     private boolean persistGamepadsAfterDisconnect;
     private boolean enableUltraLowLatency;
+    private boolean enableMicrophone;
 
     public static class Builder {
         private StreamConfiguration config = new StreamConfiguration();
@@ -146,6 +147,11 @@ public class StreamConfiguration {
             return this;
         }
 
+        public StreamConfiguration.Builder setEnableMicrophone(boolean enable) {
+            config.enableMicrophone = enable;
+            return this;
+        }
+
         public StreamConfiguration build() {
             return config;
         }
@@ -257,5 +263,9 @@ public class StreamConfiguration {
 
     public boolean getEnableUltraLowLatency() {
         return enableUltraLowLatency;
+    }
+
+    public boolean getEnableMicrophone() {
+        return enableMicrophone;
     }
 }

--- a/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
+++ b/app/src/main/java/com/limelight/nvstream/jni/MoonBridge.java
@@ -348,7 +348,8 @@ public class MoonBridge {
                                               int clientRefreshRateX100,
                                               byte[] riAesKey, byte[] riAesIv,
                                               int videoCapabilities,
-                                              int colorSpace, int colorRange);
+                                              int colorSpace, int colorRange,
+                                              boolean enableMicrophone);
 
     public static native void stopConnection();
 
@@ -402,6 +403,20 @@ public class MoonBridge {
     public static native int getPendingAudioDuration();
 
     public static native int getPendingVideoFrames();
+
+    public static native boolean isMicrophoneStreamActive();
+
+    public static native boolean isMicrophoneEncryptionEnabled();
+
+    public static native int setupMicrophoneEncoder(int sampleRate, int channelCount, int bitrate);
+
+    public static native void startMicrophoneStreaming();
+
+    public static native void stopMicrophoneStreaming();
+
+    public static native void cleanupMicrophoneEncoder();
+
+    public static native int queueMicrophonePcm(short[] pcmData, int sampleCount);
 
     public static native int testClientConnectivity(String testServerHostName, int referencePort, int testFlags);
 

--- a/app/src/main/java/com/limelight/preferences/MicrophonePreviewPreference.java
+++ b/app/src/main/java/com/limelight/preferences/MicrophonePreviewPreference.java
@@ -1,0 +1,55 @@
+package com.limelight.preferences;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.util.AttributeSet;
+import android.widget.ProgressBar;
+
+import androidx.annotation.NonNull;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import com.limelight.R;
+
+public class MicrophonePreviewPreference extends Preference {
+    private int levelPercent;
+    private boolean signalDetected;
+
+    public MicrophonePreviewPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public MicrophonePreviewPreference(Context context) {
+        super(context);
+        init();
+    }
+
+    private void init() {
+        setSelectable(false);
+        setWidgetLayoutResource(R.layout.preference_microphone_preview_widget);
+        setSummary(R.string.microphone_preview_inactive);
+    }
+
+    public void updatePreviewState(String status, double level, boolean detected) {
+        levelPercent = Math.max(0, Math.min(100, (int) Math.round(level * 100.0)));
+        signalDetected = detected;
+        setSummary(status + "\n" + getContext().getString(
+                detected ? R.string.microphone_preview_signal_detected :
+                        R.string.microphone_preview_signal_missing));
+        notifyChanged();
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        ProgressBar previewBar = (ProgressBar) holder.findViewById(R.id.microphone_preview_bar);
+        if (previewBar != null) {
+            previewBar.setProgress(levelPercent);
+            previewBar.setProgressTintList(ColorStateList.valueOf(Color.parseColor(
+                    signalDetected ? "#45c486" : "#5f6f86")));
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -60,6 +60,8 @@ public class PreferenceConfiguration {
     private static final String SMALL_ICONS_PREF_STRING = "checkbox_small_icon_mode";
     private static final String MULTI_CONTROLLER_PREF_STRING = "checkbox_multi_controller";
     static final String AUDIO_CONFIG_PREF_STRING = "list_audio_config";
+    static final String ENABLE_MICROPHONE_PREF_STRING = "checkbox_enable_microphone";
+    static final String MICROPHONE_DEVICE_PREF_STRING = "list_microphone_device";
     private static final String USB_DRIVER_PREF_SRING = "checkbox_usb_driver";
     private static final String VIDEO_FORMAT_PREF_STRING = "video_format";
     private static final String ONSCREEN_CONTROLLER_PREF_STRING = "checkbox_show_onscreen_controls";
@@ -178,6 +180,8 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_FLIP_FACE_BUTTONS = false;
     private static final boolean DEFAULT_TOUCHSCREEN_TRACKPAD = true;
     private static final String DEFAULT_AUDIO_CONFIG = "2"; // Stereo
+    private static final boolean DEFAULT_ENABLE_MICROPHONE = false;
+    private static final String DEFAULT_MICROPHONE_DEVICE = "0";
     private static final boolean DEFAULT_LATENCY_TOAST = false;
     private static final String DEFAULT_FRAME_PACING = "latency";
     private static final boolean DEFAULT_ABSOLUTE_MOUSE_MODE = false;
@@ -365,6 +369,8 @@ public class PreferenceConfiguration {
     public int vibrateFallbackToDeviceStrength;
     public boolean touchscreenTrackpad;
     public MoonBridge.AudioConfiguration audioConfiguration;
+    public boolean enableMicrophone;
+    public int microphoneDeviceId;
     public int framePacing;
     public boolean absoluteMouseMode;
     public boolean enableAudioFx;
@@ -851,6 +857,15 @@ private static int getFramePacingValue(Context context) {
         }
         else /* if (audioConfig.equals("2")) */ {
             config.audioConfiguration = MoonBridge.AUDIO_CONFIGURATION_STEREO;
+        }
+
+        config.enableMicrophone = prefs.getBoolean(ENABLE_MICROPHONE_PREF_STRING, DEFAULT_ENABLE_MICROPHONE);
+        try {
+            config.microphoneDeviceId = Integer.parseInt(prefs.getString(MICROPHONE_DEVICE_PREF_STRING, DEFAULT_MICROPHONE_DEVICE));
+        }
+        catch (NumberFormatException e) {
+            config.microphoneDeviceId = 0;
+            prefs.edit().putString(MICROPHONE_DEVICE_PREF_STRING, DEFAULT_MICROPHONE_DEVICE).apply();
         }
 
         config.videoScaleMode = getVideoScaleMode(context);

--- a/app/src/main/java/com/limelight/preferences/StreamSettings.java
+++ b/app/src/main/java/com/limelight/preferences/StreamSettings.java
@@ -2,6 +2,7 @@ package com.limelight.preferences;
 
 import static com.limelight.utils.ServerHelper.getActiveDisplay;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -50,6 +51,7 @@ import com.limelight.GameMenu;
 import com.limelight.LimeLog;
 import com.limelight.PcView;
 import com.limelight.R;
+import com.limelight.binding.audio.MicrophoneCaptureManager;
 import com.limelight.binding.input.virtual_controller.keyboard.KeyBoardControllerConfigurationLoader;
 import com.limelight.binding.video.MediaCodecHelper;
 import com.limelight.utils.Dialog;
@@ -162,10 +164,19 @@ public class StreamSettings extends AppCompatActivity {
     }
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
+        private static final int READ_REQUEST_CODE = 1001;
+        private static final int READ_REQUEST_SPECIAL_CODE = 1002;
+        private static final int RECORD_AUDIO_PERMISSION_REQUEST_CODE = 1003;
+
         private int nativeResolutionStartIndex = Integer.MAX_VALUE;
         private boolean nativeFramerateShown = false;
 
         private PreferenceConfiguration prevPrefConfig;
+        private MicrophoneCaptureManager microphoneCaptureManager;
+        private CheckBoxPreference microphoneEnablePreference;
+        private ListPreference microphoneDevicePreference;
+        private MicrophonePreviewPreference microphonePreviewPreference;
+        private boolean pendingMicrophoneEnableAfterPermission;
 
         public SettingsFragment(PreferenceConfiguration prefCfg) {
             prevPrefConfig = prefCfg;
@@ -394,6 +405,8 @@ public class StreamSettings extends AppCompatActivity {
                         (PreferenceCategory) findPreference("category_ui_settings");
                 category.removePreference(findPreference("checkbox_enable_pip"));
             }
+
+            initializeMicrophonePreferences(screen);
 
             // Fire TV apps are not allowed to use WebViews or browsers, so hide the Help category
             /*if (getActivity().getPackageManager().hasSystemFeature("amazon.hardware.fire_tv")) {
@@ -958,6 +971,163 @@ public class StreamSettings extends AppCompatActivity {
             }
         }
 
+        private void initializeMicrophonePreferences(PreferenceScreen screen) {
+            microphoneEnablePreference = findPreference(PreferenceConfiguration.ENABLE_MICROPHONE_PREF_STRING);
+            microphoneDevicePreference = findPreference(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING);
+            microphonePreviewPreference = findPreference("microphone_preview");
+
+            if (microphoneEnablePreference != null) {
+                microphoneEnablePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                    boolean enableMicrophone = (Boolean) newValue;
+
+                    if (enableMicrophone &&
+                            !MicrophoneCaptureManager.hasRecordAudioPermission(requireContext())) {
+                        pendingMicrophoneEnableAfterPermission = true;
+                        requestPermissions(
+                                new String[] { Manifest.permission.RECORD_AUDIO },
+                                RECORD_AUDIO_PERMISSION_REQUEST_CODE);
+                        return false;
+                    }
+
+                    pendingMicrophoneEnableAfterPermission = false;
+                    getPrefs().edit()
+                            .putBoolean(PreferenceConfiguration.ENABLE_MICROPHONE_PREF_STRING, enableMicrophone)
+                            .apply();
+                    microphoneEnablePreference.setChecked(enableMicrophone);
+
+                    if (isResumed()) {
+                        refreshMicrophonePreview();
+                    }
+                    return false;
+                });
+            }
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                getPrefs().edit()
+                        .putString(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, "0")
+                        .apply();
+                screen.removePreferenceRecursively(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING);
+                microphoneDevicePreference = null;
+            }
+            else {
+                populateMicrophoneDevicePreference();
+
+                if (microphoneDevicePreference != null) {
+                    microphoneDevicePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                        String selectedDeviceId = (String) newValue;
+                        getPrefs().edit()
+                                .putString(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, selectedDeviceId)
+                                .apply();
+                        microphoneDevicePreference.setValue(selectedDeviceId);
+
+                        if (isResumed()) {
+                            refreshMicrophonePreview();
+                        }
+                        return false;
+                    });
+                }
+            }
+
+            if (microphonePreviewPreference != null) {
+                int statusResId = MicrophoneCaptureManager.hasRecordAudioPermission(requireContext()) ?
+                        R.string.microphone_preview_inactive :
+                        R.string.microphone_preview_permission_required;
+                microphonePreviewPreference.updatePreviewState(getString(statusResId), 0.0, false);
+            }
+        }
+
+        private void populateMicrophoneDevicePreference() {
+            if (microphoneDevicePreference == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                return;
+            }
+
+            java.util.List<MicrophoneCaptureManager.InputDeviceEntry> deviceEntries =
+                    MicrophoneCaptureManager.getAvailableInputDevices(requireContext());
+            CharSequence[] labels = new CharSequence[deviceEntries.size() + 1];
+            CharSequence[] values = new CharSequence[deviceEntries.size() + 1];
+
+            labels[0] = getString(R.string.microphone_device_default);
+            values[0] = "0";
+
+            String selectedValue = getPrefs().getString(
+                    PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, "0");
+            boolean hasSelectedDevice = "0".equals(selectedValue);
+
+            for (int i = 0; i < deviceEntries.size(); i++) {
+                MicrophoneCaptureManager.InputDeviceEntry deviceEntry = deviceEntries.get(i);
+                labels[i + 1] = deviceEntry.label;
+                values[i + 1] = Integer.toString(deviceEntry.id);
+                if (values[i + 1].equals(selectedValue)) {
+                    hasSelectedDevice = true;
+                }
+            }
+
+            if (!hasSelectedDevice) {
+                selectedValue = "0";
+                getPrefs().edit()
+                        .putString(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, selectedValue)
+                        .apply();
+                if (microphonePreviewPreference != null) {
+                    microphonePreviewPreference.updatePreviewState(
+                            getString(R.string.microphone_preview_selected_missing), 0.0, false);
+                }
+            }
+
+            microphoneDevicePreference.setEntries(labels);
+            microphoneDevicePreference.setEntryValues(values);
+            microphoneDevicePreference.setValue(selectedValue);
+        }
+
+        private int getSelectedMicrophoneDeviceId() {
+            String selectedValue = getPrefs().getString(
+                    PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, "0");
+            try {
+                return Integer.parseInt(selectedValue);
+            }
+            catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+
+        private MicrophoneCaptureManager getMicrophoneCaptureManager() {
+            if (microphoneCaptureManager == null) {
+                microphoneCaptureManager = new MicrophoneCaptureManager(requireContext());
+            }
+            return microphoneCaptureManager;
+        }
+
+        private void refreshMicrophonePreview() {
+            if (!isAdded() || microphonePreviewPreference == null) {
+                return;
+            }
+
+            stopMicrophonePreview();
+
+            if (!MicrophoneCaptureManager.hasRecordAudioPermission(requireContext())) {
+                microphonePreviewPreference.updatePreviewState(
+                        getString(R.string.microphone_preview_permission_required), 0.0, false);
+                return;
+            }
+
+            if (!getMicrophoneCaptureManager().startPreview(
+                    getSelectedMicrophoneDeviceId(),
+                    (level, signalDetected, status) -> {
+                        if (microphonePreviewPreference != null) {
+                            microphonePreviewPreference.updatePreviewState(
+                                    status, level, signalDetected);
+                        }
+                    })) {
+                microphonePreviewPreference.updatePreviewState(
+                        getString(R.string.microphone_preview_open_failed), 0.0, false);
+            }
+        }
+
+        private void stopMicrophonePreview() {
+            if (microphoneCaptureManager != null) {
+                microphoneCaptureManager.stop();
+            }
+        }
+
         private void removeEntryFromListAndSetValue(String resolutionPrefString, String entryToRemove, String nextDefault) {
             removeValue(resolutionPrefString, entryToRemove, new Runnable() {
                 @Override
@@ -992,8 +1162,24 @@ public class StreamSettings extends AppCompatActivity {
             }, 500);
         }
 
-        int READ_REQUEST_CODE = 1001;
-        int READ_REQUEST_SPECIAL_CODE = 1002;
+        @Override
+        public void onResume() {
+            super.onResume();
+            refreshMicrophonePreview();
+        }
+
+        @Override
+        public void onPause() {
+            stopMicrophonePreview();
+            super.onPause();
+        }
+
+        @Override
+        public void onDestroy() {
+            stopMicrophonePreview();
+            microphoneCaptureManager = null;
+            super.onDestroy();
+        }
 
         @Override
         public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -1041,6 +1227,45 @@ public class StreamSettings extends AppCompatActivity {
                     e.printStackTrace();
                     Toast.makeText(getActivity(), getString(R.string.pref_error_occurred) + e.getMessage(), Toast.LENGTH_SHORT).show();
                 }
+            }
+        }
+
+        @Override
+        public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+            if (requestCode != RECORD_AUDIO_PERMISSION_REQUEST_CODE) {
+                return;
+            }
+
+            boolean granted = grantResults.length > 0 &&
+                    grantResults[0] == PackageManager.PERMISSION_GRANTED;
+
+            if (granted) {
+                if (pendingMicrophoneEnableAfterPermission && microphoneEnablePreference != null) {
+                    getPrefs().edit()
+                            .putBoolean(PreferenceConfiguration.ENABLE_MICROPHONE_PREF_STRING, true)
+                            .apply();
+                    microphoneEnablePreference.setChecked(true);
+                }
+                pendingMicrophoneEnableAfterPermission = false;
+                if (isResumed()) {
+                    refreshMicrophonePreview();
+                }
+                return;
+            }
+
+            pendingMicrophoneEnableAfterPermission = false;
+            if (microphoneEnablePreference != null) {
+                microphoneEnablePreference.setChecked(false);
+            }
+            getPrefs().edit()
+                    .putBoolean(PreferenceConfiguration.ENABLE_MICROPHONE_PREF_STRING, false)
+                    .apply();
+            Toast.makeText(requireContext(), R.string.microphone_permission_denied, Toast.LENGTH_SHORT).show();
+            if (microphonePreviewPreference != null) {
+                microphonePreviewPreference.updatePreviewState(
+                        getString(R.string.microphone_preview_permission_required), 0.0, false);
             }
         }
 

--- a/app/src/main/jni/moonlight-core/Android.mk
+++ b/app/src/main/jni/moonlight-core/Android.mk
@@ -17,6 +17,7 @@ LOCAL_SRC_FILES := moonlight-common-c/src/AudioStream.c \
                    moonlight-common-c/src/InputStream.c \
                    moonlight-common-c/src/LinkedBlockingQueue.c \
                    moonlight-common-c/src/Misc.c \
+                   moonlight-common-c/src/MicrophoneStream.c \
                    moonlight-common-c/src/Platform.c \
                    moonlight-common-c/src/PlatformCrypto.c \
                    moonlight-common-c/src/PlatformSockets.c \

--- a/app/src/main/jni/moonlight-core/callbacks.c
+++ b/app/src/main/jni/moonlight-core/callbacks.c
@@ -1,10 +1,13 @@
 #include <jni.h>
 
 #include <pthread.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <Limelight.h>
 
+#include <opus.h>
 #include <opus_multistream.h>
 #include <android/log.h>
 
@@ -40,6 +43,185 @@ static jmethodID BridgeClSetMotionEventStateMethod;
 static jmethodID BridgeClSetControllerLEDMethod;
 static jbyteArray DecodedFrameBuffer;
 static jshortArray DecodedAudioBuffer;
+
+#define MIC_SAMPLE_RATE 48000
+#define MIC_CHANNEL_COUNT 1
+#define MIC_FRAME_SIZE 960
+#define MIC_DEFAULT_BITRATE 24000
+#define MIC_MAX_ENCODED_PACKET 1024
+#define MIC_MAX_BUFFERED_SAMPLES (MIC_FRAME_SIZE * 12)
+
+static OpusEncoder* MicEncoder;
+static pthread_t MicEncoderThread;
+static pthread_mutex_t MicEncoderMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t MicEncoderCond = PTHREAD_COND_INITIALIZER;
+static opus_int16* MicSampleBuffer;
+static size_t MicSampleBufferCount;
+static size_t MicSampleBufferCapacity;
+static bool MicEncoderThreadRunning;
+static bool MicEncoderStopRequested;
+static bool MicStreamingActive;
+static bool MicFirstPacketLogged;
+
+static void MicLog(const char* format, ...) {
+    va_list va;
+    va_start(va, format);
+    __android_log_vprint(ANDROID_LOG_INFO, "moonlight-mic", format, va);
+    va_end(va);
+}
+
+static void clearMicBufferedSamplesLocked(void) {
+    MicSampleBufferCount = 0;
+}
+
+static int ensureMicSampleCapacityLocked(size_t minimumCapacity) {
+    opus_int16* resizedBuffer;
+    size_t newCapacity = MicSampleBufferCapacity == 0 ? MIC_FRAME_SIZE * 4 : MicSampleBufferCapacity;
+
+    while (newCapacity < minimumCapacity) {
+        newCapacity *= 2;
+    }
+
+    resizedBuffer = realloc(MicSampleBuffer, newCapacity * sizeof(opus_int16));
+    if (resizedBuffer == NULL) {
+        return -1;
+    }
+
+    MicSampleBuffer = resizedBuffer;
+    MicSampleBufferCapacity = newCapacity;
+    return 0;
+}
+
+static int compareTimespec(const struct timespec* lhs, const struct timespec* rhs) {
+    if (lhs->tv_sec == rhs->tv_sec) {
+        if (lhs->tv_nsec == rhs->tv_nsec) {
+            return 0;
+        }
+        return lhs->tv_nsec < rhs->tv_nsec ? -1 : 1;
+    }
+
+    return lhs->tv_sec < rhs->tv_sec ? -1 : 1;
+}
+
+static int64_t diffTimespecNs(const struct timespec* lhs, const struct timespec* rhs) {
+    return ((int64_t)lhs->tv_sec - rhs->tv_sec) * 1000000000LL +
+            ((int64_t)lhs->tv_nsec - rhs->tv_nsec);
+}
+
+static void addTimespecNs(struct timespec* value, int64_t deltaNs) {
+    value->tv_sec += (time_t)(deltaNs / 1000000000LL);
+    value->tv_nsec += (long)(deltaNs % 1000000000LL);
+
+    if (value->tv_nsec >= 1000000000L) {
+        value->tv_sec++;
+        value->tv_nsec -= 1000000000L;
+    }
+}
+
+static void* MicEncoderWorker(void* context) {
+    opus_int16 frame[MIC_FRAME_SIZE];
+    unsigned char encodedPacket[MIC_MAX_ENCODED_PACKET];
+    const int64_t frameDurationNs = (1000000000LL * MIC_FRAME_SIZE) / MIC_SAMPLE_RATE;
+    struct timespec nextSendDeadline = {0};
+    bool pacingActive = false;
+
+    while (true) {
+        struct timespec now;
+        int encodedBytes;
+        int sendResult;
+
+        pthread_mutex_lock(&MicEncoderMutex);
+        while (!MicEncoderStopRequested &&
+                (!MicStreamingActive || MicSampleBufferCount < MIC_FRAME_SIZE)) {
+            pthread_cond_wait(&MicEncoderCond, &MicEncoderMutex);
+        }
+
+        if (MicEncoderStopRequested) {
+            pthread_mutex_unlock(&MicEncoderMutex);
+            break;
+        }
+
+        if (MicEncoder == NULL) {
+            pthread_mutex_unlock(&MicEncoderMutex);
+            pacingActive = false;
+            continue;
+        }
+
+        memcpy(frame, MicSampleBuffer, sizeof(frame));
+        MicSampleBufferCount -= MIC_FRAME_SIZE;
+        if (MicSampleBufferCount > 0) {
+            memmove(MicSampleBuffer,
+                    MicSampleBuffer + MIC_FRAME_SIZE,
+                    MicSampleBufferCount * sizeof(opus_int16));
+        }
+        pthread_mutex_unlock(&MicEncoderMutex);
+
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        if (!pacingActive) {
+            nextSendDeadline = now;
+            pacingActive = true;
+        }
+        else if (diffTimespecNs(&now, &nextSendDeadline) > (frameDurationNs * 2)) {
+            nextSendDeadline = now;
+        }
+
+        if (compareTimespec(&nextSendDeadline, &now) > 0) {
+            clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &nextSendDeadline, NULL);
+        }
+        addTimespecNs(&nextSendDeadline, frameDurationNs);
+
+        encodedBytes = opus_encode(MicEncoder,
+                                   frame,
+                                   MIC_FRAME_SIZE,
+                                   encodedPacket,
+                                   (opus_int32)sizeof(encodedPacket));
+        if (encodedBytes <= 0) {
+            continue;
+        }
+
+        sendResult = LiSendMicrophoneOpusDataEx(encodedPacket, encodedBytes, MIC_FRAME_SIZE);
+        if (sendResult >= 0 && !MicFirstPacketLogged) {
+            MicFirstPacketLogged = true;
+            MicLog("Sent first client microphone packet (%d bytes Opus)", encodedBytes);
+        }
+        else if (sendResult < 0) {
+            MicLog("LiSendMicrophoneOpusDataEx() failed for microphone capture");
+        }
+    }
+
+    return NULL;
+}
+
+static void TeardownMicrophoneEncoder(void) {
+    bool shouldJoin;
+    pthread_t threadToJoin;
+
+    pthread_mutex_lock(&MicEncoderMutex);
+    MicEncoderStopRequested = true;
+    MicStreamingActive = false;
+    pthread_cond_broadcast(&MicEncoderCond);
+    shouldJoin = MicEncoderThreadRunning;
+    threadToJoin = MicEncoderThread;
+    pthread_mutex_unlock(&MicEncoderMutex);
+
+    if (shouldJoin) {
+        pthread_join(threadToJoin, NULL);
+    }
+
+    pthread_mutex_lock(&MicEncoderMutex);
+    MicEncoderThreadRunning = false;
+    MicEncoderStopRequested = false;
+    clearMicBufferedSamplesLocked();
+    if (MicEncoder != NULL) {
+        opus_encoder_destroy(MicEncoder);
+        MicEncoder = NULL;
+    }
+    free(MicSampleBuffer);
+    MicSampleBuffer = NULL;
+    MicSampleBufferCapacity = 0;
+    MicFirstPacketLogged = false;
+    pthread_mutex_unlock(&MicEncoderMutex);
+}
 
 void DetachThread(void* context) {
     (*JVM)->DetachCurrentThread(JVM);
@@ -451,6 +633,152 @@ hasFastAes() {
     }
 }
 
+JNIEXPORT jboolean JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_isMicrophoneStreamActive(JNIEnv *env, jclass clazz) {
+    return LiIsMicrophoneStreamActive();
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_isMicrophoneEncryptionEnabled(JNIEnv *env, jclass clazz) {
+    return LiIsMicrophoneEncryptionEnabled();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_setupMicrophoneEncoder(JNIEnv *env, jclass clazz,
+                                                                  jint sampleRate, jint channelCount,
+                                                                  jint bitrate) {
+    int err = OPUS_OK;
+
+    if (sampleRate != MIC_SAMPLE_RATE || channelCount != MIC_CHANNEL_COUNT) {
+        MicLog("Unsupported microphone encoder format: %d Hz, %d channels", sampleRate, channelCount);
+        return -1;
+    }
+
+    pthread_mutex_lock(&MicEncoderMutex);
+    if (MicEncoder != NULL) {
+        pthread_mutex_unlock(&MicEncoderMutex);
+        return 0;
+    }
+
+    MicEncoder = opus_encoder_create(sampleRate, channelCount, OPUS_APPLICATION_VOIP, &err);
+    if (MicEncoder == NULL || err != OPUS_OK) {
+        MicEncoder = NULL;
+        pthread_mutex_unlock(&MicEncoderMutex);
+        MicLog("opus_encoder_create() failed for microphone capture: %s", opus_strerror(err));
+        return -1;
+    }
+
+    opus_encoder_ctl(MicEncoder, OPUS_SET_BITRATE(bitrate > 0 ? bitrate : MIC_DEFAULT_BITRATE));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_VBR(1));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_COMPLEXITY(10));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_SIGNAL(OPUS_SIGNAL_VOICE));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_LSB_DEPTH(16));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_DTX(0));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_INBAND_FEC(1));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_PACKET_LOSS_PERC(5));
+    opus_encoder_ctl(MicEncoder, OPUS_SET_EXPERT_FRAME_DURATION(OPUS_FRAMESIZE_20_MS));
+
+    clearMicBufferedSamplesLocked();
+    MicStreamingActive = false;
+    MicEncoderStopRequested = false;
+    MicFirstPacketLogged = false;
+
+    if (!MicEncoderThreadRunning) {
+        if (pthread_create(&MicEncoderThread, NULL, MicEncoderWorker, NULL) != 0) {
+            opus_encoder_destroy(MicEncoder);
+            MicEncoder = NULL;
+            pthread_mutex_unlock(&MicEncoderMutex);
+            MicLog("Failed to create microphone encoder worker thread");
+            return -1;
+        }
+
+        MicEncoderThreadRunning = true;
+    }
+
+    pthread_mutex_unlock(&MicEncoderMutex);
+    return 0;
+}
+
+JNIEXPORT void JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_startMicrophoneStreaming(JNIEnv *env, jclass clazz) {
+    pthread_mutex_lock(&MicEncoderMutex);
+    clearMicBufferedSamplesLocked();
+    MicFirstPacketLogged = false;
+    MicStreamingActive = MicEncoder != NULL;
+    pthread_cond_broadcast(&MicEncoderCond);
+    pthread_mutex_unlock(&MicEncoderMutex);
+}
+
+JNIEXPORT void JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_stopMicrophoneStreaming(JNIEnv *env, jclass clazz) {
+    pthread_mutex_lock(&MicEncoderMutex);
+    MicStreamingActive = false;
+    clearMicBufferedSamplesLocked();
+    pthread_cond_broadcast(&MicEncoderCond);
+    pthread_mutex_unlock(&MicEncoderMutex);
+}
+
+JNIEXPORT void JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_cleanupMicrophoneEncoder(JNIEnv *env, jclass clazz) {
+    TeardownMicrophoneEncoder();
+}
+
+JNIEXPORT jint JNICALL
+Java_com_limelight_nvstream_jni_MoonBridge_queueMicrophonePcm(JNIEnv *env, jclass clazz,
+                                                              jshortArray pcmData, jint sampleCount) {
+    jsize arrayLength;
+    jshort* samples;
+    size_t requestedSamples;
+
+    if (pcmData == NULL || sampleCount <= 0) {
+        return 0;
+    }
+
+    arrayLength = (*env)->GetArrayLength(env, pcmData);
+    if (arrayLength <= 0) {
+        return 0;
+    }
+
+    if (sampleCount > arrayLength) {
+        sampleCount = arrayLength;
+    }
+
+    samples = (*env)->GetShortArrayElements(env, pcmData, NULL);
+    if (samples == NULL) {
+        return -1;
+    }
+
+    requestedSamples = (size_t)sampleCount;
+
+    pthread_mutex_lock(&MicEncoderMutex);
+    if (MicEncoder == NULL) {
+        pthread_mutex_unlock(&MicEncoderMutex);
+        (*env)->ReleaseShortArrayElements(env, pcmData, samples, JNI_ABORT);
+        return -1;
+    }
+
+    if (ensureMicSampleCapacityLocked(MicSampleBufferCount + requestedSamples) != 0) {
+        pthread_mutex_unlock(&MicEncoderMutex);
+        (*env)->ReleaseShortArrayElements(env, pcmData, samples, JNI_ABORT);
+        return -1;
+    }
+
+    memcpy(MicSampleBuffer + MicSampleBufferCount, samples, requestedSamples * sizeof(opus_int16));
+    MicSampleBufferCount += requestedSamples;
+    if (MicSampleBufferCount > MIC_MAX_BUFFERED_SAMPLES) {
+        const size_t trimSamples = MicSampleBufferCount - MIC_MAX_BUFFERED_SAMPLES;
+        memmove(MicSampleBuffer,
+                MicSampleBuffer + trimSamples,
+                (MicSampleBufferCount - trimSamples) * sizeof(opus_int16));
+        MicSampleBufferCount = MIC_MAX_BUFFERED_SAMPLES;
+    }
+    pthread_cond_signal(&MicEncoderCond);
+    pthread_mutex_unlock(&MicEncoderMutex);
+
+    (*env)->ReleaseShortArrayElements(env, pcmData, samples, JNI_ABORT);
+    return sampleCount;
+}
+
 JNIEXPORT jint JNICALL
 Java_com_limelight_nvstream_jni_MoonBridge_startConnection(JNIEnv *env, jclass clazz,
                                                            jstring address, jstring appVersion, jstring gfeVersion,
@@ -461,7 +789,8 @@ Java_com_limelight_nvstream_jni_MoonBridge_startConnection(JNIEnv *env, jclass c
                                                            jint clientRefreshRateX100,
                                                            jbyteArray riAesKey, jbyteArray riAesIv,
                                                            jint videoCapabilities,
-                                                           jint colorSpace, jint colorRange) {
+                                                           jint colorSpace, jint colorRange,
+                                                           jboolean enableMicrophone) {
     SERVER_INFORMATION serverInfo = {
             .address = (*env)->GetStringUTFChars(env, address, 0),
             .serverInfoAppVersion = (*env)->GetStringUTFChars(env, appVersion, 0),
@@ -479,7 +808,8 @@ Java_com_limelight_nvstream_jni_MoonBridge_startConnection(JNIEnv *env, jclass c
             .audioConfiguration = audioConfiguration,
             .supportedVideoFormats = supportedVideoFormats,
             .clientRefreshRateX100 = clientRefreshRateX100,
-            .encryptionFlags = ENCFLG_AUDIO,
+            .enableMic = enableMicrophone,
+            .encryptionFlags = ENCFLG_AUDIO | (enableMicrophone ? ENCFLG_MICROPHONE : 0),
             .colorSpace = colorSpace,
             .colorRange = colorRange
     };

--- a/app/src/main/res/layout/preference_microphone_preview_widget.xml
+++ b/app/src/main/res/layout/preference_microphone_preview_widget.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="140dp"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="8dp"
+    android:paddingEnd="0dp">
+
+    <ProgressBar
+        android:id="@+id/microphone_preview_bar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="8dp"
+        android:max="100"
+        android:progress="0" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,6 +218,26 @@
     <string name="summary_audio_config_list">Enable 5.1 or 7.1 surround sound for home-theater systems</string>
     <string name="title_checkbox_enable_audiofx">Enable system equalizer support</string>
     <string name="summary_checkbox_enable_audiofx">Allows audio effects to function while streaming, but may increase audio latency</string>
+    <string name="title_checkbox_enable_microphone">Enable microphone streaming</string>
+    <string name="summary_checkbox_enable_microphone">Streams your microphone audio to the host PC when the host supports microphone passthrough.</string>
+    <string name="title_microphone_device_list">Microphone input device</string>
+    <string name="summary_microphone_device_list">Choose which local microphone Artemis captures. Leave this on the default option to follow your system input device.</string>
+    <string name="microphone_device_default">Default system microphone</string>
+    <string name="title_microphone_preview">Microphone input preview</string>
+    <string name="microphone_preview_inactive">Microphone preview inactive</string>
+    <string name="microphone_preview_permission_required">Microphone permission is required</string>
+    <string name="microphone_preview_signal_detected">Input detected on the selected microphone.</string>
+    <string name="microphone_preview_signal_missing">No microphone input detected yet.</string>
+    <string name="microphone_preview_selected_missing">Selected microphone unavailable, previewing the system default input</string>
+    <string name="microphone_preview_default_active">Previewing the default microphone input</string>
+    <string name="microphone_preview_selected_active">Previewing the selected microphone input</string>
+    <string name="microphone_preview_open_failed">Microphone preview unavailable: could not open the selected input</string>
+    <string name="microphone_encoder_setup_failed">Unable to prepare the microphone encoder</string>
+    <string name="microphone_capture_start_failed">Unable to start microphone capture</string>
+    <string name="microphone_permission_denied">Microphone permission denied</string>
+    <string name="microphone_host_not_negotiated">Host did not negotiate microphone streaming; leaving client microphone disabled</string>
+    <string name="microphone_stream_permission_revoked">Microphone capture skipped because RECORD_AUDIO permission is not granted</string>
+    <string name="microphone_stream_start_failed">Unable to start local microphone capture; continuing without microphone input</string>
 
     <string name="category_gamepad_settings">Gamepad Settings</string>
     <string name="title_checkbox_multi_controller">Automatic gamepad presence detection</string>
@@ -726,6 +746,18 @@
     <string name="title_low_latency_frame_balance">LFR (Experimental)</string>
     <string name="summary_low_latency_frame_balance">Minimizes delay by dropping queued frames.</string>
     <string name="category_perf_monitor_settings">Performance Monitor</string>
+    <string name="category_perf_charts">Performance Charts</string>
+    <string name="desc_chart_latency">Network latency chart</string>
+    <string name="desc_chart_decode">Decode time chart</string>
+    <string name="desc_chart_fps">FPS chart</string>
+    <string name="title_enable_perf_charts">Enable performance charts</string>
+    <string name="summary_enable_perf_charts">Show performance charts in the in-game overlay.</string>
+    <string name="title_perf_chart_latency">Chart: Network latency</string>
+    <string name="summary_perf_chart_latency">Show average network latency in milliseconds.</string>
+    <string name="title_perf_chart_decode">Chart: Decode time</string>
+    <string name="summary_perf_chart_decode">Show frame decode time in milliseconds.</string>
+    <string name="title_perf_chart_fps">Chart: FPS</string>
+    <string name="summary_perf_chart_fps">Show incoming and rendered frames per second.</string>
 
     <string name="title_checkbox_full_screen">Enable Full Screen</string>
     <string name="summary_checkbox_full_screen">Hide system bars with immersive mode</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -236,6 +236,23 @@
             android:summary="@string/summary_checkbox_enable_audiofx"
             android:title="@string/title_checkbox_enable_audiofx"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="checkbox_enable_microphone"
+            android:summary="@string/summary_checkbox_enable_microphone"
+            android:title="@string/title_checkbox_enable_microphone"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:defaultValue="0"
+            android:dependency="checkbox_enable_microphone"
+            android:key="list_microphone_device"
+            android:summary="@string/summary_microphone_device_list"
+            android:title="@string/title_microphone_device_list"
+            app:iconSpaceReserved="false" />
+        <com.limelight.preferences.MicrophonePreviewPreference
+            android:key="microphone_preview"
+            android:title="@string/title_microphone_preview"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/test/java/com/limelight/nvstream/NvConnectionMicrophoneTest.java
+++ b/app/src/test/java/com/limelight/nvstream/NvConnectionMicrophoneTest.java
@@ -1,0 +1,67 @@
+package com.limelight.nvstream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.limelight.nvstream.http.ComputerDetails;
+import com.limelight.nvstream.jni.MoonBridge;
+import com.limelight.shadows.ShadowMoonBridge;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import javax.crypto.spec.SecretKeySpec;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33, shadows = {ShadowMoonBridge.class})
+public class NvConnectionMicrophoneTest {
+
+    @Before
+    public void setUp() {
+        ShadowMoonBridge.reset();
+    }
+
+    @Test
+    public void startBridgeConnectionForwardsEnabledMicrophoneFlag() {
+        ConnectionContext context = createConnectionContext(true);
+
+        int result = NvConnection.startBridgeConnection(context, new byte[16], null, null, null);
+
+        assertEquals(0, result);
+        assertTrue(ShadowMoonBridge.lastStartConnectionEnableMicrophone);
+    }
+
+    @Test
+    public void startBridgeConnectionForwardsDisabledMicrophoneFlag() {
+        ConnectionContext context = createConnectionContext(false);
+
+        int result = NvConnection.startBridgeConnection(context, new byte[16], null, null, null);
+
+        assertEquals(0, result);
+        assertFalse(ShadowMoonBridge.lastStartConnectionEnableMicrophone);
+    }
+
+    private static ConnectionContext createConnectionContext(boolean enableMicrophone) {
+        ConnectionContext context = new ConnectionContext();
+        context.serverAddress = new ComputerDetails.AddressTuple("127.0.0.1", 47984);
+        context.serverAppVersion = "1.0.0.0";
+        context.serverGfeVersion = "1.0.0.0";
+        context.rtspSessionUrl = "rtsp://127.0.0.1";
+        context.serverCodecModeSupport = 0;
+        context.negotiatedWidth = 1920;
+        context.negotiatedHeight = 1080;
+        context.negotiatedPacketSize = 1024;
+        context.negotiatedRemoteStreaming = StreamConfiguration.STREAM_CFG_LOCAL;
+        context.videoCapabilities = 0;
+        context.riKey = new SecretKeySpec(new byte[16], "AES");
+        context.streamConfig = new StreamConfiguration.Builder()
+                .setAudioConfiguration(new MoonBridge.AudioConfiguration(2, 0x3))
+                .setEnableMicrophone(enableMicrophone)
+                .build();
+        return context;
+    }
+}

--- a/app/src/test/java/com/limelight/nvstream/StreamConfigurationTest.java
+++ b/app/src/test/java/com/limelight/nvstream/StreamConfigurationTest.java
@@ -1,0 +1,32 @@
+package com.limelight.nvstream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.limelight.shadows.ShadowMoonBridge;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33, shadows = {ShadowMoonBridge.class})
+public class StreamConfigurationTest {
+
+    @Test
+    public void microphoneFlagDefaultsDisabled() {
+        StreamConfiguration config = new StreamConfiguration.Builder().build();
+
+        assertFalse(config.getEnableMicrophone());
+    }
+
+    @Test
+    public void microphoneFlagCanBeEnabled() {
+        StreamConfiguration config = new StreamConfiguration.Builder()
+                .setEnableMicrophone(true)
+                .build();
+
+        assertTrue(config.getEnableMicrophone());
+    }
+}

--- a/app/src/test/java/com/limelight/preferences/PreferenceConfigurationTest.java
+++ b/app/src/test/java/com/limelight/preferences/PreferenceConfigurationTest.java
@@ -1,0 +1,57 @@
+package com.limelight.preferences;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.limelight.shadows.ShadowMoonBridge;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33, shadows = {ShadowMoonBridge.class})
+public class PreferenceConfigurationTest {
+    private Context context;
+    private SharedPreferences prefs;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        prefs.edit().clear().commit();
+    }
+
+    @Test
+    public void readPreferencesLoadsMicrophoneSettings() {
+        prefs.edit()
+                .putBoolean(PreferenceConfiguration.ENABLE_MICROPHONE_PREF_STRING, true)
+                .putString(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, "7")
+                .commit();
+
+        PreferenceConfiguration config = PreferenceConfiguration.readPreferences(context, prefs);
+
+        assertTrue(config.enableMicrophone);
+        assertEquals(7, config.microphoneDeviceId);
+    }
+
+    @Test
+    public void readPreferencesResetsInvalidMicrophoneDeviceSelection() {
+        prefs.edit()
+                .putString(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, "invalid")
+                .commit();
+
+        PreferenceConfiguration config = PreferenceConfiguration.readPreferences(context, prefs);
+
+        assertEquals(0, config.microphoneDeviceId);
+        assertEquals("0", prefs.getString(PreferenceConfiguration.MICROPHONE_DEVICE_PREF_STRING, null));
+    }
+}

--- a/app/src/test/java/com/limelight/shadows/ShadowMoonBridge.java
+++ b/app/src/test/java/com/limelight/shadows/ShadowMoonBridge.java
@@ -1,10 +1,20 @@
 package com.limelight.shadows;
 
+import com.limelight.nvstream.NvConnectionListener;
+import com.limelight.nvstream.av.audio.AudioRenderer;
+import com.limelight.nvstream.av.video.VideoDecoderRenderer;
+
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @Implements(value = com.limelight.nvstream.jni.MoonBridge.class, isInAndroidSdk = false)
 public class ShadowMoonBridge {
+    public static boolean lastStartConnectionEnableMicrophone;
+    public static boolean microphoneStreamActive;
+    public static boolean microphoneEncryptionEnabled;
+    public static int setupMicrophoneEncoderResult;
+    public static int lastQueuedMicrophoneSampleCount;
+    public static boolean microphoneStreamingStarted;
 
     // Static initializer override to prevent System.loadLibrary
     @Implementation
@@ -34,5 +44,82 @@ public class ShadowMoonBridge {
     public static int getPendingAudioDuration() { return 0; }
 
     // stubbed methods used by code but not relevant to unit tests
+    public static void reset() {
+        lastStartConnectionEnableMicrophone = false;
+        microphoneStreamActive = false;
+        microphoneEncryptionEnabled = false;
+        setupMicrophoneEncoderResult = 0;
+        lastQueuedMicrophoneSampleCount = 0;
+        microphoneStreamingStarted = false;
+    }
+
+    @Implementation
+    protected static void init() {
+    }
+
+    @Implementation
+    protected static void setupBridge(VideoDecoderRenderer videoRenderer,
+                                      AudioRenderer audioRenderer,
+                                      NvConnectionListener connectionListener) {
+    }
+
     public static void cleanupBridge() {}
+
+    @Implementation
+    protected static int startConnection(String address, String appVersion, String gfeVersion,
+                                         String rtspSessionUrl, int serverCodecModeSupport,
+                                         int width, int height, int fps,
+                                         int bitrate, int packetSize, int streamingRemotely,
+                                         int audioConfiguration, int supportedVideoFormats,
+                                         int clientRefreshRateX100,
+                                         byte[] riAesKey, byte[] riAesIv,
+                                         int videoCapabilities,
+                                         int colorSpace, int colorRange,
+                                         boolean enableMicrophone) {
+        lastStartConnectionEnableMicrophone = enableMicrophone;
+        return 0;
+    }
+
+    @Implementation
+    protected static void stopConnection() {
+    }
+
+    @Implementation
+    protected static void interruptConnection() {
+    }
+
+    @Implementation
+    protected static boolean isMicrophoneStreamActive() {
+        return microphoneStreamActive;
+    }
+
+    @Implementation
+    protected static boolean isMicrophoneEncryptionEnabled() {
+        return microphoneEncryptionEnabled;
+    }
+
+    @Implementation
+    protected static int setupMicrophoneEncoder(int sampleRate, int channelCount, int bitrate) {
+        return setupMicrophoneEncoderResult;
+    }
+
+    @Implementation
+    protected static void startMicrophoneStreaming() {
+        microphoneStreamingStarted = true;
+    }
+
+    @Implementation
+    protected static void stopMicrophoneStreaming() {
+        microphoneStreamingStarted = false;
+    }
+
+    @Implementation
+    protected static void cleanupMicrophoneEncoder() {
+    }
+
+    @Implementation
+    protected static int queueMicrophonePcm(short[] pcmData, int sampleCount) {
+        lastQueuedMicrophoneSampleCount = sampleCount;
+        return sampleCount;
+    }
 }


### PR DESCRIPTION
## Summary
Ports microphone streaming support from my Moonlight mic forks into Artemis Android so the client can capture microphone audio locally and stream it to Apollo-compatible hosts.

This is intended to work with [ClassicOldSong/Apollo#1428](https://github.com/ClassicOldSong/Apollo/pull/1428).

## Dependency
This draft depends on the companion `moonlight-common-c` PR:
- [ClassicOldSong/moonlight-common-c#1](https://github.com/ClassicOldSong/moonlight-common-c/pull/1)

The current branch keeps the submodule URL pointed at my fork so the Android branch can be checked out and tested immediately. Once the common-c PR lands, I can rebase this PR back onto the upstream submodule URL and commit.

## User-facing changes
- add a microphone enable toggle in stream settings
- request `RECORD_AUDIO` when microphone capture is enabled
- add microphone input device selection on Android M+
- add a live microphone preview meter in settings
- fall back to the default microphone if a saved input device disappears
- start and stop microphone capture with the stream lifecycle

## Implementation
- thread `enableMicrophone` through `Game` -> `StreamConfiguration` -> `NvConnection` -> `MoonBridge`
- add JNI/native microphone setup, PCM queueing, streaming, and teardown
- capture `48 kHz` mono PCM16 with `AudioRecord`
- encode and send Opus microphone frames through `moonlight-common-c`
- add Robolectric coverage for microphone preference persistence and `MoonBridge` forwarding
- improve preview sensitivity and deduplicate repeated Android input device entries seen on some tablets

## Source forks
- Android branch: [logabell/moonlight-android:codex/mic-android](https://github.com/logabell/moonlight-android/tree/codex/mic-android)
- common-c branch: [logabell/moonlight-common-c:codex/mic-common-c](https://github.com/logabell/moonlight-common-c/tree/codex/mic-common-c)
- reference Qt client fork: [logabell/moonlight-qt-mic](https://github.com/logabell/moonlight-qt-mic)

## Testing
Focused verification completed on my fork:
- `:app:assembleNonRoot_gameDebug`
- `NvConnectionMicrophoneTest`
- `StreamConfigurationTest`
- `PreferenceConfigurationTest`

A test build is available via Obtainium from my fork:
- repo: [logabell/moonlight-android](https://github.com/logabell/moonlight-android)
- release: [v20.2.6-mic-test2](https://github.com/logabell/moonlight-android/releases/tag/v20.2.6-mic-test2)

On device, Obtainium can be pointed at the fork repo above to install the published `arm64-v8a` debug APK for manual validation. The test build uses the `Artemis-mic` app label so it can be installed alongside an existing Artemis install.