### PR TITLE
Fix Joy-Con preference looking for the wrong key

### DIFF
--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -948,7 +948,7 @@ private static int getFramePacingValue(Context context) {
 
         config.enableKeyboardVibrate = prefs.getBoolean(CHECKBOX_ENABLE_KEYBOARD_VIBRATE,false);
         //兼容joycon手柄
-        config.enableJoyConFix = prefs.getBoolean("checkbox_joycon_fix",false);
+        config.enableJoyConFix = prefs.getBoolean("checkbox_enable_joyconfix",false);
         //全键盘透明度
         config.oscKeyboardOpacity = prefs.getInt("seekbar_keyboard_axi_opacity",DEFAULT_OPACITY);
 


### PR DESCRIPTION
**Issue:** Currently the joycon fix setting is always false=>Joycons may not work properly
Currently `preferences.xml`  defines the key for the setting as `android:key="checkbox_enable_joyconfix"` but `PreferenceConfiguration` looks for a different key: `config.enableJoyConFix = prefs.getBoolean("checkbox_joycon_fix",false);`
**Fix:** Make `PreferenceConfiguration` look for the `"checkbox_enable_joyconfix"` key.
Closes #450