### PR TITLE
Add PowerA Pro controller support

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -1399,7 +1399,8 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         // kernel changes (adding hid-nintendo) in Android 11. If we're
         // on anything newer than Pie, just use the built-in mapping.
         if ((context.vendorId == 0x057e && context.productId == 0x2009 && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) || // Switch Pro controller
-                (context.vendorId == 0x0f0d && context.productId == 0x00c1)) { // HORIPAD for Switch
+                (context.vendorId == 0x0f0d && context.productId == 0x00c1) || // HORIPAD for Switch
+                (context.vendorId == 0 && context.productId == 0 && "Lic Pro Controller".equals(context.name))) { //PowerA Pro controller 
             switch (event.getScanCode()) {
                 case 0x130://304
                     return KeyEvent.KEYCODE_BUTTON_A;


### PR DESCRIPTION
Certain official PowerA Pro controllers for the Nintendo Switch lack Android mappings and lack a `vendorId` and `productId` which means its 0. Since they have identical mappings to the regular pro controllers we use its mapping if we have no `vendorId`, no `productId` and the controllers name is `"Lic Pro controller"`.