### PR TITLE
Add foldable display support (Z Fold book-mode trigger panel)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ app/.externalNativeBuild/
 
 # agent files
 AGENTS.md
+
+# Claude Code session data
+.claude/

--- a/FOLDABLE_DEV.md
+++ b/FOLDABLE_DEV.md
@@ -1,0 +1,93 @@
+# Artemis Foldable Fork — Dev Handoff
+
+## Project
+Fork of [ClassicOldSong/moonlight-android](https://github.com/ClassicOldSong/moonlight-android) (Artemis / Moonlight Noir) adding Z Fold foldable display support.
+
+- **Branch:** `artemis-foldable` (tracking `origin/moonlight-noir`)
+- **Package:** `com.limelight`
+- **Build IDs:** debug = `com.limelight.noirdebug`, release = `com.limelight.noir`
+
+---
+
+## What's been implemented
+
+### New files
+| File | Purpose |
+|------|---------|
+| `app/src/main/java/com/limelight/ui/FoldableTriggerView.java` | Custom View — 2×2 grid of L1/L2/R1/R2 buttons, multi-touch, haptic, fires InputListener callback |
+| `app/src/main/java/com/limelight/ui/FoldStateManager.java` | Wraps Jetpack `WindowInfoTracker`, exposes `FoldState.isBookMode()` / `isTableTopMode()` |
+| `app/src/main/res/layout/foldable_trigger_panel.xml` | Layout stub (view is created programmatically) |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `app/build.gradle` | Added `androidx.window:window:1.3.0` + `lifecycle-runtime-ktx:2.8.7` |
+| `app/src/main/java/com/limelight/Game.java` | Integrated fold detection, trigger panel injection, input merging |
+
+### How it works
+1. On `Game.onCreate`, `FoldableTriggerView` is added to `rootView` (hidden).
+2. `FoldStateManager` observes `WindowInfoTracker` — lifecycle-aware, stops on activity stop.
+3. When Z Fold enters **book mode** (hinge vertical): trigger panel slides into right 50% of screen.
+4. L1/R1 send `ControllerPacket.LB_FLAG` / `RB_FLAG`. L2/R2 send analog `0xFF` trigger values.
+5. `sendFoldableTriggerState()` merges foldable flags with existing OSC `ControllerInputContext` and calls `controllerHandler.reportOscState(...)`.
+6. On unfold (flat mode): `releaseAll()` clears any held buttons, panel hides.
+
+---
+
+## Key source locations
+
+```
+app/src/main/java/com/limelight/
+├── Game.java                                      # Main stream activity — foldable wired here
+├── ui/
+│   ├── FoldableTriggerView.java                   # NEW — L1/L2/R1/R2 touch panel
+│   ├── FoldStateManager.java                      # NEW — fold posture observer
+│   ├── StreamContainer.java                       # Stream surface host
+│   └── ExternalControllerView.java                # Key/IME forwarding view
+└── binding/input/
+    ├── ControllerHandler.java                     # reportOscState() — input sink
+    └── virtual_controller/
+        ├── VirtualController.java                 # OSC controller (getControllerInputContext)
+        ├── VirtualControllerElement.java          # EID_LB=4, EID_RB=5, EID_LT=2, EID_RT=3
+        └── VirtualControllerConfigurationLoader.java  # Button layout/positioning
+```
+
+---
+
+## ControllerPacket flags (relevant)
+```java
+ControllerPacket.LB_FLAG   // L1 bumper
+ControllerPacket.RB_FLAG   // R1 bumper
+// L2 / R2 are analog — pass byte value (0x00–0xFF) via leftTrigger / rightTrigger
+```
+
+---
+
+## What's next / TODO
+
+- [ ] **Table-top mode**: when hinge is horizontal (device flat on table, bent), show trigger strip along the bottom half — L1/L2 on left, R1/R2 on right, mirroring a physical controller grip
+- [ ] **Button layout customisation**: allow user to reposition L1/L2/R1/R2 within the panel (same drag-to-move system as existing OSC uses `ControllerMode.MoveButtons`)
+- [ ] **Add more buttons to foldable panel**: D-pad, face buttons (A/B/X/Y) — `FoldableTriggerView` is easy to extend, just add more `RectF` slots and labels
+- [ ] **Hinge angle awareness**: `FoldingFeature.getBounds()` gives the hinge rect — use it to avoid rendering buttons under the physical hinge
+- [ ] **Stream viewport adjustment**: when in book mode, constrain the stream `SurfaceView` to the left half only (currently the stream still renders full-width behind the panel)
+- [ ] **Persist panel preference**: remember if user dismissed panel via a preference key in `PreferenceConfiguration`
+- [ ] **Test on emulator**: Android Studio has a foldable emulator target — use it to test without physical hardware
+
+---
+
+## Build & run
+
+```bash
+# From project root
+./gradlew assembleNonRoot_gameDebug        # fastest debug build
+./gradlew installNonRoot_gameDebug         # build + install to connected device
+```
+
+Flavors: `root` (rooted, API ≤25) and `nonRoot_game` (standard). Use `nonRoot_game` for development.
+
+---
+
+## Reference
+- [Android foldable display modes guide](https://developer.android.com/develop/adaptive-apps/guides/foldables/support-foldable-display-modes)
+- [Jetpack WindowManager `WindowInfoTracker`](https://developer.android.com/reference/androidx/window/layout/WindowInfoTracker)
+- [FoldingFeature API](https://developer.android.com/reference/androidx/window/layout/FoldingFeature)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,6 +182,7 @@ dependencies {
     implementation 'com.google.ai.edge.litert:litert:1.4.0'
     implementation 'com.google.ai.edge.litert:litert-gpu:1.4.0'
     implementation 'org.opencv:opencv:4.12.0'
+    implementation 'androidx.window:window:1.3.0'
 
     // Unit test dependencies
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -41,6 +41,8 @@ import com.limelight.preferences.GlPreferences;
 import com.limelight.preferences.PreferenceConfiguration;
 import com.limelight.profiles.ProfilesManager;
 import com.limelight.ui.ExternalControllerView;
+import com.limelight.ui.FoldableTriggerView;
+import com.limelight.ui.FoldStateManager;
 import com.limelight.ui.GameGestures;
 import com.limelight.ui.StreamContainer;
 import com.limelight.utils.Dialog;
@@ -208,6 +210,14 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private int specialKeyCode = KeyEvent.KEYCODE_UNKNOWN;
     private StreamContainer streamContainer;
     private long synthTouchDownTime = 0;
+
+    // Foldable display support
+    private FoldStateManager foldStateManager;
+    private FoldableTriggerView foldableTriggerView;
+    // Tracks L1/L2/R1/R2 flags contributed by the foldable panel
+    private int foldableTriggerInputMap = 0;
+    private byte foldableLeftTrigger = 0;
+    private byte foldableRightTrigger = 0;
 
     private boolean pendingDrag = false;
     private boolean isDragging = false;
@@ -464,6 +474,26 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         streamContainer.setCommitTextEnabled(prefConfig.enableCommitText);
 
         rootView = streamContainer.getParent();
+
+        // --- Foldable trigger panel setup ---
+        foldableTriggerView = new FoldableTriggerView(this);
+        foldableTriggerView.setVisibility(View.GONE);
+        foldableTriggerView.setInputListener((inputMapDelta, leftTrigger, rightTrigger) -> {
+            foldableTriggerInputMap = inputMapDelta;
+            foldableLeftTrigger = leftTrigger;
+            foldableRightTrigger = rightTrigger;
+            sendFoldableTriggerState();
+        });
+        FrameLayout.LayoutParams triggerParams = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+        );
+        ((FrameLayout) rootView).addView(foldableTriggerView, triggerParams);
+
+        foldStateManager = new FoldStateManager(this);
+        foldStateManager.setListener(state -> runOnUiThread(() -> onFoldStateChanged(state)));
+        foldStateManager.startObserving();
+        // --- End foldable setup ---
 
         //串流画面 顶部居中显示
         if(prefConfig.alignDisplayTopCenter){
@@ -1102,6 +1132,49 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         virtualController = new VirtualController(controllerHandler, (FrameLayout)rootView, this);
         virtualController.refreshLayout();
         virtualController.show();
+    }
+
+    /**
+     * Called on the UI thread whenever the fold/hinge state changes.
+     * Shows the trigger panel in book mode, hides it otherwise.
+     */
+    private void onFoldStateChanged(FoldStateManager.FoldState state) {
+        if (foldableTriggerView == null) return;
+
+        if (state.isBookMode()) {
+            // Book mode: right half of the inner display becomes the trigger panel.
+            // Position it on the right 50% of the screen.
+            int screenW = ((FrameLayout) rootView).getWidth();
+            int screenH = ((FrameLayout) rootView).getHeight();
+            FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(screenW / 2, screenH);
+            lp.gravity = Gravity.END;
+            foldableTriggerView.setLayoutParams(lp);
+            foldableTriggerView.setVisibility(View.VISIBLE);
+        } else {
+            foldableTriggerView.releaseAll();
+            foldableTriggerView.setVisibility(View.GONE);
+        }
+    }
+
+    /**
+     * Merges foldable panel button state into the VirtualController's input context and sends it.
+     * Called from the FoldableTriggerView input listener (already on UI thread via lambda).
+     */
+    private void sendFoldableTriggerState() {
+        if (virtualController == null || controllerHandler == null) return;
+        VirtualController.ControllerInputContext ctx = virtualController.getControllerInputContext();
+
+        // Merge foldable flags in — the existing OSC buttons remain active alongside
+        int mergedMap = ctx.inputMap | foldableTriggerInputMap;
+        byte mergedLT = (byte) Math.max(ctx.leftTrigger & 0xFF, foldableLeftTrigger & 0xFF);
+        byte mergedRT = (byte) Math.max(ctx.rightTrigger & 0xFF, foldableRightTrigger & 0xFF);
+
+        controllerHandler.reportOscState(
+                mergedMap,
+                ctx.leftStickX, ctx.leftStickY,
+                ctx.rightStickX, ctx.rightStickY,
+                mergedLT, mergedRT
+        );
     }
 
     private void initkeyBoardLayoutController(){

--- a/app/src/main/java/com/limelight/ui/FoldStateManager.java
+++ b/app/src/main/java/com/limelight/ui/FoldStateManager.java
@@ -1,0 +1,124 @@
+package com.limelight.ui;
+
+import android.app.Activity;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.content.ContextCompat;
+import androidx.window.layout.FoldingFeature;
+import androidx.window.layout.WindowInfoTracker;
+import androidx.window.layout.WindowInfoTrackerCallbackAdapter;
+import androidx.window.layout.WindowLayoutInfo;
+
+/**
+ * Observes foldable display state via Jetpack WindowManager and notifies a listener
+ * when the device enters or exits table-top / book posture.
+ */
+public class FoldStateManager {
+
+    public enum FoldPosture {
+        FLAT,
+        HALF_OPEN,
+        UNKNOWN
+    }
+
+    public enum Orientation {
+        HORIZONTAL,
+        VERTICAL,
+        UNKNOWN
+    }
+
+    public static class FoldState {
+        public final FoldPosture posture;
+        public final Orientation orientation;
+        public final boolean isSeparating;
+
+        FoldState(FoldPosture posture, Orientation orientation, boolean isSeparating) {
+            this.posture = posture;
+            this.orientation = orientation;
+            this.isSeparating = isSeparating;
+        }
+
+        /** True when the device is in book mode (hinge vertical, side-by-side panels). */
+        public boolean isBookMode() {
+            return posture == FoldPosture.HALF_OPEN && orientation == Orientation.VERTICAL;
+        }
+
+        /** True when the device is in table-top mode (hinge horizontal, top/bottom panels). */
+        public boolean isTableTopMode() {
+            return posture == FoldPosture.HALF_OPEN && orientation == Orientation.HORIZONTAL;
+        }
+    }
+
+    public interface FoldStateListener {
+        void onFoldStateChanged(FoldState state);
+    }
+
+    private final Activity activity;
+    private FoldStateListener listener;
+
+    public FoldStateManager(Activity activity) {
+        this.activity = activity;
+    }
+
+    public void setListener(FoldStateListener listener) {
+        this.listener = listener;
+    }
+
+    /**
+     * Start observing fold state. Must be called after the activity reaches STARTED.
+     * Observations stop automatically when the activity is stopped.
+     * No-op on API < 24 (foldable hardware requires API 29+ in practice).
+     */
+    public void startObserving() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            startObservingImpl();
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private void startObservingImpl() {
+        WindowInfoTrackerCallbackAdapter adapter =
+                new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.getOrCreate(activity));
+        adapter.addWindowLayoutInfoListener(
+                activity,
+                ContextCompat.getMainExecutor(activity),
+                this::onWindowLayoutInfo
+        );
+    }
+
+    private void onWindowLayoutInfo(WindowLayoutInfo info) {
+        if (listener != null) {
+            listener.onFoldStateChanged(parseFoldState(info));
+        }
+    }
+
+    private FoldState parseFoldState(WindowLayoutInfo info) {
+        for (androidx.window.layout.DisplayFeature feature : info.getDisplayFeatures()) {
+            if (feature instanceof FoldingFeature) {
+                FoldingFeature fold = (FoldingFeature) feature;
+
+                FoldPosture posture;
+                if (fold.getState() == FoldingFeature.State.HALF_OPENED) {
+                    posture = FoldPosture.HALF_OPEN;
+                } else if (fold.getState() == FoldingFeature.State.FLAT) {
+                    posture = FoldPosture.FLAT;
+                } else {
+                    posture = FoldPosture.UNKNOWN;
+                }
+
+                Orientation orientation;
+                if (fold.getOrientation() == FoldingFeature.Orientation.VERTICAL) {
+                    orientation = Orientation.VERTICAL;
+                } else if (fold.getOrientation() == FoldingFeature.Orientation.HORIZONTAL) {
+                    orientation = Orientation.HORIZONTAL;
+                } else {
+                    orientation = Orientation.UNKNOWN;
+                }
+
+                return new FoldState(posture, orientation, fold.isSeparating());
+            }
+        }
+        return new FoldState(FoldPosture.FLAT, Orientation.UNKNOWN, false);
+    }
+}

--- a/app/src/main/java/com/limelight/ui/FoldableTriggerView.java
+++ b/app/src/main/java/com/limelight/ui/FoldableTriggerView.java
@@ -1,0 +1,222 @@
+package com.limelight.ui;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.os.Build;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.limelight.binding.input.virtual_controller.VirtualController;
+import com.limelight.nvstream.input.ControllerPacket;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Foldable panel showing L1/L2/R1/R2 buttons rendered on the right half of a Z Fold screen.
+ * Integrates with VirtualController.ControllerInputContext to send bumper/trigger state.
+ */
+public class FoldableTriggerView extends View {
+
+    public interface InputListener {
+        void onStateChanged(int inputMapDelta, byte leftTrigger, byte rightTrigger);
+    }
+
+    private static final int BTN_L1 = 0;
+    private static final int BTN_L2 = 1;
+    private static final int BTN_R1 = 2;
+    private static final int BTN_R2 = 3;
+    private static final int BTN_COUNT = 4;
+
+    private static final String[] LABELS = {"L1", "L2", "R1", "R2"};
+    // Map each button to its ControllerPacket flag (L2/R2 use analog triggers, not flags)
+    private static final int[] INPUT_FLAGS = {
+        ControllerPacket.LB_FLAG,
+        0, // L2 is analog
+        ControllerPacket.RB_FLAG,
+        0  // R2 is analog
+    };
+
+    private final RectF[] btnRects = new RectF[BTN_COUNT];
+    private final boolean[] pressed = new boolean[BTN_COUNT];
+    // Track which pointer is holding each button
+    private final Map<Integer, Integer> pointerToBtn = new HashMap<>();
+
+    private final Paint bgPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint pressedPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint textPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint borderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+    private InputListener inputListener;
+    private Vibrator vibrator;
+
+    public FoldableTriggerView(Context context) {
+        super(context);
+        init(context);
+    }
+
+    public FoldableTriggerView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
+    private void init(Context context) {
+        vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
+
+        bgPaint.setColor(Color.argb(180, 30, 30, 40));
+        bgPaint.setStyle(Paint.Style.FILL);
+
+        pressedPaint.setColor(Color.argb(220, 70, 130, 200));
+        pressedPaint.setStyle(Paint.Style.FILL);
+
+        borderPaint.setColor(Color.argb(200, 120, 160, 220));
+        borderPaint.setStyle(Paint.Style.STROKE);
+        borderPaint.setStrokeWidth(4f);
+
+        textPaint.setColor(Color.WHITE);
+        textPaint.setStyle(Paint.Style.FILL);
+        textPaint.setTextAlign(Paint.Align.CENTER);
+
+        for (int i = 0; i < BTN_COUNT; i++) {
+            btnRects[i] = new RectF();
+        }
+    }
+
+    public void setInputListener(InputListener listener) {
+        this.inputListener = listener;
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldW, int oldH) {
+        super.onSizeChanged(w, h, oldW, oldH);
+        layoutButtons(w, h);
+    }
+
+    private void layoutButtons(int w, int h) {
+        // Left column: L1 (top), L2 (bottom)
+        // Right column: R1 (top), R2 (bottom)
+        float pad = w * 0.06f;
+        float colW = (w - pad * 3) / 2f;
+        float rowH = (h - pad * 3) / 2f;
+
+        textPaint.setTextSize(Math.min(colW, rowH) * 0.3f);
+
+        // L1
+        btnRects[BTN_L1].set(pad, pad, pad + colW, pad + rowH);
+        // L2
+        btnRects[BTN_L2].set(pad, pad * 2 + rowH, pad + colW, pad * 2 + rowH * 2);
+        // R1
+        btnRects[BTN_R1].set(pad * 2 + colW, pad, pad * 2 + colW * 2, pad + rowH);
+        // R2
+        btnRects[BTN_R2].set(pad * 2 + colW, pad * 2 + rowH, pad * 2 + colW * 2, pad * 2 + rowH * 2);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        for (int i = 0; i < BTN_COUNT; i++) {
+            canvas.drawRoundRect(btnRects[i], 20f, 20f, pressed[i] ? pressedPaint : bgPaint);
+            canvas.drawRoundRect(btnRects[i], 20f, 20f, borderPaint);
+            canvas.drawText(
+                LABELS[i],
+                btnRects[i].centerX(),
+                btnRects[i].centerY() - (textPaint.descent() + textPaint.ascent()) / 2f,
+                textPaint
+            );
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        int action = event.getActionMasked();
+        int pointerIdx = event.getActionIndex();
+        int pointerId = event.getPointerId(pointerIdx);
+
+        switch (action) {
+            case MotionEvent.ACTION_DOWN:
+            case MotionEvent.ACTION_POINTER_DOWN: {
+                float x = event.getX(pointerIdx);
+                float y = event.getY(pointerIdx);
+                int btn = hitTest(x, y);
+                if (btn >= 0) {
+                    pointerToBtn.put(pointerId, btn);
+                    setPressed(btn, true);
+                }
+                break;
+            }
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_POINTER_UP:
+            case MotionEvent.ACTION_CANCEL: {
+                Integer btn = pointerToBtn.remove(pointerId);
+                if (btn != null) {
+                    setPressed(btn, false);
+                }
+                break;
+            }
+        }
+        return true;
+    }
+
+    private int hitTest(float x, float y) {
+        for (int i = 0; i < BTN_COUNT; i++) {
+            if (btnRects[i].contains(x, y)) return i;
+        }
+        return -1;
+    }
+
+    private void setPressed(int btn, boolean down) {
+        if (pressed[btn] == down) return;
+        pressed[btn] = down;
+        invalidate();
+
+        if (down) {
+            haptic();
+        }
+
+        notifyListener();
+    }
+
+    private void haptic() {
+        if (vibrator == null) return;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator.vibrate(VibrationEffect.createOneShot(30, VibrationEffect.DEFAULT_AMPLITUDE));
+        } else {
+            vibrator.vibrate(30);
+        }
+    }
+
+    private void notifyListener() {
+        if (inputListener == null) return;
+
+        int inputMapDelta = 0;
+        for (int i = 0; i < BTN_COUNT; i++) {
+            if (pressed[i] && INPUT_FLAGS[i] != 0) {
+                inputMapDelta |= INPUT_FLAGS[i];
+            }
+        }
+
+        // L2 = index 1, R2 = index 3 — use full analog value when pressed
+        byte leftTrigger  = pressed[BTN_L2] ? (byte) 0xFF : 0;
+        byte rightTrigger = pressed[BTN_R2] ? (byte) 0xFF : 0;
+
+        inputListener.onStateChanged(inputMapDelta, leftTrigger, rightTrigger);
+    }
+
+    /** Reset all buttons (e.g. when panel hides so we don't leave stuck inputs). */
+    public void releaseAll() {
+        boolean changed = false;
+        for (int i = 0; i < BTN_COUNT; i++) {
+            if (pressed[i]) { pressed[i] = false; changed = true; }
+        }
+        pointerToBtn.clear();
+        if (changed) {
+            invalidate();
+            notifyListener();
+        }
+    }
+}

--- a/app/src/main/res/layout/foldable_trigger_panel.xml
+++ b/app/src/main/res/layout/foldable_trigger_panel.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Inserted into activity_game root when book-mode fold is detected.
+     The stream already occupies the left half via its own SurfaceView;
+     this panel floats over the right half showing L1/L2/R1/R2. -->
+<com.limelight.ui.FoldableTriggerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/foldableTriggerPanel"
+    android:layout_width="0dp"
+    android:layout_height="match_parent"
+    android:layout_weight="1"
+    android:background="#CC1A1A2E"
+    android:visibility="gone"
+    android:elevation="100dp" />


### PR DESCRIPTION
- FoldStateManager: wraps Jetpack WindowInfoTrackerCallbackAdapter to detect book/table-top posture; lifecycle-safe, no-op on API < 24
- FoldableTriggerView: custom View with L1/L2/R1/R2 multi-touch buttons, haptic feedback, and InputListener callback
- Game: injects trigger panel into rootView, shows/hides on fold state change, merges bumper/trigger state with existing OSC input context