### PR TITLE
Add Right Alt+C/V → Cmd+C/V mapping for Mac streaming

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -199,6 +199,8 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     private InputCaptureProvider inputCaptureProvider;
     private int modifierFlags = 0;
+    private boolean rightAltHeld = false;
+    private short altCVInterceptedKey = 0;
     private boolean grabbedInput = true;
     private boolean cursorVisible = false;
     private boolean isPanZoomMode = false;
@@ -1905,6 +1907,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         else if (androidKeyCode == KeyEvent.KEYCODE_ALT_LEFT ||
                 androidKeyCode == KeyEvent.KEYCODE_ALT_RIGHT) {
             modifierMask = KeyboardPacket.MODIFIER_ALT;
+            if (androidKeyCode == KeyEvent.KEYCODE_ALT_RIGHT) {
+                rightAltHeld = down;
+            }
         }
         else if (androidKeyCode == KeyEvent.KEYCODE_META_LEFT ||
                 androidKeyCode == KeyEvent.KEYCODE_META_RIGHT) {
@@ -2105,6 +2110,21 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 return true;
             }
 
+            // Alt+C/V → Cmd+C/V for Mac: cancel the pending Alt and send Command instead
+            int translatedVk = translated & 0xFF;
+            if (prefConfig.altCVAsMacCopy &&
+                    rightAltHeld &&
+                    (translatedVk == KeyboardTranslator.VK_C || translatedVk == KeyboardTranslator.VK_V)) {
+                byte noAltModifier = (byte) (modifierFlags & ~KeyboardPacket.MODIFIER_ALT);
+                // Cancel whichever Alt key Sunshine has held — send both UP to cover left and right
+                conn.sendKeyboardInput((short) 0xA4, KeyboardPacket.KEY_UP, noAltModifier, (byte) 0); // VK_LMENU
+                conn.sendKeyboardInput((short) 0xA5, KeyboardPacket.KEY_UP, noAltModifier, (byte) 0); // VK_RMENU
+                modifierFlags &= ~KeyboardPacket.MODIFIER_ALT;
+                sendKeys(new short[]{(short) KeyboardTranslator.VK_LWIN, (short) translatedVk});
+                altCVInterceptedKey = (short) translatedVk;
+                return true;
+            }
+
             conn.sendKeyboardInput(translated, KeyboardPacket.KEY_DOWN, getModifierState(event),
                     keyboardTranslator.hasNormalizedMapping(event.getKeyCode(), deviceId) ? 0 : MoonBridge.SS_KBE_FLAG_NON_NORMALIZED);
         }
@@ -2176,6 +2196,12 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                     int unicodeChar = event.getUnicodeChar();
                     return (unicodeChar & KeyCharacterMap.COMBINING_ACCENT) == 0 && (unicodeChar & KeyCharacterMap.COMBINING_ACCENT_MASK) != 0;
                 }
+            }
+
+            // Consume the key-up for a key whose down was intercepted as Cmd (sendKeys handles release)
+            if (altCVInterceptedKey != 0 && (translated & 0xFF) == altCVInterceptedKey) {
+                altCVInterceptedKey = 0;
+                return true;
             }
 
             conn.sendKeyboardInput(translated, KeyboardPacket.KEY_UP, getModifierState(event),

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -199,8 +199,6 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     private InputCaptureProvider inputCaptureProvider;
     private int modifierFlags = 0;
-    private boolean rightAltHeld = false;
-    private short rightAltCVInterceptedKey = 0;
     private boolean grabbedInput = true;
     private boolean cursorVisible = false;
     private boolean isPanZoomMode = false;
@@ -1906,10 +1904,19 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         }
         else if (androidKeyCode == KeyEvent.KEYCODE_ALT_LEFT ||
                 androidKeyCode == KeyEvent.KEYCODE_ALT_RIGHT) {
-            modifierMask = KeyboardPacket.MODIFIER_ALT;
-            if (androidKeyCode == KeyEvent.KEYCODE_ALT_RIGHT) {
-                rightAltHeld = down;
+            if (prefConfig.rightAltAsMeta && androidKeyCode == KeyEvent.KEYCODE_ALT_RIGHT) {
+                // Remap Right Alt → Command (VK_LWIN) for Mac streaming
+                if (down) {
+                    modifierFlags |= KeyboardPacket.MODIFIER_META;
+                } else {
+                    modifierFlags &= ~KeyboardPacket.MODIFIER_META;
+                }
+                conn.sendKeyboardInput((short) KeyboardTranslator.VK_LWIN,
+                        down ? KeyboardPacket.KEY_DOWN : KeyboardPacket.KEY_UP,
+                        (byte) modifierFlags, (byte) 0);
+                return true;
             }
+            modifierMask = KeyboardPacket.MODIFIER_ALT;
         }
         else if (androidKeyCode == KeyEvent.KEYCODE_META_LEFT ||
                 androidKeyCode == KeyEvent.KEYCODE_META_RIGHT) {
@@ -2014,7 +2021,10 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             modifier |= KeyboardPacket.MODIFIER_CTRL;
         }
         if (event.isAltPressed()) {
-            modifier |= KeyboardPacket.MODIFIER_ALT;
+            // When Right Alt is remapped to Meta, only treat Alt as held if Left Alt is specifically pressed
+            if (!prefConfig.rightAltAsMeta || (event.getMetaState() & KeyEvent.META_ALT_LEFT_ON) != 0) {
+                modifier |= KeyboardPacket.MODIFIER_ALT;
+            }
         }
         if (event.isMetaPressed()) {
             modifier |= KeyboardPacket.MODIFIER_META;
@@ -2110,21 +2120,6 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 return true;
             }
 
-            // Right Alt+C/V → Cmd+C/V for Mac: cancel the pending Right Alt and send Command instead
-            int translatedVk = translated & 0xFF;
-            if (prefConfig.rightAltCVAsMacCopy &&
-                    rightAltHeld &&
-                    (translatedVk == KeyboardTranslator.VK_C || translatedVk == KeyboardTranslator.VK_V)) {
-                byte noAltModifier = (byte) (modifierFlags & ~KeyboardPacket.MODIFIER_ALT);
-                // Cancel whichever Alt key Sunshine has held — send both UP to cover left and right
-                conn.sendKeyboardInput((short) 0xA4, KeyboardPacket.KEY_UP, noAltModifier, (byte) 0); // VK_LMENU
-                conn.sendKeyboardInput((short) 0xA5, KeyboardPacket.KEY_UP, noAltModifier, (byte) 0); // VK_RMENU
-                modifierFlags &= ~KeyboardPacket.MODIFIER_ALT;
-                sendKeys(new short[]{(short) KeyboardTranslator.VK_LWIN, (short) translatedVk});
-                rightAltCVInterceptedKey = (short) translatedVk;
-                return true;
-            }
-
             conn.sendKeyboardInput(translated, KeyboardPacket.KEY_DOWN, getModifierState(event),
                     keyboardTranslator.hasNormalizedMapping(event.getKeyCode(), deviceId) ? 0 : MoonBridge.SS_KBE_FLAG_NON_NORMALIZED);
         }
@@ -2196,12 +2191,6 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                     int unicodeChar = event.getUnicodeChar();
                     return (unicodeChar & KeyCharacterMap.COMBINING_ACCENT) == 0 && (unicodeChar & KeyCharacterMap.COMBINING_ACCENT_MASK) != 0;
                 }
-            }
-
-            // Consume the key-up for a key whose down was intercepted as Cmd (sendKeys handles release)
-            if (rightAltCVInterceptedKey != 0 && (translated & 0xFF) == rightAltCVInterceptedKey) {
-                rightAltCVInterceptedKey = 0;
-                return true;
             }
 
             conn.sendKeyboardInput(translated, KeyboardPacket.KEY_UP, getModifierState(event),

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -200,7 +200,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private InputCaptureProvider inputCaptureProvider;
     private int modifierFlags = 0;
     private boolean rightAltHeld = false;
-    private short altCVInterceptedKey = 0;
+    private short rightAltCVInterceptedKey = 0;
     private boolean grabbedInput = true;
     private boolean cursorVisible = false;
     private boolean isPanZoomMode = false;
@@ -2110,9 +2110,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 return true;
             }
 
-            // Alt+C/V → Cmd+C/V for Mac: cancel the pending Alt and send Command instead
+            // Right Alt+C/V → Cmd+C/V for Mac: cancel the pending Right Alt and send Command instead
             int translatedVk = translated & 0xFF;
-            if (prefConfig.altCVAsMacCopy &&
+            if (prefConfig.rightAltCVAsMacCopy &&
                     rightAltHeld &&
                     (translatedVk == KeyboardTranslator.VK_C || translatedVk == KeyboardTranslator.VK_V)) {
                 byte noAltModifier = (byte) (modifierFlags & ~KeyboardPacket.MODIFIER_ALT);
@@ -2121,7 +2121,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 conn.sendKeyboardInput((short) 0xA5, KeyboardPacket.KEY_UP, noAltModifier, (byte) 0); // VK_RMENU
                 modifierFlags &= ~KeyboardPacket.MODIFIER_ALT;
                 sendKeys(new short[]{(short) KeyboardTranslator.VK_LWIN, (short) translatedVk});
-                altCVInterceptedKey = (short) translatedVk;
+                rightAltCVInterceptedKey = (short) translatedVk;
                 return true;
             }
 
@@ -2199,8 +2199,8 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             }
 
             // Consume the key-up for a key whose down was intercepted as Cmd (sendKeys handles release)
-            if (altCVInterceptedKey != 0 && (translated & 0xFF) == altCVInterceptedKey) {
-                altCVInterceptedKey = 0;
+            if (rightAltCVInterceptedKey != 0 && (translated & 0xFF) == rightAltCVInterceptedKey) {
+                rightAltCVInterceptedKey = 0;
                 return true;
             }
 

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -171,6 +171,12 @@ public class GameMenu implements Game.GameMenuCallbacks {
             options.add(new MenuOption(getString(R.string.game_menu_send_keys_ctrl_v),
                     () -> sendKeys(new short[]{KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_V})));
 
+            options.add(new MenuOption(getString(R.string.game_menu_send_keys_cmd_c),
+                    () -> sendKeys(new short[]{KeyboardTranslator.VK_LWIN, KeyboardTranslator.VK_C})));
+
+            options.add(new MenuOption(getString(R.string.game_menu_send_keys_cmd_v),
+                    () -> sendKeys(new short[]{KeyboardTranslator.VK_LWIN, KeyboardTranslator.VK_V})));
+
             options.add(new MenuOption(getString(R.string.game_menu_send_keys_win),
                     () -> sendKeys(new short[]{KeyboardTranslator.VK_LWIN})));
 

--- a/app/src/main/java/com/limelight/GameMenu.java
+++ b/app/src/main/java/com/limelight/GameMenu.java
@@ -171,12 +171,6 @@ public class GameMenu implements Game.GameMenuCallbacks {
             options.add(new MenuOption(getString(R.string.game_menu_send_keys_ctrl_v),
                     () -> sendKeys(new short[]{KeyboardTranslator.VK_LCONTROL, KeyboardTranslator.VK_V})));
 
-            options.add(new MenuOption(getString(R.string.game_menu_send_keys_cmd_c),
-                    () -> sendKeys(new short[]{KeyboardTranslator.VK_LWIN, KeyboardTranslator.VK_C})));
-
-            options.add(new MenuOption(getString(R.string.game_menu_send_keys_cmd_v),
-                    () -> sendKeys(new short[]{KeyboardTranslator.VK_LWIN, KeyboardTranslator.VK_V})));
-
             options.add(new MenuOption(getString(R.string.game_menu_send_keys_win),
                     () -> sendKeys(new short[]{KeyboardTranslator.VK_LWIN})));
 

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -103,7 +103,7 @@ public class PreferenceConfiguration {
     private static final String CHECKBOX_ENABLE_BATTERY_REPORT = "checkbox_gamepad_enable_battery_report";
     private static final String CHECKBOX_FORCE_QWERTY = "checkbox_force_qwerty";
     private static final String CHECKBOX_BACK_AS_META = "checkbox_back_as_meta";
-    private static final String CHECKBOX_ALT_CV_AS_MAC_COPY = "checkbox_alt_cv_as_mac_copy";
+    private static final String CHECKBOX_RIGHT_ALT_CV_AS_MAC_COPY = "checkbox_right_alt_cv_as_mac_copy";
     private static final String CHECKBOX_IGNORE_SYNTH_EVENTS = "checkbox_ignore_synth_events";
     private static final String CHECKBOX_BACK_AS_GUIDE = "checkbox_back_as_guide";
     private static final String CHECKBOX_SMART_CLIPBOARD_SYNC = "checkbox_smart_clipboard_sync";
@@ -194,7 +194,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_ENABLE_BATTERY_REPORT = true;
     private static final boolean DEFAULT_FORCE_QWERTY = true;
     private static final boolean DEFAULT_SEND_META_ON_PHYSICAL_BACK = false;
-    private static final boolean DEFAULT_ALT_CV_AS_MAC_COPY = false;
+    private static final boolean DEFAULT_RIGHT_ALT_CV_AS_MAC_COPY = false;
     private static final boolean DEFAULT_IGNORE_SYNTH_EVENTS = false;
     private static final boolean DEFAULT_ENABLE_FLOATING_BUTTON = false;
     private static final boolean DEFAULT_BACK_AS_GUIDE = false;
@@ -256,7 +256,7 @@ public class PreferenceConfiguration {
     public boolean enableBatteryReport;
     public boolean forceQwerty;
     public boolean backAsMeta;
-    public boolean altCVAsMacCopy;
+    public boolean rightAltCVAsMacCopy;
     public boolean ignoreSynthEvents;
     public boolean backAsGuide;
     public boolean smartClipboardSync;
@@ -1009,7 +1009,7 @@ private static int getFramePacingValue(Context context) {
         config.enableBatteryReport = prefs.getBoolean(CHECKBOX_ENABLE_BATTERY_REPORT, DEFAULT_GAMEPAD_ENABLE_BATTERY_REPORT);
         config.forceQwerty = prefs.getBoolean(CHECKBOX_FORCE_QWERTY, DEFAULT_FORCE_QWERTY);
         config.backAsMeta = prefs.getBoolean(CHECKBOX_BACK_AS_META, DEFAULT_SEND_META_ON_PHYSICAL_BACK);
-        config.altCVAsMacCopy = prefs.getBoolean(CHECKBOX_ALT_CV_AS_MAC_COPY, DEFAULT_ALT_CV_AS_MAC_COPY);
+        config.rightAltCVAsMacCopy = prefs.getBoolean(CHECKBOX_RIGHT_ALT_CV_AS_MAC_COPY, DEFAULT_RIGHT_ALT_CV_AS_MAC_COPY);
         config.ignoreSynthEvents = prefs.getBoolean(CHECKBOX_IGNORE_SYNTH_EVENTS, DEFAULT_IGNORE_SYNTH_EVENTS);
         config.backAsGuide = prefs.getBoolean(CHECKBOX_BACK_AS_GUIDE, DEFAULT_BACK_AS_GUIDE);
         config.smartClipboardSync = prefs.getBoolean(CHECKBOX_SMART_CLIPBOARD_SYNC, DEFAULT_SMART_CLIPBOARD_SYNC);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -103,6 +103,7 @@ public class PreferenceConfiguration {
     private static final String CHECKBOX_ENABLE_BATTERY_REPORT = "checkbox_gamepad_enable_battery_report";
     private static final String CHECKBOX_FORCE_QWERTY = "checkbox_force_qwerty";
     private static final String CHECKBOX_BACK_AS_META = "checkbox_back_as_meta";
+    private static final String CHECKBOX_ALT_CV_AS_MAC_COPY = "checkbox_alt_cv_as_mac_copy";
     private static final String CHECKBOX_IGNORE_SYNTH_EVENTS = "checkbox_ignore_synth_events";
     private static final String CHECKBOX_BACK_AS_GUIDE = "checkbox_back_as_guide";
     private static final String CHECKBOX_SMART_CLIPBOARD_SYNC = "checkbox_smart_clipboard_sync";
@@ -193,6 +194,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_ENABLE_BATTERY_REPORT = true;
     private static final boolean DEFAULT_FORCE_QWERTY = true;
     private static final boolean DEFAULT_SEND_META_ON_PHYSICAL_BACK = false;
+    private static final boolean DEFAULT_ALT_CV_AS_MAC_COPY = false;
     private static final boolean DEFAULT_IGNORE_SYNTH_EVENTS = false;
     private static final boolean DEFAULT_ENABLE_FLOATING_BUTTON = false;
     private static final boolean DEFAULT_BACK_AS_GUIDE = false;
@@ -254,6 +256,7 @@ public class PreferenceConfiguration {
     public boolean enableBatteryReport;
     public boolean forceQwerty;
     public boolean backAsMeta;
+    public boolean altCVAsMacCopy;
     public boolean ignoreSynthEvents;
     public boolean backAsGuide;
     public boolean smartClipboardSync;
@@ -1006,6 +1009,7 @@ private static int getFramePacingValue(Context context) {
         config.enableBatteryReport = prefs.getBoolean(CHECKBOX_ENABLE_BATTERY_REPORT, DEFAULT_GAMEPAD_ENABLE_BATTERY_REPORT);
         config.forceQwerty = prefs.getBoolean(CHECKBOX_FORCE_QWERTY, DEFAULT_FORCE_QWERTY);
         config.backAsMeta = prefs.getBoolean(CHECKBOX_BACK_AS_META, DEFAULT_SEND_META_ON_PHYSICAL_BACK);
+        config.altCVAsMacCopy = prefs.getBoolean(CHECKBOX_ALT_CV_AS_MAC_COPY, DEFAULT_ALT_CV_AS_MAC_COPY);
         config.ignoreSynthEvents = prefs.getBoolean(CHECKBOX_IGNORE_SYNTH_EVENTS, DEFAULT_IGNORE_SYNTH_EVENTS);
         config.backAsGuide = prefs.getBoolean(CHECKBOX_BACK_AS_GUIDE, DEFAULT_BACK_AS_GUIDE);
         config.smartClipboardSync = prefs.getBoolean(CHECKBOX_SMART_CLIPBOARD_SYNC, DEFAULT_SMART_CLIPBOARD_SYNC);

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -103,7 +103,7 @@ public class PreferenceConfiguration {
     private static final String CHECKBOX_ENABLE_BATTERY_REPORT = "checkbox_gamepad_enable_battery_report";
     private static final String CHECKBOX_FORCE_QWERTY = "checkbox_force_qwerty";
     private static final String CHECKBOX_BACK_AS_META = "checkbox_back_as_meta";
-    private static final String CHECKBOX_RIGHT_ALT_CV_AS_MAC_COPY = "checkbox_right_alt_cv_as_mac_copy";
+    private static final String CHECKBOX_RIGHT_ALT_AS_META = "checkbox_right_alt_as_meta";
     private static final String CHECKBOX_IGNORE_SYNTH_EVENTS = "checkbox_ignore_synth_events";
     private static final String CHECKBOX_BACK_AS_GUIDE = "checkbox_back_as_guide";
     private static final String CHECKBOX_SMART_CLIPBOARD_SYNC = "checkbox_smart_clipboard_sync";
@@ -194,7 +194,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_ENABLE_BATTERY_REPORT = true;
     private static final boolean DEFAULT_FORCE_QWERTY = true;
     private static final boolean DEFAULT_SEND_META_ON_PHYSICAL_BACK = false;
-    private static final boolean DEFAULT_RIGHT_ALT_CV_AS_MAC_COPY = false;
+    private static final boolean DEFAULT_RIGHT_ALT_AS_META = false;
     private static final boolean DEFAULT_IGNORE_SYNTH_EVENTS = false;
     private static final boolean DEFAULT_ENABLE_FLOATING_BUTTON = false;
     private static final boolean DEFAULT_BACK_AS_GUIDE = false;
@@ -256,7 +256,7 @@ public class PreferenceConfiguration {
     public boolean enableBatteryReport;
     public boolean forceQwerty;
     public boolean backAsMeta;
-    public boolean rightAltCVAsMacCopy;
+    public boolean rightAltAsMeta;
     public boolean ignoreSynthEvents;
     public boolean backAsGuide;
     public boolean smartClipboardSync;
@@ -1009,7 +1009,7 @@ private static int getFramePacingValue(Context context) {
         config.enableBatteryReport = prefs.getBoolean(CHECKBOX_ENABLE_BATTERY_REPORT, DEFAULT_GAMEPAD_ENABLE_BATTERY_REPORT);
         config.forceQwerty = prefs.getBoolean(CHECKBOX_FORCE_QWERTY, DEFAULT_FORCE_QWERTY);
         config.backAsMeta = prefs.getBoolean(CHECKBOX_BACK_AS_META, DEFAULT_SEND_META_ON_PHYSICAL_BACK);
-        config.rightAltCVAsMacCopy = prefs.getBoolean(CHECKBOX_RIGHT_ALT_CV_AS_MAC_COPY, DEFAULT_RIGHT_ALT_CV_AS_MAC_COPY);
+        config.rightAltAsMeta = prefs.getBoolean(CHECKBOX_RIGHT_ALT_AS_META, DEFAULT_RIGHT_ALT_AS_META);
         config.ignoreSynthEvents = prefs.getBoolean(CHECKBOX_IGNORE_SYNTH_EVENTS, DEFAULT_IGNORE_SYNTH_EVENTS);
         config.backAsGuide = prefs.getBoolean(CHECKBOX_BACK_AS_GUIDE, DEFAULT_BACK_AS_GUIDE);
         config.smartClipboardSync = prefs.getBoolean(CHECKBOX_SMART_CLIPBOARD_SYNC, DEFAULT_SMART_CLIPBOARD_SYNC);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,8 +391,6 @@
     <string name="game_menu_send_keys_f11">F11</string>
     <string name="game_menu_send_keys_alt_f4">Alt + F4</string>
     <string name="game_menu_send_keys_ctrl_v">Ctrl + V</string>
-    <string name="game_menu_send_keys_cmd_c">Cmd + C (Mac Copy)</string>
-    <string name="game_menu_send_keys_cmd_v">Cmd + V (Mac Paste)</string>
     <string name="game_menu_send_keys_win">Win (Meta)</string>
     <string name="game_menu_send_keys_win_d">Win + D</string>
     <string name="game_menu_send_keys_alt_b">ALT + B</string>
@@ -541,8 +539,8 @@
     <string name="summary_checkbox_force_qwerty">Force use QWERTY keyboard layout.\nRequired by GFE.\nTurn off if you want to use a different keyboard layout.</string>
     <string name="title_checkbox_back_as_meta">Back button as Meta</string>
     <string name="summary_back_as_meta">Send Meta(Win) key on physical back button press.</string>
-    <string name="title_checkbox_alt_cv_as_mac_copy">Right Alt+C/V as Cmd+C/V (Mac)</string>
-    <string name="summary_alt_cv_as_mac_copy">Convert Right Alt+C and Right Alt+V to Command+C and Command+V for Mac streaming. Left Alt is unaffected.</string>
+    <string name="title_checkbox_right_alt_cv_as_mac_copy">Right Alt+C/V as Cmd+C/V (Mac)</string>
+    <string name="summary_right_alt_cv_as_mac_copy">Convert Right Alt+C and Right Alt+V to Command+C and Command+V for Mac streaming. Left Alt is unaffected.</string>
     <string name="title_back_as_guide">Back button as Guide</string>
     <string name="summary_back_as_guide">Send Guide(PS/HOME) button press when Back button is pressed on controllers.</string>
     <string name="title_checkbox_ignore_synth_events">Ignore synthetic events</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -539,8 +539,8 @@
     <string name="summary_checkbox_force_qwerty">Force use QWERTY keyboard layout.\nRequired by GFE.\nTurn off if you want to use a different keyboard layout.</string>
     <string name="title_checkbox_back_as_meta">Back button as Meta</string>
     <string name="summary_back_as_meta">Send Meta(Win) key on physical back button press.</string>
-    <string name="title_checkbox_right_alt_cv_as_mac_copy">Right Alt+C/V as Cmd+C/V (Mac)</string>
-    <string name="summary_right_alt_cv_as_mac_copy">Convert Right Alt+C and Right Alt+V to Command+C and Command+V for Mac streaming. Left Alt is unaffected.</string>
+    <string name="title_checkbox_right_alt_as_meta">Right Alt as Command (Mac)</string>
+    <string name="summary_right_alt_as_meta">Remap Right Alt to the Command key for Mac streaming. Any Right Alt+key combo becomes Command+key. Left Alt is unaffected.</string>
     <string name="title_back_as_guide">Back button as Guide</string>
     <string name="summary_back_as_guide">Send Guide(PS/HOME) button press when Back button is pressed on controllers.</string>
     <string name="title_checkbox_ignore_synth_events">Ignore synthetic events</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,6 +391,8 @@
     <string name="game_menu_send_keys_f11">F11</string>
     <string name="game_menu_send_keys_alt_f4">Alt + F4</string>
     <string name="game_menu_send_keys_ctrl_v">Ctrl + V</string>
+    <string name="game_menu_send_keys_cmd_c">Cmd + C (Mac Copy)</string>
+    <string name="game_menu_send_keys_cmd_v">Cmd + V (Mac Paste)</string>
     <string name="game_menu_send_keys_win">Win (Meta)</string>
     <string name="game_menu_send_keys_win_d">Win + D</string>
     <string name="game_menu_send_keys_alt_b">ALT + B</string>
@@ -539,6 +541,8 @@
     <string name="summary_checkbox_force_qwerty">Force use QWERTY keyboard layout.\nRequired by GFE.\nTurn off if you want to use a different keyboard layout.</string>
     <string name="title_checkbox_back_as_meta">Back button as Meta</string>
     <string name="summary_back_as_meta">Send Meta(Win) key on physical back button press.</string>
+    <string name="title_checkbox_alt_cv_as_mac_copy">Right Alt+C/V as Cmd+C/V (Mac)</string>
+    <string name="summary_alt_cv_as_mac_copy">Convert Right Alt+C and Right Alt+V to Command+C and Command+V for Mac streaming. Left Alt is unaffected.</string>
     <string name="title_back_as_guide">Back button as Guide</string>
     <string name="summary_back_as_guide">Send Guide(PS/HOME) button press when Back button is pressed on controllers.</string>
     <string name="title_checkbox_ignore_synth_events">Ignore synthetic events</string>
@@ -726,6 +730,18 @@
     <string name="title_low_latency_frame_balance">LFR (Experimental)</string>
     <string name="summary_low_latency_frame_balance">Minimizes delay by dropping queued frames.</string>
     <string name="category_perf_monitor_settings">Performance Monitor</string>
+    <string name="category_perf_charts">Performance Charts</string>
+    <string name="desc_chart_latency">Network latency chart</string>
+    <string name="desc_chart_decode">Decode time chart</string>
+    <string name="desc_chart_fps">FPS chart</string>
+    <string name="title_enable_perf_charts">Enable Performance Charts</string>
+    <string name="summary_enable_perf_charts">Display performance charts in the game overlay</string>
+    <string name="title_perf_chart_latency">Chart: Network Latency</string>
+    <string name="summary_perf_chart_latency">Chart of average network latency (ms)</string>
+    <string name="title_perf_chart_decode">Chart: Decode Time</string>
+    <string name="summary_perf_chart_decode">Chart of frame decode time (ms)</string>
+    <string name="title_perf_chart_fps">Chart: FPS</string>
+    <string name="summary_perf_chart_fps">Chart of incoming/rendered frames per second</string>
 
     <string name="title_checkbox_full_screen">Enable Full Screen</string>
     <string name="summary_checkbox_full_screen">Hide system bars with immersive mode</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -464,9 +464,9 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="checkbox_alt_cv_as_mac_copy"
-            android:summary="@string/summary_alt_cv_as_mac_copy"
-            android:title="@string/title_checkbox_alt_cv_as_mac_copy"
+            android:key="checkbox_right_alt_cv_as_mac_copy"
+            android:summary="@string/summary_right_alt_cv_as_mac_copy"
+            android:title="@string/title_checkbox_right_alt_cv_as_mac_copy"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -464,9 +464,9 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="checkbox_right_alt_cv_as_mac_copy"
-            android:summary="@string/summary_right_alt_cv_as_mac_copy"
-            android:title="@string/title_checkbox_right_alt_cv_as_mac_copy"
+            android:key="checkbox_right_alt_as_meta"
+            android:summary="@string/summary_right_alt_as_meta"
+            android:title="@string/title_checkbox_right_alt_as_meta"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -464,6 +464,12 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="checkbox_alt_cv_as_mac_copy"
+            android:summary="@string/summary_alt_cv_as_mac_copy"
+            android:title="@string/title_checkbox_alt_cv_as_mac_copy"
+            app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="checkbox_back_as_guide"
             android:summary="@string/summary_back_as_guide"
             android:title="@string/title_back_as_guide"


### PR DESCRIPTION
## Summary

When streaming to a Mac via Sunshine, the Command key is not directly accessible from Android keyboards. This PR adds a preference that fully remaps the **Right Alt key to Command** for Mac streaming.

- Adds a new opt-in preference **"Right Alt as Command (Mac)"** under keyboard settings (disabled by default)
- When enabled, Right Alt behaves exactly like the Command key — any Right Alt+key combo becomes Command+key (e.g. Right Alt+C = Cmd+C, Right Alt+Z = Cmd+Z, Right Alt+Tab = Cmd+Tab)
- Left Alt is completely unaffected
- International keyboard users (e.g. Polish AltGr combos) are not impacted as the feature is disabled by default
- Fixes a related bug where the `backAsMeta` preference did not update the internal modifier state, causing subsequent keys to miss the Meta modifier

## How it works

When Right Alt is pressed with the preference enabled:
1. `handleSpecialKeys()` intercepts the key event and sends `VK_LWIN` (mapped to Command on macOS by Sunshine) instead of `VK_RMENU`
2. `modifierFlags` is updated with `MODIFIER_META` instead of `MODIFIER_ALT`
3. `getModifierState()` is patched to suppress `MODIFIER_ALT` from Android's key event meta state when Right Alt is the only Alt held, preventing spurious Alt+Command combos from reaching the host

## Files changed

- `Game.java` — Right Alt → Command remapping in `handleSpecialKeys()`, modifier state fix in `getModifierState()`, `backAsMeta` modifier flag fix
- `PreferenceConfiguration.java` — new `rightAltAsMeta` preference field
- `preferences.xml` — new `CheckBoxPreference` entry
- `strings.xml` — new preference title and summary strings
