### PR TITLE
Fix Samsung external display fallback using Presentation surface service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA"/>
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA"/>
     <uses-feature android:glEsVersion="0x00030000" android:required="true" />
@@ -193,7 +195,6 @@
         <activity
             android:name=".Game"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
-            android:noHistory="true"
             android:supportsPictureInPicture="true"
             android:resizeableActivity="true"
             android:enableOnBackInvokedCallback="false"
@@ -224,6 +225,15 @@
         <service
             android:name=".binding.input.driver.UsbDriverService"
             android:label="Usb Driver Service" />
+        <service
+            android:name=".utils.StreamPresentationService"
+            android:label="Stream Presentation Service"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Hosts external-display presentation for streamed video output" />
+        </service>
 
         <activity
             android:name=".HelpActivity"

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -51,6 +51,7 @@ import com.limelight.utils.PerformanceDataTracker;
 import com.limelight.utils.ServerHelper;
 import com.limelight.utils.ShortcutHelper;
 import com.limelight.utils.SpinnerDialog;
+import com.limelight.utils.StreamPresentationService;
 import com.limelight.utils.UiHelper;
 
 import android.annotation.SuppressLint;
@@ -72,12 +73,14 @@ import android.content.res.Configuration;
 import android.graphics.Outline;
 import android.graphics.Point;
 import android.graphics.Rect;
+import android.graphics.Color;
 import android.hardware.display.DisplayManager;
 import android.hardware.input.InputManager;
 import android.media.AudioManager;
 import android.net.ConnectivityManager;
 import android.net.wifi.WifiManager;
 import android.os.Build;
+import android.util.Log;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -103,9 +106,10 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
-import android.widget.ImageButton;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.NotificationManagerCompat;
@@ -209,6 +213,13 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private StreamContainer streamContainer;
     private long synthTouchDownTime = 0;
 
+    private StreamPresentationService streamPresentationService;
+    private boolean boundToPresentationService = false;
+    private android.content.ServiceConnection presentationServiceConnection;
+    private int presentationDisplayId = -1;
+    private boolean inPresentationMode = false;
+    private boolean presentationSessionEnding = false;
+
     private boolean pendingDrag = false;
     private boolean isDragging = false;
     private float lastTouchDownX, lastTouchDownY;
@@ -267,6 +278,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     public static final String EXTRA_VDISPLAY = "VirtualDisplay";
     public static final String EXTRA_SERVER_COMMANDS = "ServerCommands";
     public static final String EXTRA_DISPLAY_ID = "DisplayID";
+    public static final String EXTRA_PRESENTATION_DISPLAY_ID = "PresentationDisplayID";
 
     public static final String CLIPBOARD_IDENTIFIER = "ArtemisStreaming";
 
@@ -396,24 +408,58 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         onExternelDisplay = currentDisplay.getDisplayId() != Display.DEFAULT_DISPLAY;
 
+        presentationDisplayId = getIntent().getIntExtra(EXTRA_PRESENTATION_DISPLAY_ID, -1);
+        inPresentationMode = presentationDisplayId != -1;
+        if (inPresentationMode) {
+            Log.i("MoonlightExtDisplay", "Game entering Presentation fallback mode for display id="
+                    + presentationDisplayId + " (Game activity running on default display, touchpad is host)");
+            currentOrientation = Configuration.ORIENTATION_LANDSCAPE;
+            onExternelDisplay = false;
+        }
+
         boolean shouldInvertDecoderResolution = false;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-                && onExternelDisplay
+                && (onExternelDisplay || inPresentationMode)
                 && prefConfig.renderMode == 0 // For 3D we want to maintain configured resolution
         ) {
-            Display.Mode currentMode = currentDisplay.getMode();
-            displayWidth = currentMode.getPhysicalWidth();
-            displayHeight = currentMode.getPhysicalHeight();
-            prefConfig.width = displayWidth;
-            prefConfig.height = displayHeight;
-            prefConfig.fps = currentMode.getRefreshRate();
-            prefConfig.videoScaleMode = PreferenceConfiguration.ScaleMode.STRETCH;
-            prefConfig.enableFloatingButton = false;
-            prefConfig.showOverlayZoomToggleButton = false;
-            prefConfig.enablePip = false;
+            Display targetForMode = onExternelDisplay ? currentDisplay : null;
+            if (inPresentationMode) {
+                DisplayManager dm = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+                targetForMode = dm != null ? dm.getDisplay(presentationDisplayId) : null;
+            }
+            if (inPresentationMode && targetForMode == null) {
+                Log.w("MoonlightExtDisplay", "Presentation target display id=" + presentationDisplayId + " not found");
+                if (spinner != null) {
+                    spinner.dismiss();
+                    spinner = null;
+                }
+                Toast.makeText(this, R.string.no_external_display, Toast.LENGTH_LONG).show();
+                finish();
+                return;
+            }
+            if (targetForMode != null) {
+                Display.Mode currentMode = targetForMode.getMode();
+                displayWidth = currentMode.getPhysicalWidth();
+                displayHeight = currentMode.getPhysicalHeight();
+                prefConfig.width = displayWidth;
+                prefConfig.height = displayHeight;
+                prefConfig.fps = currentMode.getRefreshRate();
+                prefConfig.videoScaleMode = PreferenceConfiguration.ScaleMode.STRETCH;
+                prefConfig.enableFloatingButton = false;
+                prefConfig.showOverlayZoomToggleButton = false;
+                prefConfig.enablePip = false;
+            }
             currentOrientation = Configuration.ORIENTATION_LANDSCAPE;
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE);
+            if (onExternelDisplay) {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE);
+            } else {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+            }
+            if (inPresentationMode) {
+                Log.i("MoonlightExtDisplay", "Stream target via Presentation: " + displayWidth + "x"
+                        + displayHeight + "@" + prefConfig.fps + "Hz");
+            }
         } else {
             if (prefConfig.renderMode != 0) {
                 prefConfig.videoScaleMode = PreferenceConfiguration.ScaleMode.STRETCH;
@@ -432,7 +478,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             displayHeight = shouldInvertDecoderResolution ? prefConfig.width : prefConfig.height;
 
             // Enter landscape unless we're on a square screen
-            setPreferredOrientationForActivity();
+            if (!inPresentationMode) {
+                setPreferredOrientationForActivity();
+            }
         }
 
 
@@ -600,7 +648,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         // Check if the user has enabled HDR
         boolean willStreamHdr = false;
         if (prefConfig.enableHdr) {
-            if (onExternelDisplay) {
+            if (onExternelDisplay || inPresentationMode) {
                 // Enforce HDR on unsupported hardware can still enable 10bit streaming for better quality
                 willStreamHdr = true;
             } else {
@@ -826,6 +874,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             if (prefConfig.enableFullExDisplay && onExternelDisplay) {
                 requestFocusToExternalDisplayControl(this);
                 listenForExternalDisplayRemoval();
+            } else if (prefConfig.enableFullExDisplay && inPresentationMode) {
+                buildTouchpadOverlay();
+                listenForExternalDisplayRemoval();
             }
 
             // Initialize touch contexts based on preferences
@@ -865,18 +916,16 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         //streamContainer.getHolder().addCallback(this);
 
         streamContainer.setOnSurfaceAvailable(() -> {
-            if (!attemptedConnection) {
-                LimeLog.info("Surface is available, starting connection...");
-                attemptedConnection = true;
-
-                // Der Decoder erhält die jeweils aktive Oberfläche vom Container
-                decoderRenderer.setRenderTarget(streamContainer.getSurface());
-
-                // Starten Sie die NvConnection
-                conn.start(new AndroidAudioRenderer(Game.this, prefConfig.playHostAudio),
-                        decoderRenderer, Game.this);
+            if (inPresentationMode) {
+                return;
             }
+            tryStartStream(streamContainer.getSurface());
         });
+
+        if (inPresentationMode) {
+            streamContainer.setVisibility(View.GONE);
+            bindToStreamPresentationService();
+        }
 
         gameMenuCallbacks = new GameMenu(this);
 
@@ -1032,6 +1081,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private void handleDisplayRemoved() {
         NotificationManagerCompat.from(getBaseContext()).cancel(SECONDARY_SCREEN_NOTIFICATION_ID);
         closeExternalDisplayControl();
+        if (inPresentationMode) {
+            try { stopService(new Intent(this, StreamPresentationService.class)); } catch (Throwable ignored) {}
+        }
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -1120,7 +1172,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     public void toggleFullKeyboard() {
-        if (isOnExternalDisplay()) {
+        if (isOnExternalDisplay() && ExternalDisplayControlActivity.instance != null) {
             ExternalDisplayControlActivity.toggleFullKeyboard();
             return;
         }
@@ -1189,7 +1241,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         super.onConfigurationChanged(newConfig);
 
         // Set requested orientation for possible new screen size
-        setPreferredOrientationForActivity();
+        if (!inPresentationMode) {
+            setPreferredOrientationForActivity();
+        }
 
         if (virtualController != null) {
             // Refresh layout of OSC for possible new screen size
@@ -1370,6 +1424,21 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        if (inPresentationMode && streamPresentationService != null && (connected || conn != null)) {
+            Log.i("MoonlightExtDisplay", "onNewIntent: connection active, dismissing spinner");
+            runOnUiThread(() -> {
+                if (spinner != null) {
+                    spinner.dismiss();
+                    spinner = null;
+                }
+            });
+        }
+    }
+
+    @Override
     public void onUserLeaveHint() {
         super.onUserLeaveHint();
 
@@ -1449,7 +1518,21 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     public boolean isOnExternalDisplay() {
-        return onExternelDisplay;
+        return onExternelDisplay || inPresentationMode;
+    }
+
+    public boolean isInPresentationMode() {
+        return inPresentationMode;
+    }
+
+    private int effectiveStreamWidth() {
+        int width = inPresentationMode ? displayWidth : streamContainer.getWidth();
+        return Math.max(width, 1);
+    }
+
+    private int effectiveStreamHeight() {
+        int height = inPresentationMode ? displayHeight : streamContainer.getHeight();
+        return Math.max(height, 1);
     }
 
     private float prepareDisplayForRendering(Display currentDisplay) {
@@ -1698,6 +1781,148 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         hideSystemUi(50);
     }
 
+    private void tryStartStream(Surface renderTarget) {
+        if (renderTarget == null || !renderTarget.isValid()) {
+            return;
+        }
+        if (!attemptedConnection) {
+            LimeLog.info("Surface is available, starting connection...");
+            attemptedConnection = true;
+            decoderRenderer.setRenderTarget(renderTarget);
+            conn.start(new AndroidAudioRenderer(Game.this, prefConfig.playHostAudio),
+                    decoderRenderer, Game.this);
+        }
+    }
+
+    private void bindToStreamPresentationService() {
+        if (presentationDisplayId == -1) {
+            return;
+        }
+        if (boundToPresentationService) {
+            if (streamPresentationService != null) {
+                streamPresentationService.requestSurface(() -> tryStartStream(streamPresentationService.getSurface()));
+            }
+            return;
+        }
+        Intent svc = new Intent(this, StreamPresentationService.class);
+        svc.putExtra(StreamPresentationService.EXTRA_DISPLAY_ID, presentationDisplayId);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(svc);
+        } else {
+            startService(svc);
+        }
+        presentationServiceConnection = new android.content.ServiceConnection() {
+            @Override
+            public void onServiceConnected(ComponentName name, android.os.IBinder service) {
+                StreamPresentationService.LocalBinder binder = (StreamPresentationService.LocalBinder) service;
+                streamPresentationService = binder.getService();
+                Log.i("MoonlightExtDisplay", "Connected to StreamPresentationService");
+                streamPresentationService.setPresentationStateListener(new StreamPresentationService.PresentationStateListener() {
+                    @Override
+                    public void onPresentationFailure(String reason) {
+                        endPresentationSession("Presentation failed: " + reason);
+                    }
+
+                    @Override
+                    public void onPresentationSurfaceDestroyed() {
+                        endPresentationSession("Presentation surface destroyed");
+                    }
+                });
+                streamPresentationService.requestSurface(() -> tryStartStream(streamPresentationService.getSurface()));
+            }
+
+            @Override
+            public void onServiceDisconnected(ComponentName name) {
+                Log.w("MoonlightExtDisplay", "StreamPresentationService disconnected");
+                streamPresentationService = null;
+            }
+        };
+        Intent bindIntent = new Intent(this, StreamPresentationService.class);
+        bindService(bindIntent, presentationServiceConnection, Context.BIND_AUTO_CREATE);
+        boundToPresentationService = true;
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void buildTouchpadOverlay() {
+        ExternalControllerView rootLayout = new ExternalControllerView(this);
+        rootLayout.setLayoutParams(new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        rootLayout.setFocusable(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) rootLayout.setFocusedByDefault(true);
+        rootLayout.setInputCallbacks(this);
+        rootLayout.setCommitTextEnabled(prefConfig.enableCommitText);
+        rootLayout.setOnTouchListener((v, event) -> { handleMotionEvent(v, event); return true; });
+
+        LinearLayout topLeftHolder = createTouchpadButtonContainer(Gravity.TOP | Gravity.START);
+        topLeftHolder.addView(createTouchpadButton(R.drawable.ic_zoom_toggle,
+                v -> {
+                    if (keyBoardLayoutController != null && keyBoardLayoutController.isKeyboardVisible()) return;
+                    toggleZoomMode();
+                }));
+
+        LinearLayout topRightHolder = createTouchpadButtonContainer(Gravity.TOP | Gravity.END);
+        topRightHolder.addView(createTouchpadButton(R.drawable.ic_menu_external, v -> {
+            if (gameMenuCallbacks != null) gameMenuCallbacks.showMenu(null);
+        }));
+        topRightHolder.addView(createTouchpadButton(R.drawable.ic_close_external, v -> {
+            stopConnection();
+            if (inPresentationMode) {
+                try {
+                    stopService(new Intent(this, StreamPresentationService.class));
+                } catch (Throwable ignored) {}
+            }
+            finish();
+        }));
+
+        LinearLayout bottomLeftHolder = createTouchpadButtonContainer(Gravity.BOTTOM | Gravity.START);
+        bottomLeftHolder.addView(createTouchpadButton(R.drawable.ic_android_keyboard, v -> {
+            InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.toggleSoftInput(0, 0);
+        }));
+
+        LinearLayout bottomRightHolder = createTouchpadButtonContainer(Gravity.BOTTOM | Gravity.END);
+        bottomRightHolder.addView(createTouchpadButton(R.drawable.ic_fullscreen_keyboard, v -> {
+            if (keyBoardLayoutController == null) {
+                keyBoardLayoutController = new KeyBoardLayoutController(rootLayout, Game.this, prefConfig);
+                keyBoardLayoutController.refreshLayout();
+                keyBoardLayoutController.show();
+            } else {
+                keyBoardLayoutController.toggleVisibility();
+            }
+        }));
+
+        rootLayout.addView(topLeftHolder);
+        rootLayout.addView(topRightHolder);
+        rootLayout.addView(bottomLeftHolder);
+        rootLayout.addView(bottomRightHolder);
+
+        ViewGroup root = findViewById(android.R.id.content);
+        root.addView(rootLayout,
+                new FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+    }
+
+    private LinearLayout createTouchpadButtonContainer(int gravity) {
+        LinearLayout l = new LinearLayout(this);
+        l.setOrientation(LinearLayout.HORIZONTAL);
+        l.setGravity(gravity);
+        l.setLayoutParams(new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, gravity));
+        l.setFocusable(false);
+        return l;
+    }
+
+    private ImageButton createTouchpadButton(int resId, View.OnClickListener listener) {
+        ImageButton b = new ImageButton(this);
+        b.setImageResource(resId);
+        b.setBackgroundColor(Color.TRANSPARENT);
+        b.setOnClickListener(listener);
+        float density = getResources().getDisplayMetrics().density;
+        b.setLayoutParams(new LinearLayout.LayoutParams((int)(56*density), (int)(56*density)));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) b.setTooltipText("");
+        return b;
+    }
+
     @Override
     protected void onDestroy() {
         super.onDestroy();
@@ -1706,6 +1931,20 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         timerHandler.removeCallbacksAndMessages(null);
 
         if (prefConfig.enableFullExDisplay) handleDisplayRemoved();
+
+        if (boundToPresentationService) {
+            try {
+                if (presentationServiceConnection != null) {
+                    unbindService(presentationServiceConnection);
+                }
+            } catch (Throwable ignored) {}
+            boundToPresentationService = false;
+            presentationServiceConnection = null;
+            streamPresentationService = null;
+        }
+        if (inPresentationMode) {
+            try { stopService(new Intent(this, StreamPresentationService.class)); } catch (Throwable ignored) {}
+        }
 
         if (controllerHandler != null) {
             controllerHandler.destroy();
@@ -1742,6 +1981,23 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         streamContainer.onDestroy();
     }
 
+    private void endPresentationSession(String reason) {
+        if (presentationSessionEnding || !inPresentationMode || isFinishing()) {
+            return;
+        }
+        presentationSessionEnding = true;
+        Log.w("MoonlightExtDisplay", reason);
+        runOnUiThread(() -> {
+            if (spinner != null) {
+                spinner.dismiss();
+                spinner = null;
+            }
+            try { stopService(new Intent(this, StreamPresentationService.class)); } catch (Throwable ignored) {}
+            stopConnection();
+            finish();
+        });
+    }
+
     @Override
     protected void onPause() {
         if (isFinishing()) {
@@ -1775,7 +2031,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             keyBoardLayoutController.hide();
         }
 
-        if (conn != null) {
+        if (conn != null && (!inPresentationMode || isFinishing())) {
             int videoFormat = decoderRenderer.getActiveVideoFormat();
 
             displayedFailureDialog = true;
@@ -1852,7 +2108,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         }
 
-        finish();
+        if (!inPresentationMode || isFinishing()) {
+            finish();
+        }
     }
 
     public static String formatCurrentTime(long currentTimeMillis) {
@@ -2400,7 +2658,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     @Override
     public void toggleKeyboard() {
-        if (isOnExternalDisplay()) {
+        if (isOnExternalDisplay() && ExternalDisplayControlActivity.instance != null) {
             ExternalDisplayControlActivity.toggleKeyboard();
         } else {
             LimeLog.info("Toggling keyboard overlay");
@@ -2477,11 +2735,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 normalizedY= bean.getLastRelativelyY() +dy;
             }
             if(prefConfig.touchSensitivityRotationAuto){
-                if(normalizedX>= streamContainer.getWidth()){
-                    normalizedX= streamContainer.getWidth()/2.0f;
+                if(normalizedX>= effectiveStreamWidth()){
+                    normalizedX= effectiveStreamWidth()/2.0f;
                 }
-                if(normalizedY>= streamContainer.getHeight()){
-                    normalizedY= streamContainer.getHeight()/2.0f;
+                if(normalizedY>= effectiveStreamHeight()){
+                    normalizedY= effectiveStreamHeight()/2.0f;
                 }
             }
             bean.setLastAbsoluteX(event.getX(pointerIndex));
@@ -2520,11 +2778,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         normalizedX = Math.max(normalizedX, 0.0f);
         normalizedY = Math.max(normalizedY, 0.0f);
 
-        normalizedX = Math.min(normalizedX, streamContainer.getWidth());
-        normalizedY = Math.min(normalizedY, streamContainer.getHeight());
+        normalizedX = Math.min(normalizedX, effectiveStreamWidth());
+        normalizedY = Math.min(normalizedY, effectiveStreamHeight());
 
-        normalizedX /= streamContainer.getWidth();
-        normalizedY /= streamContainer.getHeight();
+        normalizedX /= effectiveStreamWidth();
+        normalizedY /= effectiveStreamHeight();
 
         return new float[] { normalizedX, normalizedY };
     }
@@ -2624,10 +2882,10 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         float[] contactAreaMinorCartesian = polarToCartesian(contactAreaMinor, (float)(orientation + (Math.PI / 2)));
 
         // Normalize the contact area to the stream view size
-        contactAreaMajorCartesian[0] = Math.min(Math.abs(contactAreaMajorCartesian[0]), streamContainer.getWidth()) / streamContainer.getWidth();
-        contactAreaMinorCartesian[0] = Math.min(Math.abs(contactAreaMinorCartesian[0]), streamContainer.getWidth()) / streamContainer.getWidth();
-        contactAreaMajorCartesian[1] = Math.min(Math.abs(contactAreaMajorCartesian[1]), streamContainer.getHeight()) / streamContainer.getHeight();
-        contactAreaMinorCartesian[1] = Math.min(Math.abs(contactAreaMinorCartesian[1]), streamContainer.getHeight()) / streamContainer.getHeight();
+        contactAreaMajorCartesian[0] = Math.min(Math.abs(contactAreaMajorCartesian[0]), effectiveStreamWidth()) / effectiveStreamWidth();
+        contactAreaMinorCartesian[0] = Math.min(Math.abs(contactAreaMinorCartesian[0]), effectiveStreamWidth()) / effectiveStreamWidth();
+        contactAreaMajorCartesian[1] = Math.min(Math.abs(contactAreaMajorCartesian[1]), effectiveStreamHeight()) / effectiveStreamHeight();
+        contactAreaMinorCartesian[1] = Math.min(Math.abs(contactAreaMinorCartesian[1]), effectiveStreamHeight()) / effectiveStreamHeight();
 
         // Convert the normalized values back into polar coordinates
         return new float[] { cartesianToR(contactAreaMajorCartesian), cartesianToR(contactAreaMinorCartesian) };
@@ -2830,7 +3088,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                         if (prefConfig.absoluteMouseMode) {
                             // NB: view may be null, but we can unconditionally use streamView because we don't need to adjust
                             // relative axis deltas for the position of the streamView within the parent's coordinate system.
-                            conn.sendMouseMoveAsMousePosition(deltaX, deltaY, (short) streamContainer.getWidth(), (short) streamContainer.getHeight());
+                            conn.sendMouseMoveAsMousePosition(deltaX, deltaY, (short) effectiveStreamWidth(), (short) effectiveStreamHeight());
                         }
                         else {
                             conn.sendMouseMove(deltaX, deltaY);
@@ -3396,10 +3654,10 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         // Normalize these to the view size. We can't just drop them because we won't always get an event
         // right at the boundary of the view, so dropping them would result in our cursor never really
         // reaching the sides of the screen.
-        eventX = Math.min(Math.max(eventX, 0), streamContainer.getWidth());
-        eventY = Math.min(Math.max(eventY, 0), streamContainer.getHeight());
+        eventX = Math.min(Math.max(eventX, 0), effectiveStreamWidth());
+        eventY = Math.min(Math.max(eventY, 0), effectiveStreamHeight());
 
-        conn.sendMousePosition((short)eventX, (short)eventY, (short) streamContainer.getWidth(), (short) streamContainer.getHeight());
+        conn.sendMousePosition((short)eventX, (short)eventY, (short) effectiveStreamWidth(), (short) effectiveStreamHeight());
     }
 
     @Override
@@ -4004,6 +4262,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     public void rotateScreen() {
+        if (inPresentationMode) return;
         if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE) {
             currentOrientation = Configuration.ORIENTATION_PORTRAIT;
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT);
@@ -4215,6 +4474,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         if (prefConfig.smartClipboardSync) {
             getClipboard(-1);
         }
+        if (inPresentationMode) {
+            try { stopService(new Intent(this, StreamPresentationService.class)); } catch (Throwable ignored) {}
+        }
         finish();
     }
 
@@ -4232,6 +4494,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         builder.setPositiveButton(getString(R.string.yes), (dialog, which) -> {
             quitOnStop = true;
             dialog.dismiss();
+            if (inPresentationMode) {
+                try { stopService(new Intent(this, StreamPresentationService.class)); } catch (Throwable ignored) {}
+            }
             finish();
         });
 
@@ -4243,7 +4508,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     @Override
     public void showGameMenu(GameInputDevice device) {
-        if(isOnExternalDisplay()) {
+        if(isOnExternalDisplay() && ExternalDisplayControlActivity.instance != null) {
             ExternalDisplayControlActivity.toggleGameMenu();
         } else {
             if (gameMenuCallbacks != null) {

--- a/app/src/main/java/com/limelight/ui/StreamContainer.java
+++ b/app/src/main/java/com/limelight/ui/StreamContainer.java
@@ -25,6 +25,11 @@ import com.limelight.utils.Stereo3DRenderer;
  */
 public class StreamContainer extends FrameLayout implements SurfaceHolder.Callback, Stereo3DRenderer.OnSurfaceReadyListener {
 
+    public interface SurfaceAvailableCallback {
+        void onSurfaceAvailable(Surface surface);
+        void onSurfaceDestroyed();
+    }
+
     public interface InputCallbacks {
         boolean handleKeyUp(KeyEvent event);
         boolean handleKeyDown(KeyEvent event);
@@ -46,6 +51,7 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
     private SurfaceView mSurfaceView;
     private Surface mCurrentSurface;
     private Runnable onSurfaceAvailable;
+    private SurfaceAvailableCallback surfaceAvailableCallback;
     private StreamMode renderMode = null;
     private InputCallbacks mInputCallbacks;
     private boolean commitTextEnabled = false;
@@ -66,8 +72,22 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
         if (this.game != null) {
             return;
         }
-
         this.game = game;
+        initInternal(prefConfig);
+    }
+
+    public void setSurfaceAvailableCallback(SurfaceAvailableCallback callback) {
+        this.surfaceAvailableCallback = callback;
+    }
+
+    public void initAsPresentation(PreferenceConfiguration prefConfig) {
+        if (this.prefConfig != null) {
+            return;
+        }
+        initInternal(prefConfig);
+    }
+
+    private void initInternal(PreferenceConfiguration prefConfig) {
         this.prefConfig = prefConfig;
         this.renderMode = mapIntToStreamMode(prefConfig.renderMode);
 
@@ -79,7 +99,7 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
         Context context = getContext();
         LayoutParams childParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
 
-        // Always craete a surface view as a Workaround for the sizing issue of GLSurfaceView
+        // Always create a surface view as a workaround for the sizing issue of GLSurfaceView
         mSurfaceView = new SurfaceView(context);
         addView(mSurfaceView, childParams);
 
@@ -230,11 +250,14 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
         if (onSurfaceAvailable != null) {
             onSurfaceAvailable.run();
         }
+        if (surfaceAvailableCallback != null && mCurrentSurface != null) {
+            surfaceAvailableCallback.onSurfaceAvailable(mCurrentSurface);
+        }
     }
 
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
-        game.surfaceCreated(holder);
+        if (game != null) game.surfaceCreated(holder);
     }
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
@@ -243,7 +266,7 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
             notifySurfaceReady();
         }
 
-        game.surfaceChanged(holder, format, width, height);
+        if (game != null) game.surfaceChanged(holder, format, width, height);
     }
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
@@ -254,7 +277,10 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
             mStereoRenderer.onSurfaceDestroyed();
         }
 
-        game.surfaceDestroyed(holder);
+        if (game != null) game.surfaceDestroyed(holder);
+        if (surfaceAvailableCallback != null) {
+            surfaceAvailableCallback.onSurfaceDestroyed();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/limelight/utils/ExternalDisplayControlActivity.java
+++ b/app/src/main/java/com/limelight/utils/ExternalDisplayControlActivity.java
@@ -19,6 +19,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.view.Display;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -55,6 +56,8 @@ import com.limelight.ui.ExternalControllerView;
  * It creates its own UI programmatically and hosts the GameMenu for in-game options.
  */
 public class ExternalDisplayControlActivity extends AppCompatActivity implements View.OnKeyListener, KeyBoardLayoutController.ViewCallbacks {
+
+    private static final String TAG = "MoonlightExtDisplay";
 
     public static String EXTRA_LAUNCH_INTENT = "launchIntent";
 
@@ -123,20 +126,53 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
                 finish();
             } else {
                 Display secondaryDisplay = getSecondaryDisplay(this);
+                boolean launchedOnSecondary = false;
                 if (secondaryDisplay != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    ActivityOptions options = ActivityOptions.makeBasic();
-                    options.setLaunchDisplayId(secondaryDisplay.getDisplayId());
+                    try {
+                        ActivityOptions options = ActivityOptions.makeBasic();
+                        options.setLaunchDisplayId(secondaryDisplay.getDisplayId());
+                        Toast.makeText(this,
+                                getString(R.string.external_display_info,
+                                        secondaryDisplay.getMode().getPhysicalWidth(),
+                                        secondaryDisplay.getMode().getPhysicalHeight(),
+                                        secondaryDisplay.getMode().getRefreshRate()),
+                                Toast.LENGTH_LONG).show();
+                        startActivity(gameIntent, options.toBundle());
+                        launchedOnSecondary = true;
+                        ServerHelper.setSamsungRestricted(false);
+                    } catch (RuntimeException e) {
+                        Log.w(TAG, "setLaunchDisplayId failed on display id="
+                                + secondaryDisplay.getDisplayId()
+                                + " (likely Samsung Android 16 / One UI 8 restriction). "
+                                + "Falling back to Presentation path: " + e);
+                        ServerHelper.setSamsungRestricted(true);
+                        launchedOnSecondary = false;
+                    }
+                }
+                if (!launchedOnSecondary && secondaryDisplay != null) {
                     Toast.makeText(this,
                             getString(R.string.external_display_info,
                                     secondaryDisplay.getMode().getPhysicalWidth(),
                                     secondaryDisplay.getMode().getPhysicalHeight(),
                                     secondaryDisplay.getMode().getRefreshRate()),
                             Toast.LENGTH_LONG).show();
-
-                    startActivity(gameIntent, options.toBundle());
-                } else {
+                    gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY);
+                    gameIntent.putExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, secondaryDisplay.getDisplayId());
+                    try {
+                        startActivity(gameIntent);
+                        launchedOnSecondary = true;
+                    } catch (RuntimeException e) {
+                        Log.w(TAG, "Fallback startActivity (Presentation path) failed: " + e);
+                    }
+                }
+                if (!launchedOnSecondary) {
                     LimeLog.warning(getString(R.string.no_external_display));
-                    startActivity(gameIntent);
+                    Toast.makeText(this, R.string.no_external_display, Toast.LENGTH_LONG).show();
+                    try {
+                        startActivity(gameIntent);
+                    } catch (RuntimeException e) {
+                        Log.w(TAG, "Starting Game on default display failed: " + e);
+                    }
                     finish();
                 }
             }
@@ -514,6 +550,9 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
     // --- Notification Management ---
 
     private void checkNotificationPermission() {
+        if (Game.instance != null && Game.instance.isOnExternalDisplay()) {
+            return;
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
                 ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.POST_NOTIFICATIONS}, PERMISSION_REQUEST_CODE);

--- a/app/src/main/java/com/limelight/utils/GamePresentation.java
+++ b/app/src/main/java/com/limelight/utils/GamePresentation.java
@@ -1,0 +1,107 @@
+package com.limelight.utils;
+
+import android.app.Presentation;
+import android.content.Context;
+import android.graphics.PixelFormat;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Display;
+import android.view.Surface;
+import android.view.WindowManager;
+import android.widget.FrameLayout;
+
+import com.limelight.preferences.PreferenceConfiguration;
+import com.limelight.ui.StreamContainer;
+
+public class GamePresentation extends Presentation implements StreamContainer.SurfaceAvailableCallback {
+
+    private static final String TAG = "MoonlightExtDisplay";
+
+    public interface OnSurfaceAvailableListener {
+        void onSurfaceAvailable(Surface surface);
+        void onSurfaceDestroyed();
+    }
+
+    private final OnSurfaceAvailableListener listener;
+    private final PreferenceConfiguration prefConfig;
+    private StreamContainer streamContainer;
+    private Surface currentSurface;
+    private boolean surfaceReady = false;
+
+    public GamePresentation(Context outerContext, Display display, OnSurfaceAvailableListener listener,
+                           PreferenceConfiguration prefConfig) {
+        super(outerContext, display);
+        this.listener = listener;
+        this.prefConfig = prefConfig;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        FrameLayout root = new FrameLayout(getContext());
+        root.setLayoutParams(new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT));
+
+        streamContainer = new StreamContainer(getContext(), null);
+        streamContainer.setLayoutParams(new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT));
+        streamContainer.setSurfaceAvailableCallback(this);
+        streamContainer.initAsPresentation(prefConfig);
+
+        root.addView(streamContainer);
+        setContentView(root);
+
+        try {
+            getWindow().setFormat(PixelFormat.OPAQUE);
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        } catch (Throwable ignored) {}
+
+        Log.i(TAG, "GamePresentation created on display " + getDisplay());
+    }
+
+    public boolean showSafely() {
+        try {
+            super.show();
+            return true;
+        } catch (WindowManager.InvalidDisplayException e) {
+            Log.w(TAG, "Cannot show GamePresentation on display " + getDisplay() + ": " + e);
+        } catch (RuntimeException e) {
+            Log.w(TAG, "Cannot show GamePresentation: " + e);
+        }
+        return false;
+    }
+
+    @Override
+    public void onSurfaceAvailable(Surface surface) {
+        if (surface == null || !surface.isValid()) return;
+        currentSurface = surface;
+        if (!surfaceReady) {
+            surfaceReady = true;
+            Log.i(TAG, "GamePresentation surface ready");
+            if (listener != null) {
+                listener.onSurfaceAvailable(currentSurface);
+            }
+        }
+    }
+
+    @Override
+    public void onSurfaceDestroyed() {
+        Log.i(TAG, "GamePresentation surface destroyed");
+        surfaceReady = false;
+        currentSurface = null;
+        if (listener != null) {
+            listener.onSurfaceDestroyed();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (streamContainer != null) {
+            streamContainer.onDestroy();
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/utils/ServerHelper.java
+++ b/app/src/main/java/com/limelight/utils/ServerHelper.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.hardware.display.DisplayManager;
 import android.os.Build;
+import android.util.Log;
 import android.view.Display;
 import android.widget.Toast;
 
@@ -34,6 +35,16 @@ import java.util.ArrayList;
 
 public class ServerHelper {
     public static final String CONNECTION_TEST_SERVER = "android.conntest.moonlight-stream.org";
+    private static final String TAG = "MoonlightExtDisplay";
+    private static Boolean sSamsungRestricted = null;
+
+    public static void setSamsungRestricted(boolean restricted) {
+        sSamsungRestricted = restricted;
+    }
+
+    private static boolean isExternalDisplayLaunchRestricted() {
+        return sSamsungRestricted != null && sSamsungRestricted;
+    }
 
     public static ComputerDetails.AddressTuple getCurrentAddressFromComputer(ComputerDetails computer) throws IOException {
         if (computer.activeAddress == null) {
@@ -72,22 +83,38 @@ public class ServerHelper {
 
     public static Display getSecondaryDisplay(Context context) {
         DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
-        Display display = null;
-        Display[] displays = displayManager.getDisplays();
+        if (displayManager == null) {
+            return null;
+        }
+
         int mainDisplayId = Display.DEFAULT_DISPLAY;
-        int secondaryDisplayId = -1;
-        for (Display displayVariant : displays) {
-            LimeLog.info(displayVariant.toString());
-            if (displayVariant.getDisplayId() != mainDisplayId) {
-                secondaryDisplayId = displayVariant.getDisplayId();
-                break;
+
+        Display[] presentationDisplays = displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION);
+        ArrayList<Display> candidates = new ArrayList<>();
+        if (presentationDisplays != null) {
+            for (Display d : presentationDisplays) {
+                if (d != null && d.getDisplayId() != mainDisplayId && d.getState() == Display.STATE_ON) {
+                    candidates.add(d);
+                }
+            }
+        }
+        Display[] allDisplays = displayManager.getDisplays();
+        if (allDisplays != null) {
+            for (Display d : allDisplays) {
+                if (d != null && d.getDisplayId() != mainDisplayId && !candidates.contains(d)
+                        && d.getState() == Display.STATE_ON) {
+                    candidates.add(d);
+                }
             }
         }
 
-        if (secondaryDisplayId != -1) {
-            display = displayManager.getDisplay(secondaryDisplayId);
+        for (Display d : candidates) {
+            Log.i(TAG, "Selected secondary display id=" + d.getDisplayId() + " " + d);
+            return d;
         }
-        return display;
+
+        Log.w(TAG, "No usable secondary display found (candidates=" + candidates.size() + ")");
+        return null;
     }
 
     public static Intent createStartIntent(Activity parent, NvApp app, ComputerDetails computer,
@@ -95,11 +122,17 @@ public class ServerHelper {
                                            boolean withVDisplay) {
         Intent gameIntent = null;
         PreferenceConfiguration prefConfig = PreferenceConfiguration.readPreferences(parent);
-        // Try to add secondary DisplayContext if supported and connected
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && prefConfig.enableFullExDisplay && getSecondaryDisplay(parent) != null) {
-            Context displayContext = parent.createDisplayContext(getSecondaryDisplay(parent)); // use secondary display
-            gameIntent = new Intent(displayContext, Game.class);
-            gameIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        Display secondaryDisplay = prefConfig.enableFullExDisplay ? getSecondaryDisplay(parent) : null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && secondaryDisplay != null) {
+            try {
+                Context displayContext = parent.createDisplayContext(secondaryDisplay);
+                gameIntent = new Intent(displayContext, Game.class);
+                gameIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            } catch (RuntimeException e) {
+                Log.w(TAG, "createDisplayContext failed for display id=" + secondaryDisplay.getDisplayId()
+                        + ", falling back to default context: " + e);
+                gameIntent = null;
+            }
         }
         if(gameIntent == null) gameIntent = new Intent(parent, Game.class);
         gameIntent.putExtra(Game.EXTRA_HOST, computer.activeAddress.address);
@@ -123,15 +156,18 @@ public class ServerHelper {
             e.printStackTrace();
         }
 
-        if (prefConfig.enableFullExDisplay) {
-            Display secondaryDisplay = getSecondaryDisplay(parent);
-            if (secondaryDisplay != null) {
-                int secondaryDisplayId = secondaryDisplay.getDisplayId();
-                gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, secondaryDisplayId);
-                Intent touchpadIntent = new Intent(parent, ExternalDisplayControlActivity.class);
-                touchpadIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent);
-                return touchpadIntent;
+        if (secondaryDisplay != null) {
+            int secondaryDisplayId = secondaryDisplay.getDisplayId();
+            if (isExternalDisplayLaunchRestricted()) {
+                Log.i(TAG, "External display launch restriction detected; returning Game intent with Presentation extras");
+                gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY);
+                gameIntent.putExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, secondaryDisplayId);
+                return gameIntent;
             }
+            gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, secondaryDisplayId);
+            Intent touchpadIntent = new Intent(parent, ExternalDisplayControlActivity.class);
+            touchpadIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent);
+            return touchpadIntent;
         }
 
         return gameIntent;

--- a/app/src/main/java/com/limelight/utils/StreamPresentationService.java
+++ b/app/src/main/java/com/limelight/utils/StreamPresentationService.java
@@ -1,0 +1,190 @@
+package com.limelight.utils;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.hardware.display.DisplayManager;
+import android.os.Binder;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+import android.view.Display;
+import android.view.Surface;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+import com.limelight.preferences.PreferenceConfiguration;
+
+public class StreamPresentationService extends Service implements GamePresentation.OnSurfaceAvailableListener {
+
+    private static final String TAG = "MoonlightExtDisplay";
+    private static final String CHANNEL_ID = "stream_presentation_channel";
+    private static final int NOTIFICATION_ID = 2;
+
+    public static final String EXTRA_DISPLAY_ID = "displayId";
+
+    public interface PresentationStateListener {
+        void onPresentationFailure(String reason);
+        void onPresentationSurfaceDestroyed();
+    }
+
+    private final LocalBinder binder = new LocalBinder();
+    private GamePresentation gamePresentation;
+    private Surface availableSurface;
+    private Runnable pendingSurfaceCallback;
+    private PresentationStateListener presentationStateListener;
+    private String presentationFailureReason;
+
+    public class LocalBinder extends Binder {
+        public StreamPresentationService getService() {
+            return StreamPresentationService.this;
+        }
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+        Intent notifyIntent = getPackageManager().getLaunchIntentForPackage(getPackageName());
+        PendingIntent pi = null;
+        if (notifyIntent != null) {
+            notifyIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            pi = PendingIntent.getActivity(this, 0, notifyIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        }
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle("Artemis Streaming")
+                .setContentText("Streaming to external display")
+                .setSmallIcon(com.limelight.R.drawable.app_icon)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true);
+        if (pi != null) builder.setContentIntent(pi);
+        startForeground(NOTIFICATION_ID, builder.build());
+        Log.i(TAG, "StreamPresentationService started (foreground)");
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null && intent.hasExtra(EXTRA_DISPLAY_ID) && gamePresentation == null) {
+            int displayId = intent.getIntExtra(EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY);
+            attachToDisplay(displayId);
+        }
+        return START_NOT_STICKY;
+    }
+
+    private void attachToDisplay(int displayId) {
+        if (gamePresentation != null) {
+            return;
+        }
+        DisplayManager dm = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+        if (dm == null) {
+            failPresentation("DisplayManager unavailable; cannot attach Presentation");
+            return;
+        }
+        Display targetDisplay = dm.getDisplay(displayId);
+        if (targetDisplay == null) {
+            failPresentation("Display id=" + displayId + " not found");
+            return;
+        }
+        Log.i(TAG, "Attaching GamePresentation to display id=" + displayId);
+        PreferenceConfiguration prefConfig = PreferenceConfiguration.readPreferences(this);
+        GamePresentation presentation = new GamePresentation(this, targetDisplay, this, prefConfig);
+        if (!presentation.showSafely()) {
+            failPresentation("Cannot show Presentation on display id=" + displayId);
+            return;
+        }
+        gamePresentation = presentation;
+    }
+
+    @Override
+    public void onSurfaceAvailable(Surface surface) {
+        availableSurface = surface;
+        Log.i(TAG, "Service: Presentation surface available");
+        if (pendingSurfaceCallback != null) {
+            Runnable cb = pendingSurfaceCallback;
+            pendingSurfaceCallback = null;
+            cb.run();
+        }
+    }
+
+    @Override
+    public void onSurfaceDestroyed() {
+        availableSurface = null;
+        pendingSurfaceCallback = null;
+        Log.i(TAG, "Service: Presentation surface destroyed");
+        if (presentationStateListener != null) {
+            presentationStateListener.onPresentationSurfaceDestroyed();
+        }
+    }
+
+    public Surface getSurface() {
+        return availableSurface;
+    }
+
+    public void requestSurface(Runnable callback) {
+        if (presentationFailureReason != null) {
+            if (presentationStateListener != null) {
+                presentationStateListener.onPresentationFailure(presentationFailureReason);
+            }
+            return;
+        }
+        if (availableSurface != null && availableSurface.isValid()) {
+            callback.run();
+        } else {
+            pendingSurfaceCallback = callback;
+        }
+    }
+
+    public void setPresentationStateListener(PresentationStateListener listener) {
+        presentationStateListener = listener;
+        if (presentationFailureReason != null && presentationStateListener != null) {
+            presentationStateListener.onPresentationFailure(presentationFailureReason);
+            stopSelf();
+        }
+    }
+
+    private void failPresentation(String reason) {
+        presentationFailureReason = reason;
+        pendingSurfaceCallback = null;
+        Log.w(TAG, reason);
+        if (presentationStateListener != null) {
+            presentationStateListener.onPresentationFailure(reason);
+            stopSelf();
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        if (gamePresentation != null) {
+            try { gamePresentation.dismiss(); } catch (Throwable ignored) {}
+            gamePresentation = null;
+        }
+        availableSurface = null;
+        pendingSurfaceCallback = null;
+        presentationStateListener = null;
+        Log.i(TAG, "StreamPresentationService destroyed");
+        super.onDestroy();
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            if (nm != null) {
+                NotificationChannel ch = new NotificationChannel(
+                        CHANNEL_ID, "Stream Presentation", NotificationManager.IMPORTANCE_LOW);
+                ch.setShowBadge(false);
+                nm.createNotificationChannel(ch);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes Samsung devices where launching Game directly on the external display is blocked. Keeps the normal external-display probe path, falls back only after failure, hosts the Presentation surface from a foreground service, and fails cleanly if the presentation surface cannot be created.