### PR TITLE
Fix Japanese IME keys on physical keyboards

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.java
+++ b/app/src/main/java/com/limelight/binding/input/KeyboardTranslator.java
@@ -159,6 +159,13 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
     }
 
     public boolean hasNormalizedMapping(int keycode, int deviceId) {
+        // Japanese IME keys are layout-specific and must be interpreted using the host layout.
+        // Treating them as normalized makes Apollo use its US VK-to-scancode table, where
+        // VK_OEM_AUTO maps to 0x5F rather than the Japanese Hankaku/Zenkaku scancode 0x29.
+        if (isJapaneseImeKey(keycode)) {
+            return false;
+        }
+
         if (deviceId >= 0) {
             KeyboardMapping mapping = keyboardMappings.get(deviceId);
             if (mapping != null) {
@@ -174,6 +181,18 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
         return false;
     }
 
+    static boolean isJapaneseImeKey(int keycode) {
+        switch (keycode) {
+            case KeyEvent.KEYCODE_ZENKAKU_HANKAKU:
+            case KeyEvent.KEYCODE_HENKAN:
+            case KeyEvent.KEYCODE_MUHENKAN:
+            case KeyEvent.KEYCODE_KATAKANA_HIRAGANA:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     /**
      * Translates the given keycode and returns the GFE keycode
      * @param keycode the code to be translated
@@ -185,7 +204,7 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
 
         // If a device ID was provided, look up the keyboard mapping
         // Force qwerty will break user's keyboard layout settings
-        if (prefConfig.forceQwerty && deviceId >= 0) {
+        if (prefConfig.forceQwerty && !isJapaneseImeKey(keycode) && deviceId >= 0) {
             KeyboardMapping mapping = keyboardMappings.get(deviceId);
             if (mapping != null) {
                 // Try to map this device-specific keycode onto a QWERTY layout.
@@ -402,6 +421,22 @@ public class KeyboardTranslator implements InputManager.InputDeviceListener {
 
             case KeyEvent.KEYCODE_NUMPAD_DOT:
                 translated = 0x6E;
+                break;
+
+            case KeyEvent.KEYCODE_ZENKAKU_HANKAKU:
+                translated = KeyMapper.VK_OEM_AUTO;
+                break;
+
+            case KeyEvent.KEYCODE_HENKAN:
+                translated = KeyMapper.VK_CONVERT;
+                break;
+
+            case KeyEvent.KEYCODE_MUHENKAN:
+                translated = KeyMapper.VK_NONCONVERT;
+                break;
+
+            case KeyEvent.KEYCODE_KATAKANA_HIRAGANA:
+                translated = KeyMapper.VK_OEM_COPY;
                 break;
 
             default:

--- a/app/src/main/java/com/limelight/utils/KeyMapper.java
+++ b/app/src/main/java/com/limelight/utils/KeyMapper.java
@@ -925,6 +925,9 @@ public class KeyMapper {
     public static int VK_PACKET = 0xE7;    // Used to pass Unicode characters as if they were keystrokes. The VK_PACKET key is the low word of a 32-bit Virtual Key value used for non-keyboard input methods. For more information, see Remark in KEYBDINPUT, SendInput, WM_KEYDOWN, and WM_KEYUP
     // 0xE8 Unassigned
     // 0xE9-F5 OEM specific
+    public static int VK_OEM_FINISH = 0xF1;    // VK_DBE_KATAKANA on Japanese keyboard layouts
+    public static int VK_OEM_COPY = 0xF2;    // VK_DBE_HIRAGANA on Japanese keyboard layouts
+    public static int VK_OEM_AUTO = 0xF3;    // VK_DBE_SBCSCHAR (Hankaku/Zenkaku key) on Japanese keyboard layouts
     public static int VK_ATTN = 0xF6;    // Attn key
     public static int VK_CRSEL = 0xF7;    // CrSel key
     public static int VK_EXSEL = 0xF8;    // ExSel key
@@ -1057,7 +1060,13 @@ public class KeyMapper {
         linuxToWindowsKeyMap[KEY_KP3] = VK_NUMPAD3;
         linuxToWindowsKeyMap[KEY_KP0] = VK_NUMPAD0;
         linuxToWindowsKeyMap[KEY_KPDOT] = VK_DECIMAL;
+        linuxToWindowsKeyMap[KEY_ZENKAKUHANKAKU] = VK_OEM_AUTO;
         linuxToWindowsKeyMap[KEY_102ND] = VK_OEM_102;
+        linuxToWindowsKeyMap[KEY_KATAKANA] = VK_OEM_FINISH;
+        linuxToWindowsKeyMap[KEY_HIRAGANA] = VK_OEM_COPY;
+        linuxToWindowsKeyMap[KEY_HENKAN] = VK_CONVERT;
+        linuxToWindowsKeyMap[KEY_KATAKANAHIRAGANA] = VK_OEM_COPY;
+        linuxToWindowsKeyMap[KEY_MUHENKAN] = VK_NONCONVERT;
         linuxToWindowsKeyMap[KEY_COMPOSE] = VK_PROCESSKEY;
     }
 

--- a/app/src/test/java/com/limelight/binding/input/KeyboardTranslatorTest.java
+++ b/app/src/test/java/com/limelight/binding/input/KeyboardTranslatorTest.java
@@ -1,0 +1,82 @@
+package com.limelight.binding.input;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.view.KeyEvent;
+
+import com.limelight.preferences.PreferenceConfiguration;
+import com.limelight.utils.KeyMapper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {33})
+public class KeyboardTranslatorTest {
+    private KeyboardTranslator translator;
+
+    @Before
+    public void setUp() {
+        translator = new KeyboardTranslator(new PreferenceConfiguration());
+    }
+
+    @Test
+    public void translatesJapaneseAndroidKeyCodes() {
+        assertEquals(keyMap(KeyMapper.VK_OEM_AUTO),
+                translator.translate(KeyEvent.KEYCODE_ZENKAKU_HANKAKU, 0, 0));
+        assertEquals(keyMap(KeyMapper.VK_CONVERT),
+                translator.translate(KeyEvent.KEYCODE_HENKAN, 0, 0));
+        assertEquals(keyMap(KeyMapper.VK_NONCONVERT),
+                translator.translate(KeyEvent.KEYCODE_MUHENKAN, 0, 0));
+        assertEquals(keyMap(KeyMapper.VK_OEM_COPY),
+                translator.translate(KeyEvent.KEYCODE_KATAKANA_HIRAGANA, 0, 0));
+    }
+
+    @Test
+    public void translatesJapaneseLinuxScanCodesAsFallback() {
+        assertEquals(keyMap(KeyMapper.VK_OEM_AUTO),
+                translator.translate(KeyEvent.KEYCODE_UNKNOWN, KeyMapper.KEY_ZENKAKUHANKAKU, 0));
+        assertEquals(keyMap(KeyMapper.VK_OEM_FINISH),
+                translator.translate(KeyEvent.KEYCODE_UNKNOWN, KeyMapper.KEY_KATAKANA, 0));
+        assertEquals(keyMap(KeyMapper.VK_OEM_COPY),
+                translator.translate(KeyEvent.KEYCODE_UNKNOWN, KeyMapper.KEY_HIRAGANA, 0));
+        assertEquals(keyMap(KeyMapper.VK_CONVERT),
+                translator.translate(KeyEvent.KEYCODE_UNKNOWN, KeyMapper.KEY_HENKAN, 0));
+        assertEquals(keyMap(KeyMapper.VK_OEM_COPY),
+                translator.translate(KeyEvent.KEYCODE_UNKNOWN, KeyMapper.KEY_KATAKANAHIRAGANA, 0));
+        assertEquals(keyMap(KeyMapper.VK_NONCONVERT),
+                translator.translate(KeyEvent.KEYCODE_UNKNOWN, KeyMapper.KEY_MUHENKAN, 0));
+    }
+
+    @Test
+    public void keepsJapaneseImeKeysLayoutSpecific() {
+        assertTrue(KeyboardTranslator.isJapaneseImeKey(KeyEvent.KEYCODE_ZENKAKU_HANKAKU));
+        assertTrue(KeyboardTranslator.isJapaneseImeKey(KeyEvent.KEYCODE_HENKAN));
+        assertTrue(KeyboardTranslator.isJapaneseImeKey(KeyEvent.KEYCODE_MUHENKAN));
+        assertTrue(KeyboardTranslator.isJapaneseImeKey(KeyEvent.KEYCODE_KATAKANA_HIRAGANA));
+        assertFalse(KeyboardTranslator.isJapaneseImeKey(KeyEvent.KEYCODE_A));
+
+        assertFalse(translator.hasNormalizedMapping(KeyEvent.KEYCODE_ZENKAKU_HANKAKU, 0));
+        assertFalse(translator.hasNormalizedMapping(KeyEvent.KEYCODE_HENKAN, 0));
+        assertFalse(translator.hasNormalizedMapping(KeyEvent.KEYCODE_MUHENKAN, 0));
+        assertFalse(translator.hasNormalizedMapping(KeyEvent.KEYCODE_KATAKANA_HIRAGANA, 0));
+    }
+
+    @Test
+    public void keepsCommonKeyboardMappingsUnchanged() {
+        assertEquals(keyMap(KeyMapper.VK_A), translator.translate(KeyEvent.KEYCODE_A, 30, 0));
+        assertEquals(keyMap(KeyMapper.VK_LCONTROL), translator.translate(KeyEvent.KEYCODE_CTRL_LEFT, 29, 0));
+        assertEquals(keyMap(KeyMapper.VK_LMENU), translator.translate(KeyEvent.KEYCODE_ALT_LEFT, 56, 0));
+        assertEquals(keyMap(KeyMapper.VK_LWIN), translator.translate(KeyEvent.KEYCODE_META_LEFT, 125, 0));
+        assertEquals(keyMap(KeyMapper.VK_TAB), translator.translate(KeyEvent.KEYCODE_TAB, 15, 0));
+    }
+
+    private static short keyMap(int virtualKey) {
+        return (short) (0x8000 | virtualKey);
+    }
+}


### PR DESCRIPTION
## Summary

Fix Japanese IME keys when using a physical Japanese JIS keyboard
with the non-root Android client.

This adds support for:

- Hankaku/Zenkaku
- Henkan
- Muhenkan
- Katakana/Hiragana
- Linux scan-code fallbacks for the corresponding Japanese keys

## Problem

When a Japanese JIS keyboard was connected to an Android device,
normal keys and modifiers were forwarded correctly, but the
Hankaku/Zenkaku key did not affect the IME on the Windows host.

`KEYCODE_ZENKAKU_HANKAKU` and Linux `KEY_ZENKAKUHANKAKU` were not
fully mapped in the Android keyboard translation path.

In addition, Japanese IME keys could be marked as normalized.
Apollo then used its US VK-to-scan-code table, where `VK_OEM_AUTO`
(`0xF3`) maps to scan code `0x5F` instead of the Japanese keyboard
scan code `0x29`.

## Changes

- Map `KEYCODE_ZENKAKU_HANKAKU` to `VK_OEM_AUTO` (`0xF3`)
- Map `KEYCODE_HENKAN` to `VK_CONVERT`
- Map `KEYCODE_MUHENKAN` to `VK_NONCONVERT`
- Map `KEYCODE_KATAKANA_HIRAGANA` to `VK_OEM_COPY`
- Add Linux scan-code fallbacks for Japanese IME keys
- Keep Japanese IME keys non-normalized so the host keyboard layout
  can perform the correct VK-to-scan-code conversion
- Add unit tests for the new mappings and common keyboard keys

## Testing

Tested with:

- AQUOS R10
- Physical Japanese JIS keyboard
- Android non-root debug build
- Apollo Virtual Display
- Windows 11
- Google Japanese Input

Verified:

- Hankaku/Zenkaku toggles Google Japanese Input correctly
- Regular alphanumeric keys continue to work
- Ctrl, Alt, Meta and Tab continue to work
- Japanese Android key-code mappings pass unit tests
- Japanese Linux scan-code fallbacks pass unit tests

Commands:

```shell
./gradlew :app:testNonRoot_gameDebugUnitTest \
  --tests com.limelight.binding.input.KeyboardTranslatorTest

./gradlew :app:assembleNonRoot_gameDebug