### PR TITLE
Add configurable rumble rate limiting

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -3754,9 +3754,10 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     @Override
     public void rumbleTriggers(short controllerNumber, short leftTrigger, short rightTrigger) {
-        LimeLog.info(String.format((Locale)null, "Rumble on gamepad triggers %d: %04x %04x", controllerNumber, leftTrigger, rightTrigger));
-
-        controllerHandler.handleRumbleTriggers(controllerNumber, leftTrigger, rightTrigger);
+        if (prefConfig.enableRumble) {
+            LimeLog.info(String.format((Locale)null, "Rumble on gamepad triggers %d: %04x %04x", controllerNumber, leftTrigger, rightTrigger));
+            controllerHandler.handleRumbleTriggers(controllerNumber, leftTrigger, rightTrigger);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
+++ b/app/src/main/java/com/limelight/binding/input/ControllerHandler.java
@@ -125,6 +125,8 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
     private final SensorManager deviceSensorManager;
     private final SceManager sceManager;
     private final Handler mainThreadHandler;
+    private final RumbleRateLimiter rumbleRateLimiter;
+    private final RumbleRateLimiter triggerRumbleRateLimiter;
     private final HandlerThread backgroundHandlerThread;
     private final Handler backgroundThreadHandler;
     private boolean hasGameController;
@@ -142,6 +144,21 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         this.deviceSensorManager = (SensorManager) activityContext.getSystemService(Context.SENSOR_SERVICE);
         this.inputManager = (InputManager) activityContext.getSystemService(Context.INPUT_SERVICE);
         this.mainThreadHandler = new Handler(Looper.getMainLooper());
+        RumbleRateLimiter.Scheduler rumbleScheduler = new RumbleRateLimiter.Scheduler() {
+            @Override
+            public void postDelayed(Runnable runnable, long delayMs) {
+                mainThreadHandler.postDelayed(runnable, delayMs);
+            }
+
+            @Override
+            public void removeCallbacks(Runnable runnable) {
+                mainThreadHandler.removeCallbacks(runnable);
+            }
+        };
+        this.rumbleRateLimiter = new RumbleRateLimiter(prefConfig.rumbleThrottleMs,
+                android.os.SystemClock::uptimeMillis, rumbleScheduler, this::applyRumble);
+        this.triggerRumbleRateLimiter = new RumbleRateLimiter(prefConfig.rumbleThrottleMs,
+                android.os.SystemClock::uptimeMillis, rumbleScheduler, this::applyRumbleTriggers);
 
         // Create a HandlerThread to process battery state updates. These can be slow enough
         // that they lead to ANRs if we do them on the main thread.
@@ -268,13 +285,16 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         inputDeviceContexts.put(deviceId, newContext);
     }
 
-    public void stop() {
+    public synchronized void stop() {
         if (stopped) {
             return;
         }
 
         // Stop new device contexts from being created or used
         stopped = true;
+
+        rumbleRateLimiter.cancelAll();
+        triggerRumbleRateLimiter.cancelAll();
 
         // Unregister our input device callbacks
         inputManager.unregisterInputDeviceListener(this);
@@ -408,7 +428,7 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         return mask;
     }
 
-    private void releaseControllerNumber(GenericControllerContext context) {
+    private synchronized void releaseControllerNumber(GenericControllerContext context) {
         // If we reserved a controller number, remove that reservation
         if (context.reservedControllerNumber) {
             LimeLog.info("Controller number "+context.controllerNumber+" is now available");
@@ -419,6 +439,8 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         // We must do this after clearing the currentControllers entry so this
         // causes the device to be removed on the server PC.
         if (context.assignedControllerNumber) {
+            rumbleRateLimiter.cancel(context.controllerNumber);
+            triggerRumbleRateLimiter.cancel(context.controllerNumber);
             conn.sendControllerInput(context.controllerNumber, getActiveControllerMask(),
                     (short) 0,
                     (byte) 0, (byte) 0,
@@ -2162,7 +2184,14 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         }
     }
 
-    public void handleRumble(short controllerNumber, short lowFreqMotor, short highFreqMotor) {
+    public synchronized void handleRumble(short controllerNumber, short lowFreqMotor, short highFreqMotor) {
+        if (stopped) {
+            return;
+        }
+        rumbleRateLimiter.submit(controllerNumber, lowFreqMotor, highFreqMotor);
+    }
+
+    private void applyRumble(short controllerNumber, short lowFreqMotor, short highFreqMotor) {
         boolean foundMatchingDevice = false;
         boolean vibrated = false;
 
@@ -2238,7 +2267,14 @@ public class ControllerHandler implements InputManager.InputDeviceListener, UsbD
         }
     }
 
-    public void handleRumbleTriggers(short controllerNumber, short leftTrigger, short rightTrigger) {
+    public synchronized void handleRumbleTriggers(short controllerNumber, short leftTrigger, short rightTrigger) {
+        if (stopped) {
+            return;
+        }
+        triggerRumbleRateLimiter.submit(controllerNumber, leftTrigger, rightTrigger);
+    }
+
+    private void applyRumbleTriggers(short controllerNumber, short leftTrigger, short rightTrigger) {
         if (stopped) {
             return;
         }

--- a/app/src/main/java/com/limelight/binding/input/RumbleRateLimiter.java
+++ b/app/src/main/java/com/limelight/binding/input/RumbleRateLimiter.java
@@ -1,0 +1,97 @@
+package com.limelight.binding.input;
+
+import java.util.HashMap;
+import java.util.Map;
+final class RumbleRateLimiter {
+    interface Clock {
+        long uptimeMillis();
+    }
+
+    interface Scheduler {
+        void postDelayed(Runnable runnable, long delayMs);
+        void removeCallbacks(Runnable runnable);
+    }
+
+    interface Output {
+        void rumble(short controllerNumber, short firstMotor, short secondMotor);
+    }
+
+    private static class State {
+        short firstMotor;
+        short secondMotor;
+        long lastDispatchTime;
+        boolean pending;
+        Runnable runnable;
+    }
+
+    private final int intervalMs;
+    private final Clock clock;
+    private final Scheduler scheduler;
+    private final Output output;
+    private final Map<Short, State> states = new HashMap<>();
+
+    RumbleRateLimiter(int intervalMs, Clock clock, Scheduler scheduler, Output output) {
+        this.intervalMs = intervalMs;
+        this.clock = clock;
+        this.scheduler = scheduler;
+        this.output = output;
+    }
+
+    synchronized void submit(short controllerNumber, short firstMotor, short secondMotor) {
+        if (intervalMs <= 0) {
+            output.rumble(controllerNumber, firstMotor, secondMotor);
+            return;
+        }
+
+        State state = states.computeIfAbsent(controllerNumber, unused -> createState(controllerNumber));
+        state.firstMotor = firstMotor;
+        state.secondMotor = secondMotor;
+
+        long now = clock.uptimeMillis();
+        long delayMs = intervalMs - (now - state.lastDispatchTime);
+        if ((firstMotor == 0 && secondMotor == 0) || delayMs <= 0) {
+            if (state.pending) {
+                scheduler.removeCallbacks(state.runnable);
+            }
+            dispatch(controllerNumber, state);
+        }
+        else if (!state.pending) {
+            state.pending = true;
+            scheduler.postDelayed(state.runnable, delayMs);
+        }
+    }
+
+    synchronized void cancel(short controllerNumber) {
+        State state = states.remove(controllerNumber);
+        if (state != null && state.pending) {
+            scheduler.removeCallbacks(state.runnable);
+        }
+    }
+
+    synchronized void cancelAll() {
+        for (State state : states.values()) {
+            if (state.pending) {
+                scheduler.removeCallbacks(state.runnable);
+            }
+        }
+        states.clear();
+    }
+
+    private State createState(short controllerNumber) {
+        State state = new State();
+        state.runnable = () -> {
+            synchronized (RumbleRateLimiter.this) {
+                if (states.get(controllerNumber) == state) {
+                    dispatch(controllerNumber, state);
+                }
+            }
+        };
+        return state;
+    }
+
+    private void dispatch(short controllerNumber, State state) {
+        state.pending = false;
+        state.lastDispatchTime = clock.uptimeMillis();
+        output.rumble(controllerNumber, state.firstMotor, state.secondMotor);
+    }
+}

--- a/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
+++ b/app/src/main/java/com/limelight/preferences/PreferenceConfiguration.java
@@ -96,6 +96,7 @@ public class PreferenceConfiguration {
     private static final String FULL_SCREEN_PREF_STRING = "checkbox_full_screen";
 
     private static final String ENABLE_RUMBLE_PREF_STRING = "checkbox_enable_rumble";
+    private static final String RUMBLE_THROTTLE_PREF_STRING = "seekbar_rumble_throttle_ms";
     private static final String PREVENT_PACKET_LOSS_PREF_STRING = "checkbox_prevent_packet_loss";
 
     private static final String LIST_ONSCREEN_KEYBOARD_ALIGN_MODE = "list_onscreen_keyboard_align_mode";
@@ -189,6 +190,7 @@ public class PreferenceConfiguration {
     private static final boolean DEFAULT_GAMEPAD_MOTION_FALLBACK = false;
     private static final boolean DEFAULT_FORCE_MOTION_SENSORS_FALLBACK = false;
     private static final boolean DEFAULT_ENABLE_RUMBLE = true;
+    private static final int DEFAULT_RUMBLE_THROTTLE_MS = 0;
     private static final boolean DEFAULT_PREVENT_PACKET_LOSS = false;
     private static final boolean DEFAULT_GAMEPAD_ENABLE_BATTERY_REPORT = true;
     private static final boolean DEFAULT_FORCE_QWERTY = true;
@@ -375,6 +377,7 @@ public class PreferenceConfiguration {
     public boolean gamepadMotionSensorsFallbackToDevice;
     public boolean forceMotionSensorsFallbackToDevice;
     public boolean enableRumble;
+    public int rumbleThrottleMs;
     public boolean preventPacketLoss;
 
     public boolean rememberZoomPan;
@@ -1020,6 +1023,7 @@ private static int getFramePacingValue(Context context) {
         config.gamepadMotionSensorsFallbackToDevice = prefs.getBoolean(GAMEPAD_MOTION_FALLBACK_PREF_STRING, DEFAULT_GAMEPAD_MOTION_FALLBACK);
         config.forceMotionSensorsFallbackToDevice = prefs.getBoolean(FORCE_MOTION_SENSORS_FALLBACK_PREF_STRING, DEFAULT_FORCE_MOTION_SENSORS_FALLBACK);
         config.enableRumble = prefs.getBoolean(ENABLE_RUMBLE_PREF_STRING, DEFAULT_ENABLE_RUMBLE);
+        config.rumbleThrottleMs = prefs.getInt(RUMBLE_THROTTLE_PREF_STRING, DEFAULT_RUMBLE_THROTTLE_MS);
         config.preventPacketLoss = prefs.getBoolean(PREVENT_PACKET_LOSS_PREF_STRING, DEFAULT_PREVENT_PACKET_LOSS);
 
         // Read custom values

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,9 @@
     <string name="summary_checkbox_force_device_motion">Enforce using devices\'s built-in motion sensor even when the controller reported motion sensors are supported.</string>
     <string name="title_enable_rumble">Enable Rumble</string>
     <string name="summary_enable_rumble">Enable rumble feedback on supported gamepads.</string>
+    <string name="title_rumble_throttle">Rumble update interval</string>
+    <string name="summary_rumble_throttle">Sets the minimum interval between updates for each rumble motor group. Increase this value if frequent rumble causes controller or device instability. Stop commands are always sent immediately. Set to 0 to disable throttling.</string>
+    <string name="suffix_rumble_throttle">ms</string>
     <string name="category_input_settings">Input Settings</string>
     <string name="title_checkbox_touchscreen_trackpad">Use the touchscreen as a trackpad</string>
     <string name="summary_checkbox_touchscreen_trackpad">If enabled, the touchscreen acts like a trackpad. If disabled, the touchscreen directly controls the mouse cursor.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -335,6 +335,18 @@
             android:summary="@string/summary_enable_rumble"
             android:title="@string/title_enable_rumble"
             app:iconSpaceReserved="false" />
+        <com.limelight.preferences.SeekBarPreference
+            android:defaultValue="0"
+            android:dependency="checkbox_enable_rumble"
+            android:key="seekbar_rumble_throttle_ms"
+            android:max="100"
+            android:summary="@string/summary_rumble_throttle"
+            android:text="@string/suffix_rumble_throttle"
+            android:title="@string/title_rumble_throttle"
+            app:iconSpaceReserved="false"
+            seekbar:keyStep="5"
+            seekbar:min="0"
+            seekbar:step="5" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:dependency="checkbox_enable_rumble"

--- a/app/src/test/java/com/limelight/binding/input/RumbleRateLimiterTest.java
+++ b/app/src/test/java/com/limelight/binding/input/RumbleRateLimiterTest.java
@@ -1,0 +1,99 @@
+package com.limelight.binding.input;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RumbleRateLimiterTest {
+    private long now;
+    private final List<Runnable> scheduled = new ArrayList<>();
+    private final List<short[]> outputs = new ArrayList<>();
+    private RumbleRateLimiter limiter;
+
+    @Before
+    public void setup() {
+        now = 1000;
+        scheduled.clear();
+        outputs.clear();
+        limiter = new RumbleRateLimiter(50, () -> now, new RumbleRateLimiter.Scheduler() {
+            @Override
+            public void postDelayed(Runnable runnable, long delayMs) {
+                scheduled.add(runnable);
+            }
+
+            @Override
+            public void removeCallbacks(Runnable runnable) {
+                scheduled.remove(runnable);
+            }
+        }, (controllerNumber, firstMotor, secondMotor) ->
+                outputs.add(new short[] {controllerNumber, firstMotor, secondMotor}));
+    }
+
+    @Test
+    public void coalescesToLatestPendingValues() {
+        limiter.submit((short) 0, (short) 1, (short) 2);
+        now += 10;
+        limiter.submit((short) 0, (short) 3, (short) 4);
+        limiter.submit((short) 0, (short) 5, (short) 6);
+
+        assertEquals(1, outputs.size());
+        assertEquals(1, scheduled.size());
+
+        now += 40;
+        scheduled.remove(0).run();
+
+        assertEquals(2, outputs.size());
+        assertArrayEquals(new short[] {0, 5, 6}, outputs.get(1));
+    }
+
+    @Test
+    public void sendsStopImmediatelyAndDropsPendingValues() {
+        limiter.submit((short) 0, (short) 1, (short) 2);
+        now += 10;
+        limiter.submit((short) 0, (short) 3, (short) 4);
+        limiter.submit((short) 0, (short) 0, (short) 0);
+
+        assertEquals(2, outputs.size());
+        assertArrayEquals(new short[] {0, 0, 0}, outputs.get(1));
+        assertEquals(0, scheduled.size());
+    }
+
+    @Test
+    public void cancelPreventsPendingDispatch() {
+        limiter.submit((short) 0, (short) 1, (short) 2);
+        now += 10;
+        limiter.submit((short) 0, (short) 3, (short) 4);
+
+        limiter.cancel((short) 0);
+
+        assertEquals(0, scheduled.size());
+        assertEquals(1, outputs.size());
+    }
+
+    @Test
+    public void disabledLimiterDispatchesEveryUpdate() {
+        limiter = new RumbleRateLimiter(0, () -> now, new RumbleRateLimiter.Scheduler() {
+            @Override
+            public void postDelayed(Runnable runnable, long delayMs) {
+                scheduled.add(runnable);
+            }
+
+            @Override
+            public void removeCallbacks(Runnable runnable) {
+                scheduled.remove(runnable);
+            }
+        }, (controllerNumber, firstMotor, secondMotor) ->
+                outputs.add(new short[] {controllerNumber, firstMotor, secondMotor}));
+
+        limiter.submit((short) 0, (short) 1, (short) 2);
+        limiter.submit((short) 0, (short) 3, (short) 4);
+
+        assertEquals(2, outputs.size());
+        assertEquals(0, scheduled.size());
+    }
+}

--- a/app/src/test/java/com/limelight/preferences/PreferenceConfigurationTest.java
+++ b/app/src/test/java/com/limelight/preferences/PreferenceConfigurationTest.java
@@ -1,0 +1,52 @@
+package com.limelight.preferences;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.limelight.TestLogSuppressor;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(sdk = {33}, shadows = {com.limelight.shadows.ShadowMoonBridge.class})
+@RunWith(RobolectricTestRunner.class)
+public class PreferenceConfigurationTest {
+    private Context context;
+    private SharedPreferences preferences;
+
+    @BeforeClass
+    public static void suppressInvalidIdLogs() {
+        TestLogSuppressor.install();
+    }
+
+    @Before
+    public void setup() {
+        context = ApplicationProvider.getApplicationContext();
+        preferences = context.getSharedPreferences("rumble-throttle-test", Context.MODE_PRIVATE);
+        preferences.edit().clear().commit();
+    }
+
+    @Test
+    public void rumbleThrottleDefaultsToDisabled() {
+        PreferenceConfiguration config = PreferenceConfiguration.readPreferences(context, preferences);
+
+        assertEquals(0, config.rumbleThrottleMs);
+    }
+
+    @Test
+    public void rumbleThrottleReadsConfiguredInterval() {
+        preferences.edit().putInt("seekbar_rumble_throttle_ms", 50).commit();
+
+        PreferenceConfiguration config = PreferenceConfiguration.readPreferences(context, preferences);
+
+        assertEquals(50, config.rumbleThrottleMs);
+    }
+}


### PR DESCRIPTION
## Summary

- add a configurable 0-100 ms minimum interval for normal and trigger rumble updates
- coalesce bursts to the latest motor values while delivering zero-strength stop commands immediately
- clear queued updates when controllers disconnect or streaming stops
- make trigger rumble honor the existing Enable Rumble setting

## Motivation

An XGIMI XR13A running Android 14 reproducibly restarts its Android framework during Artemis sessions with a DualSense controller. The native tombstone shows `system_server` aborting in the input stack:

```text
Fatal signal 6 (SIGABRT) in InputReader
std::__1::__throw_bad_variant_access()
android::QueuedInputListener::flush()
android::InputReader::loopOnce()
```

Immediately before the crash, Artemis logs a dense burst of rumble updates. Disabling Apollo's `forward_rumble` option prevents the restart, but removes vibration entirely. This setting provides a client-side compatibility workaround without disabling rumble.

The default is 0 ms, preserving existing behavior. Stop commands bypass the limiter to avoid stuck vibration.

## Testing

- `ANDROID_HOME=/usr/lib/android-sdk ./gradlew :app:compileNonRoot_gameDebugJavaWithJavac`
- `ANDROID_HOME=/usr/lib/android-sdk ./gradlew :app:testNonRoot_gameDebugUnitTest --tests com.limelight.binding.input.RumbleRateLimiterTest --tests com.limelight.preferences.PreferenceConfigurationTest`

The focused tests cover disabled behavior, latest-value coalescing, immediate stops, controller cancellation, and preference loading. The complete existing unit suite was also run; it retains five unrelated baseline failures in layout/startup/profile navigation tests.