### PR TITLE
Add Samsung One UI fully external display support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,24 @@ android {
             dimension "root"
             buildConfigField "boolean", "ROOT_BUILD", "false"
         }
+
+        externalDisplayStandard {
+            externalNativeBuild {
+                ndkBuild {
+                    arguments "PRODUCT_FLAVOR=nonRoot"
+                }
+            }
+
+            resValue "string",
+                    "obtainium_app_url",
+                    "https://apps.obtainium.imranr.dev/redirect?r=obtainium://app/%7B%22id%22%3A%22com.bgking.artemis.externaldisplay.standard%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FClassicOldSong%2Fmoonlight-android%22%2C%22author%22%3A%22BgKing%22%2C%22name%22%3A%22Artemis%20External%20Standard%22%2C%22additionalSettings%22%3A%22%7B%5C%22apkFilterRegEx%5C%22%3A%5C%22externalDisplayStandard%5C%22%2C%5C%22matchGroutToUse%5C%22%3A%5C%22%241%5C%22%2C%5C%22versionExtractionRegEx%5C%22%3A%5C%22v(.%2B)%5C%22%7D%22%7D"
+
+            applicationId "com.bgking.artemis.externaldisplay.standard"
+            dimension "root"
+            versionCode 59
+            versionName "20.2.6-bgking-standard.2"
+            buildConfigField "boolean", "ROOT_BUILD", "false"
+        }
     }
 
     compileOptions {
@@ -102,6 +120,16 @@ android {
 
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        adbTest {
+            initWith debug
+            applicationIdSuffix ""
+            signingConfig signingConfigs.debug
+            debuggable true
+            resValue "string", "app_label", "Artemis External Standard"
+            resValue "string", "app_label_root", "Artemis External Standard (Root)"
+            resValue "string", "app_label_game", "Artemis External Standard (Game)"
+            matchingFallbacks = ['debug']
         }
         release {
             // To whomever is releasing/using an APK in release mode with

--- a/app/src/externalDisplayStandard/AndroidManifest.xml
+++ b/app/src/externalDisplayStandard/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:label="Artemis External Standard"
+        tools:replace="android:label">
+        <service
+            android:name="com.limelight.KeyboardAccessibilityService"
+            tools:node="remove" />
+    </application>
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA"/>
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA"/>
     <uses-feature android:glEsVersion="0x00030000" android:required="true" />
@@ -193,7 +195,6 @@
         <activity
             android:name=".Game"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize|layoutDirection"
-            android:noHistory="true"
             android:supportsPictureInPicture="true"
             android:resizeableActivity="true"
             android:enableOnBackInvokedCallback="false"
@@ -224,6 +225,15 @@
         <service
             android:name=".binding.input.driver.UsbDriverService"
             android:label="Usb Driver Service" />
+        <service
+            android:name=".utils.StreamPresentationService"
+            android:label="Stream Presentation Service"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Hosts an external-display Presentation surface for streamed video output" />
+        </service>
 
         <activity
             android:name=".HelpActivity"

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1,9 +1,7 @@
 package com.limelight;
 
 
-import static com.limelight.StartExternalDisplayControlReceiver.requestFocusToExternalDisplayControl;
 import static com.limelight.binding.input.KeyboardTranslator.getModifier;
-import static com.limelight.utils.ExternalDisplayControlActivity.SECONDARY_SCREEN_NOTIFICATION_ID;
 import static com.limelight.utils.ExternalDisplayControlActivity.closeExternalDisplayControl;
 import static com.limelight.utils.ServerHelper.getActiveDisplay;
 import static com.limelight.utils.ServerHelper.getSecondaryDisplay;
@@ -51,6 +49,7 @@ import com.limelight.utils.PerformanceDataTracker;
 import com.limelight.utils.ServerHelper;
 import com.limelight.utils.ShortcutHelper;
 import com.limelight.utils.SpinnerDialog;
+import com.limelight.utils.StreamPresentationService;
 import com.limelight.utils.UiHelper;
 
 import android.annotation.SuppressLint;
@@ -108,7 +107,6 @@ import android.widget.Toast;
 import android.widget.ImageButton;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.NotificationManagerCompat;
 import androidx.preference.PreferenceManager;
 
 import android.os.Looper;
@@ -143,6 +141,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener {
     public static Game instance;
 
+    private DisplayManager.DisplayListener externalDisplayListener;
+    private int externalDisplayId = Display.DEFAULT_DISPLAY;
+
     private int lastButtonState = 0;
 
     // Only 2 touches are supported
@@ -155,6 +156,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     private static final int REFERENCE_HORIZ_RES = 1280;
     private static final int REFERENCE_VERT_RES = 720;
+    private static final String INPUT_TAG = "MoonlightInput";
 
     private static final int STYLUS_DOWN_DEAD_ZONE_DELAY = 100;
     private static final int STYLUS_DOWN_DEAD_ZONE_RADIUS = 20;
@@ -196,11 +198,14 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private String appName;
     private NvApp app;
     private float desiredRefreshRate;
+    private int preferredDisplayModeId;
 
     private InputCaptureProvider inputCaptureProvider;
+    private View inputCaptureTarget;
     private int modifierFlags = 0;
     private boolean grabbedInput = true;
     private boolean cursorVisible = false;
+    private boolean invalidAbsoluteMouseReferenceLogged;
     private boolean isPanZoomMode = false;
     private boolean synthClickPending = false;
     private boolean pointerSwiping = false;
@@ -208,6 +213,25 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     private int specialKeyCode = KeyEvent.KEYCODE_UNKNOWN;
     private StreamContainer streamContainer;
     private long synthTouchDownTime = 0;
+
+    private StreamPresentationService streamPresentationService;
+    private boolean boundToPresentationService;
+    private ServiceConnection presentationServiceConnection;
+    private int presentationDisplayId = -1;
+    private boolean inPresentationMode;
+    private boolean presentationSessionEnding;
+    private ExternalDisplayControlActivity.PresentationEndReason presentationEndReason;
+    private static final long PRESENTATION_CONTROLLER_FOCUS_TIMEOUT_MS = 5_000;
+    private final Runnable presentationControllerFocusTimeout = () -> {
+        if (inPresentationMode
+                && !presentationSessionEnding
+                && !ExternalDisplayControlActivity.isPresentationControllerActive()) {
+            endExternalPresentationSession(
+                    ExternalDisplayControlActivity.PresentationEndReason.FOCUS_TIMEOUT,
+                    "Controller did not gain window focus within "
+                            + PRESENTATION_CONTROLLER_FOCUS_TIMEOUT_MS + " ms");
+        }
+    };
 
     private boolean pendingDrag = false;
     private boolean isDragging = false;
@@ -267,6 +291,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     public static final String EXTRA_VDISPLAY = "VirtualDisplay";
     public static final String EXTRA_SERVER_COMMANDS = "ServerCommands";
     public static final String EXTRA_DISPLAY_ID = "DisplayID";
+    public static final String EXTRA_PRESENTATION_DISPLAY_ID = "PresentationDisplayID";
 
     public static final String CLIPBOARD_IDENTIFIER = "ArtemisStreaming";
 
@@ -387,7 +412,8 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         Display currentDisplay = null;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             int displayId = getIntent().getIntExtra(EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY);
-            currentDisplay = getSystemService(DisplayManager.class).getDisplay(displayId);
+            DisplayManager displayManager = getSystemService(DisplayManager.class);
+            currentDisplay = displayManager != null ? displayManager.getDisplay(displayId) : null;
         }
 
         if (currentDisplay == null) {
@@ -395,14 +421,58 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         }
 
         onExternelDisplay = currentDisplay.getDisplayId() != Display.DEFAULT_DISPLAY;
+        presentationDisplayId = getIntent().getIntExtra(EXTRA_PRESENTATION_DISPLAY_ID, -1);
+        inPresentationMode = presentationDisplayId != -1;
+        if (inPresentationMode) {
+            LimeLog.info("Game entering Presentation fallback mode for display id=" + presentationDisplayId);
+            onExternelDisplay = false;
+        }
+
+        if (onExternelDisplay) {
+            externalDisplayId = currentDisplay.getDisplayId();
+            listenForExternalDisplayRemoval();
+        } else if (inPresentationMode) {
+            externalDisplayId = presentationDisplayId;
+            listenForExternalDisplayRemoval();
+        }
+
+        Display presentationDisplay = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && inPresentationMode) {
+            DisplayManager displayManager = getSystemService(DisplayManager.class);
+            presentationDisplay = displayManager != null ? displayManager.getDisplay(presentationDisplayId) : null;
+        }
+        Display renderDisplay = chooseRenderDisplayForPresentation(currentDisplay, presentationDisplay, inPresentationMode);
+        if (inPresentationMode && renderDisplay == null) {
+            LimeLog.warning("Presentation target display id=" + presentationDisplayId + " not found");
+            if (spinner != null) {
+                spinner.dismiss();
+                spinner = null;
+            }
+            Toast.makeText(this, R.string.no_external_display, Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
+
+        View renderRoot = getWindow().getDecorView().findViewById(android.R.id.content);
 
         boolean shouldInvertDecoderResolution = false;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-                && onExternelDisplay
+                && (onExternelDisplay || inPresentationMode)
                 && prefConfig.renderMode == 0 // For 3D we want to maintain configured resolution
         ) {
-            Display.Mode currentMode = currentDisplay.getMode();
+            Display targetDisplay = renderDisplay;
+            if (targetDisplay == null) {
+                LimeLog.warning("Presentation target display id=" + presentationDisplayId + " not found");
+                if (spinner != null) {
+                    spinner.dismiss();
+                    spinner = null;
+                }
+                Toast.makeText(this, R.string.no_external_display, Toast.LENGTH_LONG).show();
+                finish();
+                return;
+            }
+            Display.Mode currentMode = targetDisplay.getMode();
             displayWidth = currentMode.getPhysicalWidth();
             displayHeight = currentMode.getPhysicalHeight();
             prefConfig.width = displayWidth;
@@ -413,7 +483,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             prefConfig.showOverlayZoomToggleButton = false;
             prefConfig.enablePip = false;
             currentOrientation = Configuration.ORIENTATION_LANDSCAPE;
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE);
+            if (!inPresentationMode) {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE);
+            }
         } else {
             if (prefConfig.renderMode != 0) {
                 prefConfig.videoScaleMode = PreferenceConfiguration.ScaleMode.STRETCH;
@@ -432,7 +504,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             displayHeight = shouldInvertDecoderResolution ? prefConfig.width : prefConfig.height;
 
             // Enter landscape unless we're on a square screen
-            setPreferredOrientationForActivity();
+            if (!inPresentationMode) {
+                setPreferredOrientationForActivity();
+            }
         }
 
 
@@ -443,20 +517,18 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             // Allow the activity to layout under notches if the fill-screen option
             // was turned on by the user or it's a full-screen native resolution
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                getWindow().getAttributes().layoutInDisplayCutoutMode =
-                        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+                setRenderWindowCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS);
             }
             else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                getWindow().getAttributes().layoutInDisplayCutoutMode =
-                        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+                setRenderWindowCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES);
             }
         }
 
         //光标是否显示
-        cursorVisible = prefConfig.enableMouseLocalCursor;
+        cursorVisible = !inPresentationMode && prefConfig.enableMouseLocalCursor;
 
         // Listen for non-touch events on the game surface
-        streamContainer = findViewById(R.id.streamContainer);
+        streamContainer = renderRoot.findViewById(R.id.streamContainer);
         streamContainer.init(this, prefConfig);
         streamContainer.setOnGenericMotionListener(this);
         streamContainer.setOnKeyListener(this);
@@ -474,7 +546,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         // to work on areas outside of the StreamView itself. We use a separate View
         // for this rather than just handling it at the Activity level, because that
         // allows proper touch splitting, which the OSC relies upon.
-        View backgroundTouchView = findViewById(R.id.backgroundTouchView);
+        View backgroundTouchView = renderRoot.findViewById(R.id.backgroundTouchView);
         backgroundTouchView.setOnTouchListener(this);
 
 
@@ -515,26 +587,18 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             );
         }
 
-        notificationOverlayView = findViewById(R.id.notificationOverlay);
+        notificationOverlayView = renderRoot.findViewById(R.id.notificationOverlay);
 
-        performanceOverlayView = findViewById(R.id.performanceOverlay);
+        performanceOverlayView = renderRoot.findViewById(R.id.performanceOverlay);
 
-        performanceOverlayLite = findViewById(R.id.performanceOverlayLite);
+        performanceOverlayLite = renderRoot.findViewById(R.id.performanceOverlayLite);
 
-        performanceOverlayBig = findViewById(R.id.performanceOverlayBig);
+        performanceOverlayBig = renderRoot.findViewById(R.id.performanceOverlayBig);
 
         inputCaptureProvider = InputCaptureManager.getInputCaptureProvider(this, this);
+        inputCaptureTarget = streamContainer;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            streamContainer.setOnCapturedPointerListener(new View.OnCapturedPointerListener() {
-                @Override
-                public boolean onCapturedPointer(View view, MotionEvent motionEvent) {
-//                    LimeLog.info("onCapturedPointer="+motionEvent.toString());
-//                    LimeLog.info("onCapturedPointer-Device="+motionEvent.getDevice().toString());
-                    return handleMotionEvent(view, motionEvent);
-                }
-            });
-        }
+        attachCapturedPointerListener(streamContainer);
 
         // Warn the user if they're on a metered connection
         ConnectivityManager connMgr = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
@@ -606,7 +670,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             } else {
                 // Start our HDR checklist
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    Display.HdrCapabilities hdrCaps = currentDisplay.getHdrCapabilities();
+                    Display.HdrCapabilities hdrCaps = renderDisplay.getHdrCapabilities();
 
                     // We must now ensure our display is compatible with HDR10
                     if (hdrCaps != null) {
@@ -747,7 +811,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         }
 
         // Set to the optimal mode for streaming
-        float displayRefreshRate = prepareDisplayForRendering(currentDisplay);
+        float displayRefreshRate = prepareDisplayForRendering(renderDisplay);
         LimeLog.info("Display refresh rate: "+displayRefreshRate);
 
         // If the user requested frame pacing using a capped FPS, we will need to change our
@@ -823,11 +887,6 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             allowChangeMouseMode = false;
             applyMouseMode(2);
         } else {
-            if (prefConfig.enableFullExDisplay && onExternelDisplay) {
-                requestFocusToExternalDisplayControl(this);
-                listenForExternalDisplayRemoval();
-            }
-
             // Initialize touch contexts based on preferences
             // The mouse mode preference is also read in PreferenceConfiguration to set the boolean flags
             initMouseMode();
@@ -865,31 +924,29 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         //streamContainer.getHolder().addCallback(this);
 
         streamContainer.setOnSurfaceAvailable(() -> {
-            if (!attemptedConnection) {
-                LimeLog.info("Surface is available, starting connection...");
-                attemptedConnection = true;
-
-                // Der Decoder erhält die jeweils aktive Oberfläche vom Container
-                decoderRenderer.setRenderTarget(streamContainer.getSurface());
-
-                // Starten Sie die NvConnection
-                conn.start(new AndroidAudioRenderer(Game.this, prefConfig.playHostAudio),
-                        decoderRenderer, Game.this);
+            if (inPresentationMode) {
+                return;
             }
+            tryStartStream(streamContainer.getSurface());
         });
+
+        if (inPresentationMode) {
+            streamContainer.setVisibility(View.GONE);
+            bindToStreamPresentationService();
+        }
 
         gameMenuCallbacks = new GameMenu(this);
 
-        floatingMenuButton = findViewById(R.id.floatingMenuButton);
+        floatingMenuButton = renderRoot.findViewById(R.id.floatingMenuButton);
         updateFloatingButtonVisibility(prefConfig.enableBackMenu && prefConfig.enableFloatingButton);
         initFloatingButton();
 
-        overlayToggleButton = findViewById(R.id.overlayToggleZoomButton);
+        overlayToggleButton = renderRoot.findViewById(R.id.overlayToggleZoomButton);
         setupOverlayToggleButton();
 
         //fixed size + pacing without back-pressure on MTK
         try {
-            View root = findViewById(android.R.id.content);
+            View root = renderRoot.findViewById(android.R.id.content);
             // Niente getIdentifier: troviamo la prima SurfaceView nel layout
             SurfaceView streamSurfaceView = findFirstSurfaceViewFrom(root);
 
@@ -906,9 +963,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                     float displayHz = 60f;
                     try {
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-                            displayHz = currentDisplay.getMode().getRefreshRate();
+                            displayHz = renderDisplay.getMode().getRefreshRate();
                         } else {
-                            displayHz = currentDisplay.getRefreshRate();
+                            displayHz = renderDisplay.getRefreshRate();
                         }
                     } catch (Throwable ignored) {}
 
@@ -1009,29 +1066,62 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     private void listenForExternalDisplayRemoval() {
+        if (!shouldRegisterExternalDisplayRemovalListener(isOnExternalDisplay(), externalDisplayListener != null)) {
+            return;
+        }
+
         DisplayManager displayManager = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
-        displayManager.registerDisplayListener(new DisplayManager.DisplayListener() {
+        externalDisplayListener = new DisplayManager.DisplayListener() {
             @Override
             public void onDisplayAdded(int displayId) {
             }
 
             @Override
             public void onDisplayRemoved(int displayId) {
-                if (getSecondaryDisplay(getBaseContext()) == null) {
-                    handleDisplayRemoved();
-                    finish();
+                if (displayId == externalDisplayId || getSecondaryDisplay(getBaseContext()) == null) {
+                    if (inPresentationMode) {
+                        endExternalPresentationSession(
+                                ExternalDisplayControlActivity.PresentationEndReason.DISPLAY_REMOVED,
+                                "External display removed id=" + displayId);
+                    }
+                    else {
+                        handleDisplayRemoved();
+                        finish();
+                    }
                 }
             }
 
             @Override
             public void onDisplayChanged(int displayId) {
             }
-        }, null);
+        };
+        displayManager.registerDisplayListener(externalDisplayListener, null);
+    }
+
+    private void unregisterExternalDisplayRemovalListener() {
+        if (externalDisplayListener == null) {
+            return;
+        }
+
+        DisplayManager displayManager = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+        displayManager.unregisterDisplayListener(externalDisplayListener);
+        externalDisplayListener = null;
     }
 
     private void handleDisplayRemoved() {
-        NotificationManagerCompat.from(getBaseContext()).cancel(SECONDARY_SCREEN_NOTIFICATION_ID);
-        closeExternalDisplayControl();
+        if (inPresentationMode) {
+            ExternalDisplayControlActivity.finishForPresentationEnd(
+                    presentationEndReason != null
+                            ? presentationEndReason
+                            : ExternalDisplayControlActivity.PresentationEndReason.CONNECTION_ERROR);
+            try {
+                stopService(new Intent(this, StreamPresentationService.class));
+            } catch (RuntimeException ignored) {
+            }
+        }
+        else {
+            closeExternalDisplayControl();
+        }
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -1346,8 +1436,15 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     public void setMetaKeyCaptureState(boolean enabled) {
+        setMetaKeyCaptureState(getComponentName(), enabled);
+    }
+
+    public void setMetaKeyCaptureState(ComponentName targetComponent, boolean enabled) {
         // This uses custom APIs present on some Samsung devices to allow capture of
         // meta key events while streaming.
+        if (targetComponent == null) {
+            return;
+        }
         try {
             Class<?> semWindowManager = Class.forName("com.samsung.android.view.SemWindowManager");
             Method getInstanceMethod = semWindowManager.getMethod("getInstance");
@@ -1358,7 +1455,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 parameterTypes[0] = ComponentName.class;
                 parameterTypes[1] = boolean.class;
                 Method requestMetaKeyEventMethod = semWindowManager.getDeclaredMethod("requestMetaKeyEvent", parameterTypes);
-                requestMetaKeyEventMethod.invoke(manager, this.getComponentName(), enabled);
+                requestMetaKeyEventMethod.invoke(manager, targetComponent, enabled);
             }
             else {
                 LimeLog.warning("SemWindowManager.getInstance() returned null");
@@ -1449,11 +1546,68 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     }
 
     public boolean isOnExternalDisplay() {
-        return onExternelDisplay;
+        return onExternelDisplay || inPresentationMode;
+    }
+
+    public boolean isInPresentationMode() {
+        return inPresentationMode;
+    }
+
+    public boolean isInputGrabbed() {
+        return grabbedInput;
+    }
+
+    static Display chooseRenderDisplayForPresentation(Display currentDisplay,
+                                                      Display presentationDisplay,
+                                                      boolean inPresentationMode) {
+        return inPresentationMode ? presentationDisplay : currentDisplay;
+    }
+
+    static boolean shouldApplyDisplayModeToActivityWindow(boolean inPresentationMode) {
+        return !inPresentationMode;
+    }
+
+    static boolean shouldKeepExternalPresentationAliveOnStop(boolean onExternalDisplay,
+                                                             boolean hasPresentation,
+                                                             boolean controllerSessionAlive,
+                                                             boolean finishing,
+                                                             boolean changingConfigurations) {
+        return onExternalDisplay && hasPresentation && controllerSessionAlive && !finishing;
+    }
+
+    static boolean shouldForwardPresentationControllerFocus(boolean inPresentationMode,
+                                                            boolean hasInputCaptureProvider) {
+        return inPresentationMode && hasInputCaptureProvider;
+    }
+
+    public boolean isExternalPresentationActive() {
+        return inPresentationMode;
+    }
+
+    static boolean shouldRegisterExternalDisplayRemovalListener(boolean onExternalDisplay,
+                                                                boolean alreadyRegistered) {
+        return onExternalDisplay && !alreadyRegistered;
+    }
+
+    private Window getRenderWindow() {
+        return getWindow();
+    }
+
+    private View getRenderDecorView() {
+        Window renderWindow = getRenderWindow();
+        return renderWindow != null ? renderWindow.getDecorView() : null;
+    }
+
+    private void setRenderWindowCutoutMode(int cutoutMode) {
+        Window renderWindow = getRenderWindow();
+        WindowManager.LayoutParams layoutParams = renderWindow.getAttributes();
+        layoutParams.layoutInDisplayCutoutMode = cutoutMode;
+        renderWindow.setAttributes(layoutParams);
     }
 
     private float prepareDisplayForRendering(Display currentDisplay) {
-        WindowManager.LayoutParams windowLayoutParams = getWindow().getAttributes();
+        Window renderWindow = getRenderWindow();
+        WindowManager.LayoutParams windowLayoutParams = renderWindow.getAttributes();
         float displayRefreshRate;
 
         // On M, we can explicitly set the optimal display mode
@@ -1546,8 +1700,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             LimeLog.info("Best display mode: "+bestMode.getPhysicalWidth()+"x"+
                     bestMode.getPhysicalHeight()+"x"+bestMode.getRefreshRate());
 
+            preferredDisplayModeId = bestMode.getModeId();
+
             // Only apply new window layout parameters if we've actually changed the display mode
-            if (currentDisplay.getMode().getModeId() != bestMode.getModeId()) {
+            if (shouldApplyDisplayModeToActivityWindow(inPresentationMode)
+                    && currentDisplay.getMode().getModeId() != bestMode.getModeId()) {
                 // If we only changed refresh rate and we're on an OS that supports Surface.setFrameRate()
                 // use that instead of using preferredDisplayModeId to avoid the possibility of triggering
                 // bugs that can cause the system to switch from 4K60 to 4K24 on Chromecast 4K.
@@ -1557,7 +1714,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                         currentDisplay.getMode().getPhysicalHeight() != bestMode.getPhysicalHeight()) {
                     // Apply the display mode change
                     windowLayoutParams.preferredDisplayModeId = bestMode.getModeId();
-                    getWindow().setAttributes(windowLayoutParams);
+                    renderWindow.setAttributes(windowLayoutParams);
                 }
                 else {
                     LimeLog.info("Using setFrameRate() instead of preferredDisplayModeId due to matching resolution");
@@ -1592,7 +1749,7 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             displayRefreshRate = bestRefreshRate;
 
             // Apply the refresh rate change
-            getWindow().setAttributes(windowLayoutParams);
+            renderWindow.setAttributes(windowLayoutParams);
         }
 
         // Until Marshmallow, we can't ask for a 4K display mode, so we'll
@@ -1651,13 +1808,17 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
             // In multi-window mode on N+, we need to drop our layout flags or we'll
             // be drawing underneath the system UI.
+            View renderDecorView = getRenderDecorView();
+            if (renderDecorView == null) {
+                return;
+            }
             if (!prefConfig.fullScreen || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isInMultiWindowMode())) {
-                Game.this.getWindow().getDecorView().setSystemUiVisibility(
+                renderDecorView.setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
             }
             else {
                 // Use immersive mode
-                Game.this.getWindow().getDecorView().setSystemUiVisibility(
+                renderDecorView.setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                                 View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
                                 View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
@@ -1669,7 +1830,8 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
     };
 
     private void hideSystemUi(int delay) {
-        Handler h = getWindow().getDecorView().getHandler();
+        View renderDecorView = getRenderDecorView();
+        Handler h = renderDecorView != null ? renderDecorView.getHandler() : null;
         if (h != null) {
             h.removeCallbacks(hideSystemUi);
             h.postDelayed(hideSystemUi, delay);
@@ -1685,17 +1847,128 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         // flag. It will cause us to collide with the system UI.
         // This function will also be called for PiP so we can cover
         // that case here too.
+        Window renderWindow = getRenderWindow();
         if (isInMultiWindowMode) {
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            renderWindow.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             decoderRenderer.notifyVideoBackground();
         }
         else {
-            getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            renderWindow.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             decoderRenderer.notifyVideoForeground();
         }
 
         // Correct the system UI visibility flags
         hideSystemUi(50);
+    }
+
+    private void tryStartStream(Surface renderTarget) {
+        if (attemptedConnection || renderTarget == null || !renderTarget.isValid()) {
+            return;
+        }
+
+        LimeLog.info("Surface is available, starting connection...");
+        attemptedConnection = true;
+        decoderRenderer.setRenderTarget(renderTarget);
+        conn.start(new AndroidAudioRenderer(Game.this, prefConfig.playHostAudio),
+                decoderRenderer, Game.this);
+    }
+
+    private void bindToStreamPresentationService() {
+        if (presentationDisplayId == -1) {
+            return;
+        }
+        if (boundToPresentationService) {
+            if (streamPresentationService != null) {
+                streamPresentationService.requestSurface(() -> tryStartStream(streamPresentationService.getSurface()));
+            }
+            return;
+        }
+
+        Intent serviceIntent = new Intent(this, StreamPresentationService.class);
+        serviceIntent.putExtra(StreamPresentationService.EXTRA_DISPLAY_ID, presentationDisplayId);
+        serviceIntent.putExtra(StreamPresentationService.EXTRA_DISPLAY_MODE_ID, preferredDisplayModeId);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(serviceIntent);
+        } else {
+            startService(serviceIntent);
+        }
+
+        presentationServiceConnection = new ServiceConnection() {
+            @Override
+            public void onServiceConnected(ComponentName name, IBinder service) {
+                StreamPresentationService.LocalBinder binder = (StreamPresentationService.LocalBinder) service;
+                streamPresentationService = binder.getService();
+                LimeLog.info("Connected to StreamPresentationService");
+                streamPresentationService.setPresentationStateListener(new StreamPresentationService.PresentationStateListener() {
+                    @Override
+                    public void onPresentationFailure(String reason) {
+                        endExternalPresentationSession(
+                                ExternalDisplayControlActivity.PresentationEndReason.CONNECTION_ERROR,
+                                "Presentation failed: " + reason);
+                    }
+
+                    @Override
+                    public void onPresentationSurfaceDestroyed() {
+                        endExternalPresentationSession(
+                                ExternalDisplayControlActivity.PresentationEndReason.CONNECTION_ERROR,
+                                "Presentation surface destroyed");
+                    }
+                });
+                streamPresentationService.requestSurface(() -> tryStartStream(streamPresentationService.getSurface()));
+            }
+
+            @Override
+            public void onServiceDisconnected(ComponentName name) {
+                LimeLog.warning("StreamPresentationService disconnected");
+                streamPresentationService = null;
+                boundToPresentationService = false;
+                if (!presentationSessionEnding) {
+                    endExternalPresentationSession(
+                            ExternalDisplayControlActivity.PresentationEndReason.CONNECTION_ERROR,
+                            "StreamPresentationService disconnected");
+                }
+            }
+        };
+
+        boundToPresentationService = bindService(serviceIntent, presentationServiceConnection, Context.BIND_AUTO_CREATE);
+    }
+
+    static boolean shouldEndPresentationSessionForTest(boolean inPresentationMode,
+                                                       boolean presentationSessionEnding,
+                                                       boolean finishing) {
+        return inPresentationMode && !presentationSessionEnding && !finishing;
+    }
+
+    public void endExternalPresentationSession(
+            ExternalDisplayControlActivity.PresentationEndReason reason) {
+        endExternalPresentationSession(reason, "Requested by controller");
+    }
+
+    private void endExternalPresentationSession(
+            ExternalDisplayControlActivity.PresentationEndReason reason,
+            String detail) {
+        if (!shouldEndPresentationSessionForTest(inPresentationMode, presentationSessionEnding, isFinishing())) {
+            return;
+        }
+        presentationSessionEnding = true;
+        presentationEndReason = reason;
+        timerHandler.removeCallbacks(presentationControllerFocusTimeout);
+        LimeLog.warning("Presentation session ending reason=" + reason + " detail=" + detail);
+        ExternalDisplayControlActivity.finishForPresentationEnd(reason);
+        runOnUiThread(() -> {
+            if (spinner != null) {
+                spinner.dismiss();
+                spinner = null;
+            }
+            try {
+                stopService(new Intent(this, StreamPresentationService.class));
+            } catch (RuntimeException ignored) {
+            }
+            if (conn != null) {
+                stopConnection();
+            }
+            finish();
+        });
     }
 
     @Override
@@ -1704,8 +1977,25 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         instance = null;
         timerHandler.removeCallbacksAndMessages(null);
+        unregisterExternalDisplayRemovalListener();
 
         if (prefConfig.enableFullExDisplay) handleDisplayRemoved();
+
+        if (boundToPresentationService && presentationServiceConnection != null) {
+            try {
+                unbindService(presentationServiceConnection);
+            } catch (IllegalArgumentException ignored) {
+            }
+            boundToPresentationService = false;
+            presentationServiceConnection = null;
+            streamPresentationService = null;
+        }
+        if (inPresentationMode) {
+            try {
+                stopService(new Intent(this, StreamPresentationService.class));
+            } catch (RuntimeException ignored) {
+            }
+        }
 
         if (controllerHandler != null) {
             controllerHandler.destroy();
@@ -1738,8 +2028,12 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         }
 
         // Destroy the capture provider
-        inputCaptureProvider.destroy();
-        streamContainer.onDestroy();
+        if (inputCaptureProvider != null) {
+            inputCaptureProvider.destroy();
+        }
+        if (streamContainer != null) {
+            streamContainer.onDestroy();
+        }
     }
 
     @Override
@@ -1775,7 +2069,14 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             keyBoardLayoutController.hide();
         }
 
-        if (conn != null) {
+        boolean keepPresentationAlive = shouldKeepExternalPresentationAliveOnStop(
+                isOnExternalDisplay(),
+                inPresentationMode,
+                ExternalDisplayControlActivity.shouldKeepPresentationAlive(),
+                isFinishing(),
+                isChangingConfigurations());
+
+        if (conn != null && !keepPresentationAlive && !presentationSessionEnding) {
             int videoFormat = decoderRenderer.getActiveVideoFormat();
 
             displayedFailureDialog = true;
@@ -1852,13 +2153,70 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
         }
 
-        finish();
+        if (!keepPresentationAlive) {
+            finish();
+        }
     }
 
     public static String formatCurrentTime(long currentTimeMillis) {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         Date date = new Date(currentTimeMillis);
         return dateFormat.format(date);
+    }
+
+    private void attachCapturedPointerListener(View targetView) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || targetView == null
+                || targetView instanceof ExternalControllerView) {
+            return;
+        }
+
+        targetView.setOnCapturedPointerListener((view, motionEvent) -> handleMotionEvent(view, motionEvent));
+    }
+
+    public void replaceInputCaptureTarget(View targetView) {
+        if (targetView == null || inputCaptureProvider == null) {
+            return;
+        }
+
+        if (targetView == inputCaptureTarget) {
+            return;
+        }
+
+        attachCapturedPointerListener(targetView);
+        boolean wasGrabbed = grabbedInput;
+        inputCaptureProvider.destroy();
+        inputCaptureProvider = InputCaptureManager.getInputCaptureProvider(this, targetView, this);
+        inputCaptureTarget = targetView;
+        if (wasGrabbed) {
+            inputCaptureProvider.enableCapture();
+            if (cursorVisible && !inPresentationMode) {
+                inputCaptureProvider.showCursor();
+            }
+        }
+
+        LimeLog.info("Presentation mouse capture target set to "
+                + targetView.getClass().getSimpleName());
+    }
+
+    public void onPresentationControllerWindowFocusChanged(boolean hasFocus) {
+        if (!shouldForwardPresentationControllerFocus(inPresentationMode, inputCaptureProvider != null)) {
+            return;
+        }
+
+        modifierFlags = 0;
+        inputCaptureProvider.onWindowFocusChanged(hasFocus);
+    }
+
+    public void onPresentationControllerActivated() {
+        timerHandler.removeCallbacks(presentationControllerFocusTimeout);
+        int referenceWidth = capturedMouseReferenceWidth();
+        int referenceHeight = capturedMouseReferenceHeight();
+        LimeLog.info("Presentation controller active captureTarget="
+                + (inputCaptureTarget != null
+                ? inputCaptureTarget.getClass().getSimpleName()
+                : "null")
+                + " absoluteMouseMode=" + prefConfig.absoluteMouseMode
+                + " mouseReference=" + referenceWidth + "x" + referenceHeight);
     }
 
     private void setInputGrabState(boolean grab) {
@@ -1877,7 +2235,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         }
 
         // Grab/ungrab system keyboard shortcuts
-        setMetaKeyCaptureState(grab);
+        if (!inPresentationMode) {
+            setMetaKeyCaptureState(grab);
+        }
 
         grabbedInput = grab;
     }
@@ -1949,6 +2309,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
                     // Toggle cursor visibility
                     case KeyEvent.KEYCODE_C:
+                        if (inPresentationMode) {
+                            cursorVisible = false;
+                            inputCaptureProvider.hideCursor();
+                            break;
+                        }
                         if (!grabbedInput) {
                             inputCaptureProvider.enableCapture();
                             grabbedInput = true;
@@ -2751,9 +3116,39 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         }
     }
 
+    private void logMouseInputBoundary(String boundary, View view, MotionEvent event) {
+        if (!BuildConfig.DEBUG || event == null) {
+            return;
+        }
+
+        InputDevice device = event.getDevice();
+        boolean hasCapture = view != null
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && view.hasPointerCapture();
+        LimeLog.info(INPUT_TAG + " " + boundary
+                + " action=" + MotionEvent.actionToString(event.getActionMasked())
+                + " source=0x" + Integer.toHexString(event.getSource())
+                + " tool0=" + (event.getPointerCount() > 0 ? event.getToolType(0) : -1)
+                + " x0=" + (event.getPointerCount() > 0 ? event.getX(0) : 0)
+                + " y0=" + (event.getPointerCount() > 0 ? event.getY(0) : 0)
+                + " relativeX=" + event.getAxisValue(MotionEvent.AXIS_RELATIVE_X)
+                + " relativeY=" + event.getAxisValue(MotionEvent.AXIS_RELATIVE_Y)
+                + " historySize=" + event.getHistorySize()
+                + " deviceId=" + event.getDeviceId()
+                + " deviceSources=0x" + Integer.toHexString(device != null ? device.getSources() : 0)
+                + " view=" + (view != null ? view.getClass().getSimpleName() : "null")
+                + " viewSize=" + (view != null ? view.getWidth() + "x" + view.getHeight() : "null")
+                + " pointerCapture=" + hasCapture
+                + " captureActive=" + (inputCaptureProvider != null && inputCaptureProvider.isCapturingActive())
+                + " grabbed=" + grabbedInput
+                + " presentation=" + inPresentationMode);
+    }
+
     // Returns true if the event was consumed
     // NB: View is only present if called from a view callback
     public boolean handleMotionEvent(View view, MotionEvent event) {
+        logMouseInputBoundary("Game.handleMotionEvent", view, event);
+
         // Pass through mouse/touch/joystick input if we're not grabbing
         if (!grabbedInput) {
             return false;
@@ -2828,9 +3223,21 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
                     if (deltaX != 0 || deltaY != 0) {
                         if (prefConfig.absoluteMouseMode) {
-                            // NB: view may be null, but we can unconditionally use streamView because we don't need to adjust
-                            // relative axis deltas for the position of the streamView within the parent's coordinate system.
-                            conn.sendMouseMoveAsMousePosition(deltaX, deltaY, (short) streamContainer.getWidth(), (short) streamContainer.getHeight());
+                            int referenceWidth = capturedMouseReferenceWidth();
+                            int referenceHeight = capturedMouseReferenceHeight();
+                            if (isValidCapturedMouseReference(referenceWidth, referenceHeight)) {
+                                conn.sendMouseMoveAsMousePosition(deltaX, deltaY,
+                                        (short) referenceWidth, (short) referenceHeight);
+                            }
+                            else {
+                                if (!invalidAbsoluteMouseReferenceLogged) {
+                                    invalidAbsoluteMouseReferenceLogged = true;
+                                    LimeLog.warning("Invalid absolute mouse reference "
+                                            + referenceWidth + "x" + referenceHeight
+                                            + "; falling back to relative mouse motion");
+                                }
+                                conn.sendMouseMove(deltaX, deltaY);
+                            }
                         }
                         else {
                             conn.sendMouseMove(deltaX, deltaY);
@@ -3350,12 +3757,78 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     }
 
+    static float scaleInputCoordinate(float value, int sourceSize, int targetSize) {
+        if (targetSize <= 0) {
+            return value <= 0.0f ? 0.0f : 1.0f;
+        }
+        int safeSourceSize = Math.max(sourceSize, 1);
+        float clamped = Math.min(Math.max(value, 0.0f), safeSourceSize);
+        return (clamped / safeSourceSize) * targetSize;
+    }
+
+    static boolean shouldScalePresentationInput(boolean inPresentationMode, boolean externalControllerView) {
+        return inPresentationMode && externalControllerView;
+    }
+
+    static int selectCapturedMouseReferenceDimension(boolean inPresentationMode,
+                                                     int displayDimension,
+                                                     int streamDimension) {
+        int referenceDimension = inPresentationMode
+                ? Math.max(displayDimension, streamDimension)
+                : streamDimension;
+        return Math.min(referenceDimension, Short.MAX_VALUE);
+    }
+
+    static boolean isValidCapturedMouseReference(int width, int height) {
+        return width >= 2 && height >= 2;
+    }
+
+    private int capturedMouseReferenceWidth() {
+        return selectCapturedMouseReferenceDimension(
+                inPresentationMode,
+                displayWidth,
+                streamContainer != null ? streamContainer.getWidth() : 0);
+    }
+
+    private int capturedMouseReferenceHeight() {
+        return selectCapturedMouseReferenceDimension(
+                inPresentationMode,
+                displayHeight,
+                streamContainer != null ? streamContainer.getHeight() : 0);
+    }
+
+    private int effectiveStreamWidth() {
+        return Math.max(displayWidth, streamContainer != null ? streamContainer.getWidth() : 1);
+    }
+
+    private int effectiveStreamHeight() {
+        return Math.max(displayHeight, streamContainer != null ? streamContainer.getHeight() : 1);
+    }
+
+    private boolean isPresentationControllerInput(View view) {
+        return shouldScalePresentationInput(inPresentationMode, view instanceof ExternalControllerView);
+    }
+
+    private float presentationControllerX(View view, MotionEvent event) {
+        return scaleInputCoordinate(event.getX(0), view.getWidth(), effectiveStreamWidth());
+    }
+
+    private float presentationControllerY(View view, MotionEvent event) {
+        return scaleInputCoordinate(event.getY(0), view.getHeight(), effectiveStreamHeight());
+    }
+
     private void updateMousePosition(View touchedView, MotionEvent event) {
         // X and Y are already relative to the provided view object
         float eventX, eventY;
+        boolean presentationControllerInput = isPresentationControllerInput(touchedView);
+        int targetWidth = presentationControllerInput ? effectiveStreamWidth() : streamContainer.getWidth();
+        int targetHeight = presentationControllerInput ? effectiveStreamHeight() : streamContainer.getHeight();
         // For our StreamView itself, we can use the coordinates unmodified.
 
-        if (touchedView == streamContainer) {
+        if (presentationControllerInput) {
+            eventX = presentationControllerX(touchedView, event);
+            eventY = presentationControllerY(touchedView, event);
+        } else if (touchedView == streamContainer) {
             eventX = event.getX(0);
             eventY = event.getY(0);
         } else {
@@ -3396,14 +3869,23 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         // Normalize these to the view size. We can't just drop them because we won't always get an event
         // right at the boundary of the view, so dropping them would result in our cursor never really
         // reaching the sides of the screen.
-        eventX = Math.min(Math.max(eventX, 0), streamContainer.getWidth());
-        eventY = Math.min(Math.max(eventY, 0), streamContainer.getHeight());
+        eventX = Math.min(Math.max(eventX, 0), targetWidth);
+        eventY = Math.min(Math.max(eventY, 0), targetHeight);
 
-        conn.sendMousePosition((short)eventX, (short)eventY, (short) streamContainer.getWidth(), (short) streamContainer.getHeight());
+        conn.sendMousePosition((short)eventX, (short)eventY, (short) targetWidth, (short) targetHeight);
     }
 
     @Override
     public boolean onGenericMotion(View view, MotionEvent event) {
+        return handleMotionEvent(view, event);
+    }
+
+    @Override
+    public boolean handleGenericMotion(View view, MotionEvent event) {
+        if (!isExternalPresentationActive()) {
+            return false;
+        }
+
         return handleMotionEvent(view, event);
     }
 
@@ -3546,6 +4028,14 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     @Override
     public void connectionTerminated(final int errorCode) {
+        LimeLog.severe("Connection terminated: " + errorCode
+                + " presentation=" + inPresentationMode
+                + " sessionEnding=" + presentationSessionEnding
+                + " endReason=" + presentationEndReason);
+        if (inPresentationMode && presentationSessionEnding) {
+            return;
+        }
+
         // Perform a connection test if the failure could be due to a blocked port
         // This does network I/O, so don't do it on the main thread.
         final int portFlags = MoonBridge.getPortFlagsFromTerminationErrorCode(errorCode);
@@ -3554,6 +4044,19 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
+                if (inPresentationMode) {
+                    presentationSessionEnding = true;
+                    presentationEndReason = errorCode == MoonBridge.ML_ERROR_GRACEFUL_TERMINATION
+                            ? ExternalDisplayControlActivity.PresentationEndReason.USER_CLOSE
+                            : ExternalDisplayControlActivity.PresentationEndReason.CONNECTION_ERROR;
+                    timerHandler.removeCallbacks(presentationControllerFocusTimeout);
+                    ExternalDisplayControlActivity.finishForPresentationEnd(presentationEndReason);
+                    try {
+                        stopService(new Intent(Game.this, StreamPresentationService.class));
+                    } catch (RuntimeException ignored) {
+                    }
+                }
+
                 // Let the display go to sleep now
                 getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
@@ -3566,7 +4069,6 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
                 if (!displayedFailureDialog) {
                     displayedFailureDialog = true;
-                    LimeLog.severe("Connection terminated: " + errorCode);
                     stopConnection();
 
                     // Display the error dialog if it was an unexpected termination.
@@ -3680,7 +4182,21 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 timerHandler.postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        setInputGrabState(true);
+                        if (inPresentationMode) {
+                            cursorVisible = false;
+                            grabbedInput = true;
+                            boolean takeoverRequested =
+                                    ExternalDisplayControlActivity.requestPresentationControllerTakeover(Game.this);
+                            LimeLog.info("Presentation controller takeover requested="
+                                    + takeoverRequested);
+                            timerHandler.removeCallbacks(presentationControllerFocusTimeout);
+                            timerHandler.postDelayed(
+                                    presentationControllerFocusTimeout,
+                                    PRESENTATION_CONTROLLER_FOCUS_TIMEOUT_MS);
+                        }
+                        else {
+                            setInputGrabState(true);
+                        }
                     }
                 }, 500);
 
@@ -4107,7 +4623,9 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
             }
         }
 
-        options.add(new MouseModeOption(-1, getString(R.string.toggle_local_mouse_cursor)));
+        if (!inPresentationMode) {
+            options.add(new MouseModeOption(-1, getString(R.string.toggle_local_mouse_cursor)));
+        }
 
         String[] labels = new String[options.size()];
         for (int i = 0; i < options.size(); i++) {
@@ -4138,6 +4656,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
 
     //本地鼠标光标切换
     private void toggleMouseLocalCursor(){
+        if (inPresentationMode) {
+            cursorVisible = false;
+            inputCaptureProvider.hideCursor();
+            return;
+        }
         if (!grabbedInput) {
             inputCaptureProvider.enableCapture();
             grabbedInput = true;
@@ -4215,6 +4738,12 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         if (prefConfig.smartClipboardSync) {
             getClipboard(-1);
         }
+        if (inPresentationMode) {
+            try {
+                stopService(new Intent(this, StreamPresentationService.class));
+            } catch (RuntimeException ignored) {
+            }
+        }
         finish();
     }
 
@@ -4232,6 +4761,12 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
         builder.setPositiveButton(getString(R.string.yes), (dialog, which) -> {
             quitOnStop = true;
             dialog.dismiss();
+            if (inPresentationMode) {
+                try {
+                    stopService(new Intent(this, StreamPresentationService.class));
+                } catch (RuntimeException ignored) {
+                }
+            }
             finish();
         });
 

--- a/app/src/main/java/com/limelight/StartExternalDisplayControlReceiver.java
+++ b/app/src/main/java/com/limelight/StartExternalDisplayControlReceiver.java
@@ -11,8 +11,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.view.Display;
 
-import androidx.annotation.RequiresApi;
-
 import com.limelight.utils.ExternalDisplayControlActivity;
 
 public class StartExternalDisplayControlReceiver extends BroadcastReceiver {
@@ -20,18 +18,27 @@ public class StartExternalDisplayControlReceiver extends BroadcastReceiver {
     private static Handler handler = new Handler(Looper.getMainLooper());
     private static boolean isTimeoutActive = false;
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
     public void onReceive(Context context, Intent intent) {
-        requestFocusToGameActivity(true);
+        requestFocusToExternalDisplayControl(context);
     }
 
-    public static void requestFocusToExternalDisplayControl(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Intent intentTouchpad = new Intent(context, ExternalDisplayControlActivity.class);
-            intentTouchpad.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            Bundle optionsDefault = ActivityOptions.makeBasic().setLaunchDisplayId(Display.DEFAULT_DISPLAY).toBundle();
-            context.startActivity(intentTouchpad, optionsDefault);
+    public static boolean requestFocusToExternalDisplayControl(Context context) {
+        Intent intentTouchpad = new Intent(context, ExternalDisplayControlActivity.class);
+        intentTouchpad.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                Bundle optionsDefault = ActivityOptions.makeBasic().setLaunchDisplayId(Display.DEFAULT_DISPLAY).toBundle();
+                context.startActivity(intentTouchpad, optionsDefault);
+            }
+            else {
+                context.startActivity(intentTouchpad);
+            }
+            return true;
+        }
+        catch (RuntimeException e) {
+            LimeLog.warning("Unable to focus external display controller: " + e);
+            return false;
         }
     }
 
@@ -45,6 +52,8 @@ public class StartExternalDisplayControlReceiver extends BroadcastReceiver {
         if (Game.instance != null) {
             if (focusExternalDisplayControl) {
                 requestFocusToExternalDisplayControl(Game.instance);
+                handler.postDelayed(() -> isTimeoutActive = false, TIMEOUT_MS);
+                return;
             }
             ActivityManager am = (ActivityManager) Game.instance.getSystemService(Context.ACTIVITY_SERVICE);
             if (am != null) {

--- a/app/src/main/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProvider.java
+++ b/app/src/main/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProvider.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.hardware.input.InputManager;
 import android.os.Build;
 import android.os.Handler;
+import android.os.Looper;
 import android.view.InputDevice;
 import android.view.MotionEvent;
 import android.view.View;
@@ -17,6 +18,10 @@ import android.view.View;
 public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptureProvider implements InputManager.InputDeviceListener {
     private final InputManager inputManager;
     private final View targetView;
+    private final Handler captureHandler = new Handler(Looper.getMainLooper());
+    private final Runnable recaptureRunnable = this::requestPointerCaptureIfReady;
+    private boolean inputDeviceListenerRegistered;
+    private boolean destroyed;
 
     public AndroidNativePointerCaptureProvider(Activity activity, View targetView) {
         super(activity, targetView);
@@ -26,6 +31,20 @@ public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptu
 
     public static boolean isCaptureProviderSupported() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
+    }
+
+    private void registerInputDeviceListenerIfNeeded() {
+        if (!destroyed && inputManager != null && !inputDeviceListenerRegistered) {
+            inputManager.registerInputDeviceListener(this, null);
+            inputDeviceListenerRegistered = true;
+        }
+    }
+
+    private void unregisterInputDeviceListenerIfNeeded() {
+        if (inputManager != null && inputDeviceListenerRegistered) {
+            inputManager.unregisterInputDeviceListener(this);
+            inputDeviceListenerRegistered = false;
+        }
     }
 
     // We only capture the pointer if we have a compatible InputDevice
@@ -61,15 +80,53 @@ public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptu
         return false;
     }
 
+    static boolean isCaptureActive(boolean captureEnabled,
+                                   boolean cursorVisible,
+                                   boolean attachedToWindow,
+                                   boolean hasWindowFocus,
+                                   boolean hasPointerCapture) {
+        return captureEnabled
+                && !cursorVisible
+                && attachedToWindow
+                && hasWindowFocus
+                && hasPointerCapture;
+    }
+
+    @Override
+    public boolean isCapturingActive() {
+        return !destroyed && isCaptureActive(
+                isCapturing,
+                isCursorVisible,
+                targetView.isAttachedToWindow(),
+                targetView.hasWindowFocus(),
+                targetView.hasPointerCapture());
+    }
+
+    private void requestPointerCaptureIfReady() {
+        if (destroyed || !isCapturing || isCursorVisible
+                || !targetView.isAttachedToWindow()
+                || !targetView.hasWindowFocus()
+                || targetView.hasPointerCapture()) {
+            return;
+        }
+
+        if (hasCaptureCompatibleInputDevice()) {
+            targetView.requestPointerCapture();
+        }
+    }
+
     @Override
     public void showCursor() {
+        captureHandler.removeCallbacks(recaptureRunnable);
         super.showCursor();
 
         // It is important to unregister the listener *before* releasing pointer capture,
         // because releasing pointer capture can cause an onInputDeviceChanged() callback
         // for devices with a touchpad (like a DS4 controller).
-        inputManager.unregisterInputDeviceListener(this);
-        targetView.releasePointerCapture();
+        unregisterInputDeviceListenerIfNeeded();
+        if (targetView.hasPointerCapture()) {
+            targetView.releasePointerCapture();
+        }
     }
 
     @Override
@@ -77,16 +134,28 @@ public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptu
         super.hideCursor();
 
         // Listen for device events to enable/disable capture
-        inputManager.registerInputDeviceListener(this, null);
+        registerInputDeviceListenerIfNeeded();
 
         // Capture now if we have a capture-capable device
-        if (hasCaptureCompatibleInputDevice()) {
-            targetView.requestPointerCapture();
+        requestPointerCaptureIfReady();
+    }
+
+    @Override
+    public void destroy() {
+        destroyed = true;
+        isCapturing = false;
+        captureHandler.removeCallbacks(recaptureRunnable);
+        unregisterInputDeviceListenerIfNeeded();
+        if (targetView.hasPointerCapture()) {
+            targetView.releasePointerCapture();
         }
+        super.destroy();
     }
 
     @Override
     public void onWindowFocusChanged(boolean focusActive) {
+        captureHandler.removeCallbacks(recaptureRunnable);
+
         // NB: We have to check cursor visibility here because Android pointer capture
         // doesn't support capturing the cursor while it's visible. Enabling pointer
         // capture implicitly hides the cursor.
@@ -98,15 +167,7 @@ public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptu
         // we have to delay a bit before requesting capture because otherwise
         // we'll hit the "requestPointerCapture called for a window that has no focus"
         // error and it will not actually capture the cursor.
-        Handler h = new Handler();
-        h.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (hasCaptureCompatibleInputDevice()) {
-                    targetView.requestPointerCapture();
-                }
-            }
-        }, 500);
+        captureHandler.postDelayed(recaptureRunnable, 500);
     }
 
     @Override
@@ -144,9 +205,7 @@ public class AndroidNativePointerCaptureProvider extends AndroidPointerIconCaptu
     @Override
     public void onInputDeviceAdded(int deviceId) {
         // Check if we've added a capture-compatible device
-        if (!targetView.hasPointerCapture() && hasCaptureCompatibleInputDevice()) {
-            targetView.requestPointerCapture();
-        }
+        requestPointerCaptureIfReady();
     }
 
     @Override

--- a/app/src/main/java/com/limelight/binding/input/capture/InputCaptureManager.java
+++ b/app/src/main/java/com/limelight/binding/input/capture/InputCaptureManager.java
@@ -1,6 +1,7 @@
 package com.limelight.binding.input.capture;
 
 import android.app.Activity;
+import android.view.View;
 
 import com.limelight.BuildConfig;
 import com.limelight.LimeLog;
@@ -10,9 +11,15 @@ import com.limelight.binding.input.evdev.EvdevListener;
 
 public class InputCaptureManager {
     public static InputCaptureProvider getInputCaptureProvider(Activity activity, EvdevListener rootListener) {
+        return getInputCaptureProvider(activity, activity.findViewById(R.id.streamContainer), rootListener);
+    }
+
+    public static InputCaptureProvider getInputCaptureProvider(Activity activity,
+                                                              View targetView,
+                                                              EvdevListener rootListener) {
         if (AndroidNativePointerCaptureProvider.isCaptureProviderSupported()) {
             LimeLog.info("Using Android O+ native mouse capture");
-            return new AndroidNativePointerCaptureProvider(activity, activity.findViewById(R.id.streamContainer));
+            return new AndroidNativePointerCaptureProvider(activity, targetView);
         }
         // LineageOS implemented broken NVIDIA capture extensions, so avoid using them on root builds.
         // See https://github.com/LineageOS/android_frameworks_base/commit/d304f478a023430f4712dbdc3ee69d9ad02cebd3
@@ -28,7 +35,7 @@ public class InputCaptureManager {
             // Android N's native capture can't capture over system UI elements
             // so we want to only use it if there's no other option.
             LimeLog.info("Using Android N+ pointer hiding");
-            return new AndroidPointerIconCaptureProvider(activity, activity.findViewById(R.id.streamContainer));
+            return new AndroidPointerIconCaptureProvider(activity, targetView);
         }
         else {
             LimeLog.info("Mouse capture not available");

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -796,11 +796,15 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
     @Override
     public int setup(int format, int width, int height, int redrawRate) {
-        this.targetFps = (redrawRate > 0 ? redrawRate : 60);
+        int normalizedRedrawRate = Math.round(normalizeSurfaceFrameRate(redrawRate));
+        if (normalizedRedrawRate <= 0) {
+            normalizedRedrawRate = 60;
+        }
+        this.targetFps = normalizedRedrawRate;
         this.initialWidth = invertResolution ? height : width;
         this.initialHeight = invertResolution ? width : height;
         this.videoFormat = format;
-        this.refreshRate = redrawRate;
+        this.refreshRate = normalizedRedrawRate;
 
         return initializeDecoder(false);
     }
@@ -2409,14 +2413,23 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     }
 
 
+    static float normalizeSurfaceFrameRate(int frameRate) {
+        if (frameRate > 1000) {
+            return frameRate / 1000f;
+        }
+
+        return frameRate;
+    }
+
     private void applySurfaceFrameRate(android.view.Surface surface, int targetFps) {
         if (surface == null) return;
         try {
             // API 30+ supports Surface.setFrameRate; for older, attempt View-based call elsewhere.
             if (android.os.Build.VERSION.SDK_INT >= 30) {
-                surface.setFrameRate((float) targetFps,
+                float surfaceFrameRate = normalizeSurfaceFrameRate(targetFps);
+                surface.setFrameRate(surfaceFrameRate,
                         android.view.Surface.FRAME_RATE_COMPATIBILITY_DEFAULT);
-                LimeLog.info("Applied Surface frame rate: " + targetFps + " Hz");
+                LimeLog.info("Applied Surface frame rate: " + surfaceFrameRate + " Hz");
             }
         } catch (Throwable t) {
             // best-effort

--- a/app/src/main/java/com/limelight/ui/ExternalControllerView.java
+++ b/app/src/main/java/com/limelight/ui/ExternalControllerView.java
@@ -1,13 +1,20 @@
 package com.limelight.ui;
 
 import android.content.Context;
+import android.os.Build;
+import android.view.InputDevice;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
 
+import com.limelight.BuildConfig;
+
 public class ExternalControllerView extends FrameLayout {
     private InputCallbacks inputCallbacks;
+    private Runnable userActivityCallback;
 
     // When enabled, we expose an InputConnection so that soft keyboards can send
     // commitText() events (e.g. swipe typing). Default disabled.
@@ -15,6 +22,10 @@ public class ExternalControllerView extends FrameLayout {
 
     public void setInputCallbacks(InputCallbacks callbacks) {
         this.inputCallbacks = callbacks;
+    }
+
+    public void setUserActivityCallback(Runnable callback) {
+        this.userActivityCallback = callback;
     }
 
     public void setCommitTextEnabled(boolean enabled) {
@@ -28,6 +39,81 @@ public class ExternalControllerView extends FrameLayout {
 
     public ExternalControllerView(@NonNull Context context) {
         super(context);
+    }
+
+    private static boolean shouldOfferToGame(MotionEvent event) {
+        int source = event.getSource();
+        boolean pointerOrPosition = (source & InputDevice.SOURCE_CLASS_POINTER) != 0
+                || (source & InputDevice.SOURCE_CLASS_POSITION) != 0
+                || source == InputDevice.SOURCE_MOUSE_RELATIVE;
+        if (!pointerOrPosition) {
+            return false;
+        }
+
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_HOVER_ENTER:
+            case MotionEvent.ACTION_HOVER_MOVE:
+            case MotionEvent.ACTION_HOVER_EXIT:
+            case MotionEvent.ACTION_MOVE:
+            case MotionEvent.ACTION_SCROLL:
+            case MotionEvent.ACTION_BUTTON_PRESS:
+            case MotionEvent.ACTION_BUTTON_RELEASE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void logMotionBoundary(String boundary, MotionEvent event) {
+        if (!BuildConfig.DEBUG || event == null) {
+            return;
+        }
+
+        android.util.Log.i("MoonlightInput", boundary
+                + " action=" + MotionEvent.actionToString(event.getActionMasked())
+                + " source=0x" + Integer.toHexString(event.getSource())
+                + " pointerCapture=" + (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && hasPointerCapture()));
+    }
+
+    private void reportUserActivity(MotionEvent event) {
+        if (userActivityCallback != null && shouldOfferToGame(event)) {
+            userActivityCallback.run();
+        }
+    }
+
+    @Override
+    public boolean dispatchGenericMotionEvent(MotionEvent event) {
+        logMotionBoundary("ExternalControllerView.dispatchGenericMotionEvent", event);
+        reportUserActivity(event);
+
+        if (inputCallbacks != null && shouldOfferToGame(event) &&
+                inputCallbacks.handleGenericMotion(this, event)) {
+            return true;
+        }
+
+        return super.dispatchGenericMotionEvent(event);
+    }
+
+    @Override
+    public boolean onCapturedPointerEvent(MotionEvent event) {
+        logMotionBoundary("ExternalControllerView.onCapturedPointerEvent", event);
+        reportUserActivity(event);
+        if (inputCallbacks != null && shouldOfferToGame(event) &&
+                inputCallbacks.handleGenericMotion(this, event)) {
+            return true;
+        }
+
+        return super.onCapturedPointerEvent(event);
+    }
+
+    @Override
+    public void onPointerCaptureChange(boolean hasCapture) {
+        super.onPointerCaptureChange(hasCapture);
+        if (BuildConfig.DEBUG) {
+            android.util.Log.i("MoonlightInput", "ExternalControllerView pointerCapture="
+                    + hasCapture + " attached=" + isAttachedToWindow()
+                    + " windowFocus=" + hasWindowFocus());
+        }
     }
 
     @Override
@@ -85,6 +171,7 @@ public class ExternalControllerView extends FrameLayout {
     }
 
     public interface InputCallbacks {
+        boolean handleGenericMotion(View view, MotionEvent event);
         boolean handleKeyUp(KeyEvent event);
         boolean handleKeyDown(KeyEvent event);
         boolean handleCommitText(CharSequence text);

--- a/app/src/main/java/com/limelight/ui/StreamContainer.java
+++ b/app/src/main/java/com/limelight/ui/StreamContainer.java
@@ -25,6 +25,11 @@ import com.limelight.utils.Stereo3DRenderer;
  */
 public class StreamContainer extends FrameLayout implements SurfaceHolder.Callback, Stereo3DRenderer.OnSurfaceReadyListener {
 
+    public interface SurfaceAvailableCallback {
+        void onSurfaceAvailable(Surface surface);
+        void onSurfaceDestroyed();
+    }
+
     public interface InputCallbacks {
         boolean handleKeyUp(KeyEvent event);
         boolean handleKeyDown(KeyEvent event);
@@ -46,6 +51,7 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
     private SurfaceView mSurfaceView;
     private Surface mCurrentSurface;
     private Runnable onSurfaceAvailable;
+    private SurfaceAvailableCallback surfaceAvailableCallback;
     private StreamMode renderMode = null;
     private InputCallbacks mInputCallbacks;
     private boolean commitTextEnabled = false;
@@ -68,6 +74,22 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
         }
 
         this.game = game;
+        initInternal(prefConfig);
+    }
+
+    public void setSurfaceAvailableCallback(SurfaceAvailableCallback callback) {
+        this.surfaceAvailableCallback = callback;
+    }
+
+    public void initAsPresentation(PreferenceConfiguration prefConfig) {
+        if (this.prefConfig != null) {
+            return;
+        }
+        this.game = null;
+        initInternal(prefConfig);
+    }
+
+    private void initInternal(PreferenceConfiguration prefConfig) {
         this.prefConfig = prefConfig;
         this.renderMode = mapIntToStreamMode(prefConfig.renderMode);
 
@@ -79,7 +101,7 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
         Context context = getContext();
         LayoutParams childParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
 
-        // Always craete a surface view as a Workaround for the sizing issue of GLSurfaceView
+        // Always create a surface view as a workaround for the sizing issue of GLSurfaceView
         mSurfaceView = new SurfaceView(context);
         addView(mSurfaceView, childParams);
 
@@ -230,11 +252,16 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
         if (onSurfaceAvailable != null) {
             onSurfaceAvailable.run();
         }
+        if (surfaceAvailableCallback != null && mCurrentSurface != null && mCurrentSurface.isValid()) {
+            surfaceAvailableCallback.onSurfaceAvailable(mCurrentSurface);
+        }
     }
 
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
-        game.surfaceCreated(holder);
+        if (game != null) {
+            game.surfaceCreated(holder);
+        }
     }
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
@@ -243,7 +270,9 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
             notifySurfaceReady();
         }
 
-        game.surfaceChanged(holder, format, width, height);
+        if (game != null) {
+            game.surfaceChanged(holder, format, width, height);
+        }
     }
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
@@ -254,7 +283,12 @@ public class StreamContainer extends FrameLayout implements SurfaceHolder.Callba
             mStereoRenderer.onSurfaceDestroyed();
         }
 
-        game.surfaceDestroyed(holder);
+        if (surfaceAvailableCallback != null) {
+            surfaceAvailableCallback.onSurfaceDestroyed();
+        }
+        if (game != null) {
+            game.surfaceDestroyed(holder);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/limelight/utils/ExternalDisplayControlActivity.java
+++ b/app/src/main/java/com/limelight/utils/ExternalDisplayControlActivity.java
@@ -1,18 +1,12 @@
 package com.limelight.utils;
 
 import static com.limelight.StartExternalDisplayControlReceiver.requestFocusToGameActivity;
+import static com.limelight.StartExternalDisplayControlReceiver.requestFocusToExternalDisplayControl;
 import static com.limelight.utils.ServerHelper.getSecondaryDisplay;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
-import android.app.ActivityOptions;
-import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Build;
@@ -34,18 +28,15 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
-import androidx.core.app.NotificationCompat;
-import androidx.core.content.ContextCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
+import com.limelight.BuildConfig;
 import com.limelight.Game;
 import com.limelight.GameMenu;
 import com.limelight.LimeLog;
 import com.limelight.R;
-import com.limelight.StartExternalDisplayControlReceiver;
 import com.limelight.binding.input.virtual_controller.keyboard.KeyBoardLayoutController;
 import com.limelight.preferences.PreferenceConfiguration;
 import com.limelight.ui.ExternalControllerView;
@@ -61,6 +52,23 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
     @SuppressLint("StaticFieldLeak")
     public static ExternalDisplayControlActivity instance;
 
+    public enum PresentationState {
+        IDLE,
+        LAUNCHING_GAME,
+        WAITING_FOR_CONTROLLER_FOCUS,
+        CONTROLLER_ACTIVE,
+        ENDING
+    }
+
+    public enum PresentationEndReason {
+        USER_CLOSE,
+        USER_LEFT,
+        CONTROLLER_DESTROYED,
+        DISPLAY_REMOVED,
+        FOCUS_TIMEOUT,
+        CONNECTION_ERROR
+    }
+
     private PreferenceConfiguration prefConfig;
 
     private ExternalControllerView rootLayout;
@@ -71,14 +79,13 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
 
     private final Handler handler = new Handler(Looper.getMainLooper());
     private int failCount = 0;
+    private boolean pendingGameLaunch;
+    private boolean userLeaving;
+    private boolean finishingFromGame;
+    private PresentationState presentationState = PresentationState.IDLE;
     private Runnable dimScreenRunnable;
     private float originalBrightness = -1f; // -1 = use system default
     private static final int INACTIVITY_TIMEOUT_MS = 10_000;
-
-
-    private static final String NOTIFICATION_CHANNEL_ID = "secondary_screen_active_channel_id";
-    public static final int SECONDARY_SCREEN_NOTIFICATION_ID = 1;
-    private static final int PERMISSION_REQUEST_CODE = 1001;
 
     private GameMenu gameMenu;
 
@@ -86,8 +93,107 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
 
     public static void closeExternalDisplayControl() {
         if (instance != null) {
-            instance.finish();
+            Game game = Game.instance;
+            if (game != null && game.isInPresentationMode()) {
+                instance.requestPresentationEnd(PresentationEndReason.USER_CLOSE);
+            }
+            else {
+                instance.finish();
+            }
         }
+    }
+
+    public static boolean isPresentationStateAlive(PresentationState state) {
+        return state == PresentationState.LAUNCHING_GAME
+                || state == PresentationState.WAITING_FOR_CONTROLLER_FOCUS
+                || state == PresentationState.CONTROLLER_ACTIVE;
+    }
+
+    public static boolean shouldKeepPresentationAlive(PresentationState state,
+                                                      boolean controllerAvailable) {
+        return controllerAvailable && isPresentationStateAlive(state);
+    }
+
+    public static boolean shouldEndPresentationOnControllerStop(PresentationState state,
+                                                                 boolean userLeaving,
+                                                                 boolean changingConfigurations) {
+        return state == PresentationState.CONTROLLER_ACTIVE
+                && userLeaving
+                && !changingConfigurations;
+    }
+
+    public static boolean shouldEndPresentationOnControllerDestroy(PresentationState state,
+                                                                    boolean changingConfigurations,
+                                                                    boolean finishingFromGame) {
+        return isPresentationStateAlive(state)
+                && !changingConfigurations
+                && !finishingFromGame;
+    }
+
+    public static boolean shouldKeepPresentationAlive() {
+        return instance != null
+                && shouldKeepPresentationAlive(instance.presentationState, true);
+    }
+
+    public static boolean isPresentationControllerActive() {
+        return instance != null
+                && instance.presentationState == PresentationState.CONTROLLER_ACTIVE
+                && instance.hasWindowFocus();
+    }
+
+    public static boolean requestPresentationControllerTakeover(Game game) {
+        return instance != null && instance.requestControllerTakeover(game);
+    }
+
+    public static void finishForPresentationEnd(PresentationEndReason reason) {
+        if (instance != null) {
+            instance.finishFromGame(reason);
+        }
+    }
+
+    public static boolean shouldRequestGameFocusForControllerInput(boolean gameAvailable,
+                                                                   boolean inPresentationMode,
+                                                                   int deviceId) {
+        return gameAvailable && !inPresentationMode && deviceId >= 0;
+    }
+
+    public static boolean forwardControllerKeyEvent(Game game, KeyEvent event) {
+        if (game == null || event == null) {
+            return false;
+        }
+
+        switch (event.getAction()) {
+            case KeyEvent.ACTION_DOWN:
+                return game.handleKeyDown(event);
+            case KeyEvent.ACTION_UP:
+                return game.handleKeyUp(event);
+            case KeyEvent.ACTION_MULTIPLE:
+                return game.handleKeyMultiple(event);
+            default:
+                return false;
+        }
+    }
+
+    public static boolean forwardControllerTouchEvent(Game game, View view, MotionEvent event) {
+        return game != null && event != null && game.handleMotionEvent(view, event);
+    }
+
+    public static boolean shouldFinishWhenGameUnavailable(boolean pendingGameLaunch,
+                                                          boolean gameAvailable) {
+        return !pendingGameLaunch && !gameAvailable;
+    }
+
+    public static boolean shouldActivatePresentationController(PresentationState state,
+                                                               boolean gameAvailable,
+                                                               boolean inPresentationMode,
+                                                               boolean rootAttached,
+                                                               boolean windowFocused) {
+        return (state == PresentationState.WAITING_FOR_CONTROLLER_FOCUS
+                || state == PresentationState.CONTROLLER_ACTIVE)
+                && gameAvailable
+                && inPresentationMode
+                && rootAttached
+                && windowFocused;
     }
 
     public static void toggleKeyboard() {
@@ -116,46 +222,100 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
 
         instance = this;
         prefConfig = PreferenceConfiguration.readPreferences(this);
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
-        if (!isGameInstanceAvailable()) {
-            Intent gameIntent = getIntent().getParcelableExtra(EXTRA_LAUNCH_INTENT);
-            if (gameIntent == null) {
-                finish();
-            } else {
-                Display secondaryDisplay = getSecondaryDisplay(this);
-                if (secondaryDisplay != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    ActivityOptions options = ActivityOptions.makeBasic();
-                    options.setLaunchDisplayId(secondaryDisplay.getDisplayId());
-                    Toast.makeText(this,
-                            getString(R.string.external_display_info,
-                                    secondaryDisplay.getMode().getPhysicalWidth(),
-                                    secondaryDisplay.getMode().getPhysicalHeight(),
-                                    secondaryDisplay.getMode().getRefreshRate()),
-                            Toast.LENGTH_LONG).show();
-
-                    startActivity(gameIntent, options.toBundle());
-                } else {
-                    LimeLog.warning(getString(R.string.no_external_display));
-                    startActivity(gameIntent);
-                    finish();
-                }
-            }
+        if (!handleLaunchIntent(getIntent()) && !isGameInstanceAvailable()) {
+            finish();
+            return;
         }
 
         initViews();
     }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleLaunchIntent(intent);
+        activatePresentationControllerIfReady();
+    }
+
+    private boolean handleLaunchIntent(Intent intent) {
+        if (isGameInstanceAvailable()) {
+            if (Game.instance.isInPresentationMode() && presentationState == PresentationState.IDLE) {
+                presentationState = PresentationState.WAITING_FOR_CONTROLLER_FOCUS;
+            }
+            return false;
+        }
+
+        Intent gameIntent = intent.getParcelableExtra(EXTRA_LAUNCH_INTENT);
+        if (gameIntent == null) {
+            return false;
+        }
+
+        pendingGameLaunch = true;
+        userLeaving = false;
+        finishingFromGame = false;
+        presentationState = PresentationState.LAUNCHING_GAME;
+        Display secondaryDisplay = getSecondaryDisplay(this);
+        if (secondaryDisplay != null) {
+            Toast.makeText(this,
+                    getString(R.string.external_display_info,
+                            secondaryDisplay.getMode().getPhysicalWidth(),
+                            secondaryDisplay.getMode().getPhysicalHeight(),
+                            secondaryDisplay.getMode().getRefreshRate()),
+                    Toast.LENGTH_LONG).show();
+
+            boolean launched = startPresentationFallback(gameIntent, secondaryDisplay);
+            if (!launched) {
+                presentationState = PresentationState.ENDING;
+                LimeLog.warning(getString(R.string.no_external_display));
+                try {
+                    startActivity(gameIntent);
+                } catch (RuntimeException e) {
+                    LimeLog.warning("Starting Game on default display failed: " + e);
+                }
+                finish();
+            }
+        } else {
+            presentationState = PresentationState.ENDING;
+            LimeLog.warning(getString(R.string.no_external_display));
+            startActivity(gameIntent);
+            finish();
+        }
+
+        return true;
+    }
+
+    private boolean startPresentationFallback(Intent gameIntent, Display secondaryDisplay) {
+        gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY);
+        gameIntent.putExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, secondaryDisplay.getDisplayId());
+        try {
+            startActivity(gameIntent);
+            return true;
+        } catch (RuntimeException e) {
+            LimeLog.warning("Fallback startActivity (Presentation path) failed: " + e);
+            return false;
+        }
+    }
+
     private void initViews() {
         if (Game.instance == null) {
             if (failCount > 10) {
+                pendingGameLaunch = false;
+                presentationState = PresentationState.ENDING;
                 Toast.makeText(this, getString(R.string.no_game_instance), Toast.LENGTH_LONG).show();
                 finish();
+                return;
             }
             // Wait for the intent to get started
             handler.postDelayed(this::initViews, 500);
             failCount++;
             return;
         }
+
+        pendingGameLaunch = false;
+        failCount = 0;
 
         WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
 
@@ -177,10 +337,8 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
 
         initializeComponents();
         createProgrammaticUI();
-        checkNotificationPermission();
         initTouchEventHandling();
         setupInactivityTimeoutForBrightness();
-        requestFocusToGameActivity(false);
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -188,9 +346,7 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
         // Intercept touch events on root layout
         rootLayout.setOnTouchListener((v, event) -> {
             handleUserActivity();
-            if (Game.instance != null) {
-                Game.instance.handleMotionEvent(v, event);
-            }
+            forwardControllerTouchEvent(Game.instance, v, event);
             return true;
         });
     }
@@ -198,7 +354,9 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
     @Override
     protected void onResume() {
         super.onResume();
-        if (!isGameInstanceAvailable() && gameMenu != null) {
+        userLeaving = false;
+        activatePresentationControllerIfReady();
+        if (!pendingGameLaunch && !isGameInstanceAvailable() && gameMenu != null) {
             finish();
         }
     }
@@ -206,15 +364,44 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
     @Override
     protected void onPause() {
         super.onPause();
-        if (!isGameInstanceAvailable()) {
+        if (!pendingGameLaunch && !isGameInstanceAvailable()) {
             finish();
         }
     }
 
     @Override
+    protected void onStop() {
+        super.onStop();
+        if (shouldEndPresentationOnControllerStop(
+                presentationState,
+                userLeaving,
+                isChangingConfigurations())) {
+            requestPresentationEnd(PresentationEndReason.USER_LEFT);
+        }
+    }
+
+    @Override
     protected void onDestroy() {
+        handler.removeCallbacksAndMessages(null);
+        if (shouldEndPresentationOnControllerDestroy(
+                presentationState,
+                isChangingConfigurations(),
+                finishingFromGame)) {
+            requestPresentationEnd(PresentationEndReason.CONTROLLER_DESTROYED);
+        }
+        if (instance == this) {
+            instance = null;
+        }
         super.onDestroy();
-        instance = null;
+    }
+
+    @Override
+    protected void onUserLeaveHint() {
+        super.onUserLeaveHint();
+        if (presentationState == PresentationState.CONTROLLER_ACTIVE) {
+            userLeaving = true;
+            LimeLog.info("Presentation controller user leave requested");
+        }
     }
 
     @Override
@@ -278,9 +465,20 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
-        if (isGameInstanceAvailable()) {
-            Game.instance.handleFocusChange(hasFocus);
-        } else {
+        Game game = Game.instance;
+        if (game != null) {
+            if (game.isInPresentationMode()) {
+                if (hasFocus) {
+                    activatePresentationControllerIfReady();
+                }
+                else if (presentationState == PresentationState.CONTROLLER_ACTIVE) {
+                    game.onPresentationControllerWindowFocusChanged(false);
+                    game.setMetaKeyCaptureState(getComponentName(), false);
+                }
+            } else {
+                game.handleFocusChange(hasFocus);
+            }
+        } else if (shouldFinishWhenGameUnavailable(pendingGameLaunch, false)) {
             finish();
         }
     }
@@ -302,7 +500,7 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
      * Checks if the static Game.instance is alive. If not, finishes this Activity.
      */
     private boolean isGameInstanceAvailable() {
-        return Game.instance != null;
+        return Game.instance != null && !Game.instance.isFinishing() && !Game.instance.isDestroyed();
     }
 
     /**
@@ -310,6 +508,44 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
      */
     private void initializeComponents() {
         this.gameMenu = new GameMenu(Game.instance, instance);
+    }
+
+    private void logGenericMotionForwarding(String boundary, MotionEvent event) {
+        if (!BuildConfig.DEBUG || event == null) {
+            return;
+        }
+
+        android.util.Log.i("MoonlightInput", boundary
+                + " action=" + MotionEvent.actionToString(event.getActionMasked())
+                + " source=0x" + Integer.toHexString(event.getSource()));
+    }
+
+    private void logKeyForwarding(String boundary, KeyEvent event, Game game, boolean consumed) {
+        if (!BuildConfig.DEBUG || event == null) {
+            return;
+        }
+
+        android.util.Log.i("MoonlightInput", boundary
+                + " action=" + keyActionToString(event.getAction())
+                + " keyCode=" + KeyEvent.keyCodeToString(event.getKeyCode())
+                + " scanCode=" + event.getScanCode()
+                + " source=0x" + Integer.toHexString(event.getSource())
+                + " deviceId=" + event.getDeviceId()
+                + " grabbed=" + (game != null && game.isInputGrabbed())
+                + " consumed=" + consumed);
+    }
+
+    private static String keyActionToString(int action) {
+        switch (action) {
+            case KeyEvent.ACTION_DOWN:
+                return "ACTION_DOWN";
+            case KeyEvent.ACTION_UP:
+                return "ACTION_UP";
+            case KeyEvent.ACTION_MULTIPLE:
+                return "ACTION_MULTIPLE";
+            default:
+                return Integer.toString(action);
+        }
     }
 
     @Override
@@ -322,64 +558,76 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
 
     @Override
     public boolean onGenericMotionEvent(MotionEvent event) {
-        if (Game.instance != null) {
-            requestFocusToGameActivity(false);
-            return Game.instance.onGenericMotionEvent(event);
+        logGenericMotionForwarding("ExternalDisplayControlActivity.onGenericMotionEvent", event);
+        handleUserActivity();
+        Game game = Game.instance;
+        if (game != null) {
+            if (shouldRequestGameFocusForControllerInput(true, game.isInPresentationMode(), event.getDeviceId())) {
+                requestFocusToGameActivity(false);
+            }
+            return game.onGenericMotionEvent(event);
         }
         return false;
     }
 
     @Override
     public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
-        if (Game.instance != null) {
-            if (keyEvent.getDeviceId() >= 0) {
+        Game game = Game.instance;
+        if (game != null) {
+            if (shouldRequestGameFocusForControllerInput(true, game.isInPresentationMode(), keyEvent.getDeviceId())) {
                 requestFocusToGameActivity(false);
             }
-            switch (keyEvent.getAction()) {
-                case KeyEvent.ACTION_DOWN:
-                    return Game.instance.handleKeyDown(keyEvent);
-                case KeyEvent.ACTION_UP:
-                    return Game.instance.handleKeyUp(keyEvent);
-                case KeyEvent.ACTION_MULTIPLE:
-                    return Game.instance.handleKeyMultiple(keyEvent);
-                default:
-                    return false;
-            }
+            boolean consumed = forwardControllerKeyEvent(game, keyEvent);
+            logKeyForwarding("ExternalDisplayControlActivity.onKey", keyEvent, game, consumed);
+            return consumed;
         }
 
+        logKeyForwarding("ExternalDisplayControlActivity.onKey", keyEvent, null, false);
         return false;
     }
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (Game.instance != null) {
-            if (event.getDeviceId() >= 0) {
+        Game game = Game.instance;
+        if (game != null) {
+            if (shouldRequestGameFocusForControllerInput(true, game.isInPresentationMode(), event.getDeviceId())) {
                 requestFocusToGameActivity(false);
             }
-            return Game.instance.onKeyDown(keyCode, event);
+            boolean consumed = forwardControllerKeyEvent(game, event);
+            logKeyForwarding("ExternalDisplayControlActivity.onKeyDown", event, game, consumed);
+            return consumed;
         }
+        logKeyForwarding("ExternalDisplayControlActivity.onKeyDown", event, null, false);
         return false;
     }
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if (Game.instance != null) {
-            if (event.getDeviceId() >= 0) {
+        Game game = Game.instance;
+        if (game != null) {
+            if (shouldRequestGameFocusForControllerInput(true, game.isInPresentationMode(), event.getDeviceId())) {
                 requestFocusToGameActivity(false);
             }
-            return Game.instance.onKeyUp(keyCode, event);
+            boolean consumed = forwardControllerKeyEvent(game, event);
+            logKeyForwarding("ExternalDisplayControlActivity.onKeyUp", event, game, consumed);
+            return consumed;
         }
+        logKeyForwarding("ExternalDisplayControlActivity.onKeyUp", event, null, false);
         return false;
     }
 
     @Override
     public boolean onKeyMultiple(int keyCode, int repeatCount, KeyEvent event) {
-        if (Game.instance != null) {
-            if (event.getDeviceId() >= 0) {
+        Game game = Game.instance;
+        if (game != null) {
+            if (shouldRequestGameFocusForControllerInput(true, game.isInPresentationMode(), event.getDeviceId())) {
                 requestFocusToGameActivity(false);
             }
-            return Game.instance.onKeyMultiple(keyCode, repeatCount, event);
+            boolean consumed = forwardControllerKeyEvent(game, event);
+            logKeyForwarding("ExternalDisplayControlActivity.onKeyMultiple", event, game, consumed);
+            return consumed;
         }
+        logKeyForwarding("ExternalDisplayControlActivity.onKeyMultiple", event, null, false);
         return false;
     }
 
@@ -390,14 +638,18 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT));
         rootLayout.setFocusable(true);
+        rootLayout.setFocusableInTouchMode(true);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             rootLayout.setFocusedByDefault(true);
         }
 
         rootLayout.setInputCallbacks(Game.instance);
+        rootLayout.setUserActivityCallback(this::handleUserActivity);
         rootLayout.setCommitTextEnabled(prefConfig.enableCommitText);
 
         setContentView(rootLayout);
+        rootLayout.requestFocus();
+        activatePresentationControllerIfReady();
 
         // Top-left buttons
         LinearLayout topLeftButtons = createButtonContainer(Gravity.TOP | Gravity.START);
@@ -421,7 +673,9 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
         LinearLayout topRightButtons = createButtonContainer(Gravity.TOP | Gravity.END);
         topRightButtons.setFocusable(false);
         topRightButtons.addView(createImageButton(R.drawable.ic_menu_external, v -> showGameMenu()));
-        topRightButtons.addView(createImageButton(R.drawable.ic_close_external, v -> finish()));
+        topRightButtons.addView(createImageButton(
+                R.drawable.ic_close_external,
+                v -> requestPresentationEnd(PresentationEndReason.USER_CLOSE)));
         rootLayout.addView(topRightButtons);
 
         // Bottom-left button: Android keyboard toggle
@@ -456,6 +710,88 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
         keyBoardLayoutController.setViewCallbacks(this);
         keyBoardLayoutController.refreshLayout();
         keyBoardLayoutController.show();
+    }
+
+    private void retargetPresentationCaptureToController(Game game) {
+        if (game != null && game.isInPresentationMode() && rootLayout != null) {
+            game.replaceInputCaptureTarget(rootLayout);
+        }
+    }
+
+    private boolean requestControllerTakeover(Game game) {
+        if (game == null || !game.isInPresentationMode()
+                || !isPresentationStateAlive(presentationState)) {
+            return false;
+        }
+
+        if (presentationState == PresentationState.LAUNCHING_GAME) {
+            presentationState = PresentationState.WAITING_FOR_CONTROLLER_FOCUS;
+        }
+
+        LimeLog.info("Presentation controller state=" + presentationState
+                + " requesting default-display focus");
+        boolean focusRequested = requestFocusToExternalDisplayControl(game);
+        activatePresentationControllerIfReady();
+        return focusRequested;
+    }
+
+    private void activatePresentationControllerIfReady() {
+        Game game = Game.instance;
+        if (!shouldActivatePresentationController(
+                presentationState,
+                game != null,
+                game != null && game.isInPresentationMode(),
+                rootLayout != null && rootLayout.isAttachedToWindow(),
+                hasWindowFocus())) {
+            return;
+        }
+
+        boolean firstActivation = presentationState == PresentationState.WAITING_FOR_CONTROLLER_FOCUS;
+        presentationState = PresentationState.CONTROLLER_ACTIVE;
+        userLeaving = false;
+        rootLayout.requestFocus();
+        retargetPresentationCaptureToController(game);
+        game.onPresentationControllerWindowFocusChanged(true);
+        game.setMetaKeyCaptureState(getComponentName(), true);
+        game.onPresentationControllerActivated();
+        LimeLog.info("Presentation controller state=" + presentationState
+                + " firstActivation=" + firstActivation
+                + " windowFocus=" + hasWindowFocus()
+                + " rootAttached=" + rootLayout.isAttachedToWindow());
+    }
+
+    private void requestPresentationEnd(PresentationEndReason reason) {
+        if (!isPresentationStateAlive(presentationState)) {
+            if (!isFinishing()) {
+                finish();
+            }
+            return;
+        }
+
+        presentationState = PresentationState.ENDING;
+        LimeLog.info("Presentation controller ending reason=" + reason);
+        Game game = Game.instance;
+        if (game != null && game.isInPresentationMode()) {
+            game.setMetaKeyCaptureState(getComponentName(), false);
+            game.endExternalPresentationSession(reason);
+        }
+        else if (!isFinishing()) {
+            finish();
+        }
+    }
+
+    private void finishFromGame(PresentationEndReason reason) {
+        presentationState = PresentationState.ENDING;
+        finishingFromGame = true;
+        userLeaving = false;
+        Game game = Game.instance;
+        if (game != null) {
+            game.setMetaKeyCaptureState(getComponentName(), false);
+        }
+        LimeLog.info("Presentation controller finish from Game reason=" + reason);
+        if (!isFinishing()) {
+            finish();
+        }
     }
 
     /**
@@ -506,57 +842,11 @@ public class ExternalDisplayControlActivity extends AppCompatActivity implements
         ImageButton button = new ImageButton(this);
         button.setImageResource(imageResourceId);
         button.setBackgroundColor(Color.TRANSPARENT);
+        button.setFocusable(false);
+        button.setFocusableInTouchMode(false);
         button.setOnClickListener(listener);
         button.setLayoutParams(new LinearLayout.LayoutParams(dpToPx(56), dpToPx(56)));
         return button;
-    }
-
-    // --- Notification Management ---
-
-    private void checkNotificationPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.POST_NOTIFICATIONS}, PERMISSION_REQUEST_CODE);
-                return;
-            }
-        }
-        showStickyNotification();
-    }
-
-    private void showStickyNotification() {
-        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, getString(R.string.notification_channel_name), NotificationManager.IMPORTANCE_LOW);
-            channel.setShowBadge(false);
-            notificationManager.createNotificationChannel(channel);
-        }
-
-        Intent broadcastIntent = new Intent(this, StartExternalDisplayControlReceiver.class);
-        PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, broadcastIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-                .setContentTitle(getString(R.string.notification_title))
-                .setContentText(getString(R.string.notification_text))
-                .setSmallIcon(R.drawable.app_icon)
-                .setContentIntent(pendingIntent)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setOngoing(true);
-
-        Notification notification = notificationBuilder.build();
-
-        notificationManager.notify(SECONDARY_SCREEN_NOTIFICATION_ID, notification);
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == PERMISSION_REQUEST_CODE) {
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                showStickyNotification();
-            } else {
-                Toast.makeText(this, getString(R.string.permission_denied), Toast.LENGTH_SHORT).show();
-            }
-        }
     }
 
     // --- Utility Methods ---

--- a/app/src/main/java/com/limelight/utils/GamePresentation.java
+++ b/app/src/main/java/com/limelight/utils/GamePresentation.java
@@ -1,0 +1,127 @@
+package com.limelight.utils;
+
+import android.app.Presentation;
+import android.content.Context;
+import android.graphics.PixelFormat;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Display;
+import android.view.Surface;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.FrameLayout;
+
+import com.limelight.preferences.PreferenceConfiguration;
+import com.limelight.ui.StreamContainer;
+
+public class GamePresentation extends Presentation implements StreamContainer.SurfaceAvailableCallback {
+    private static final String TAG = "MoonlightExtDisplay";
+
+    public interface OnSurfaceAvailableListener {
+        void onSurfaceAvailable(Surface surface);
+        void onSurfaceDestroyed();
+    }
+
+    private final OnSurfaceAvailableListener listener;
+    private final PreferenceConfiguration prefConfig;
+    private final int preferredDisplayModeId;
+    private StreamContainer streamContainer;
+    private Surface currentSurface;
+    private boolean surfaceReady;
+
+    public GamePresentation(Context outerContext,
+                            Display display,
+                            OnSurfaceAvailableListener listener,
+                            PreferenceConfiguration prefConfig,
+                            int preferredDisplayModeId) {
+        super(outerContext, display);
+        this.listener = listener;
+        this.prefConfig = prefConfig;
+        this.preferredDisplayModeId = preferredDisplayModeId;
+    }
+
+    static boolean shouldApplyPreferredDisplayMode(int preferredDisplayModeId) {
+        return preferredDisplayModeId != 0;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        FrameLayout root = new FrameLayout(getContext());
+        root.setLayoutParams(new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT));
+
+        streamContainer = new StreamContainer(getContext(), null);
+        streamContainer.setLayoutParams(new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT));
+        streamContainer.setSurfaceAvailableCallback(this);
+        streamContainer.initAsPresentation(prefConfig);
+
+        root.addView(streamContainer);
+        setContentView(root);
+
+        try {
+            Window window = getWindow();
+            window.setFormat(PixelFormat.OPAQUE);
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                    && shouldApplyPreferredDisplayMode(preferredDisplayModeId)) {
+                WindowManager.LayoutParams layoutParams = window.getAttributes();
+                layoutParams.preferredDisplayModeId = preferredDisplayModeId;
+                window.setAttributes(layoutParams);
+            }
+        } catch (RuntimeException ignored) {
+        }
+
+        Log.i(TAG, "GamePresentation created on display " + getDisplay());
+    }
+
+    public boolean showSafely() {
+        try {
+            super.show();
+            return true;
+        } catch (WindowManager.InvalidDisplayException e) {
+            Log.w(TAG, "Cannot show GamePresentation on display " + getDisplay() + ": " + e);
+        } catch (RuntimeException e) {
+            Log.w(TAG, "Cannot show GamePresentation: " + e);
+        }
+        return false;
+    }
+
+    @Override
+    public void onSurfaceAvailable(Surface surface) {
+        if (surface == null || !surface.isValid()) {
+            return;
+        }
+        currentSurface = surface;
+        if (!surfaceReady) {
+            surfaceReady = true;
+            Log.i(TAG, "GamePresentation surface ready");
+            if (listener != null) {
+                listener.onSurfaceAvailable(currentSurface);
+            }
+        }
+    }
+
+    @Override
+    public void onSurfaceDestroyed() {
+        Log.i(TAG, "GamePresentation surface destroyed");
+        surfaceReady = false;
+        currentSurface = null;
+        if (listener != null) {
+            listener.onSurfaceDestroyed();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (streamContainer != null) {
+            streamContainer.onDestroy();
+        }
+    }
+}

--- a/app/src/main/java/com/limelight/utils/ServerHelper.java
+++ b/app/src/main/java/com/limelight/utils/ServerHelper.java
@@ -72,36 +72,41 @@ public class ServerHelper {
 
     public static Display getSecondaryDisplay(Context context) {
         DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
-        Display display = null;
-        Display[] displays = displayManager.getDisplays();
-        int mainDisplayId = Display.DEFAULT_DISPLAY;
-        int secondaryDisplayId = -1;
-        for (Display displayVariant : displays) {
-            LimeLog.info(displayVariant.toString());
-            if (displayVariant.getDisplayId() != mainDisplayId) {
-                secondaryDisplayId = displayVariant.getDisplayId();
-                break;
+        if (displayManager == null) {
+            return null;
+        }
+
+        Display presentationDisplay = getFirstNonDefaultOnDisplay(
+                displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION));
+        if (presentationDisplay != null) {
+            return presentationDisplay;
+        }
+
+        return getFirstNonDefaultOnDisplay(displayManager.getDisplays());
+    }
+
+    private static Display getFirstNonDefaultOnDisplay(Display[] displays) {
+        if (displays == null) {
+            return null;
+        }
+
+        for (Display display : displays) {
+            LimeLog.info(display.toString());
+            if (display.getDisplayId() != Display.DEFAULT_DISPLAY
+                    && display.getState() == Display.STATE_ON) {
+                return display;
             }
         }
 
-        if (secondaryDisplayId != -1) {
-            display = displayManager.getDisplay(secondaryDisplayId);
-        }
-        return display;
+        return null;
     }
 
     public static Intent createStartIntent(Activity parent, NvApp app, ComputerDetails computer,
                                            ComputerManagerService.ComputerManagerBinder managerBinder,
                                            boolean withVDisplay) {
-        Intent gameIntent = null;
+        Intent gameIntent = new Intent(parent, Game.class);
         PreferenceConfiguration prefConfig = PreferenceConfiguration.readPreferences(parent);
-        // Try to add secondary DisplayContext if supported and connected
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && prefConfig.enableFullExDisplay && getSecondaryDisplay(parent) != null) {
-            Context displayContext = parent.createDisplayContext(getSecondaryDisplay(parent)); // use secondary display
-            gameIntent = new Intent(displayContext, Game.class);
-            gameIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        }
-        if(gameIntent == null) gameIntent = new Intent(parent, Game.class);
+        Display secondaryDisplay = prefConfig.enableFullExDisplay ? getSecondaryDisplay(parent) : null;
         gameIntent.putExtra(Game.EXTRA_HOST, computer.activeAddress.address);
         gameIntent.putExtra(Game.EXTRA_PORT, computer.activeAddress.port);
         gameIntent.putExtra(Game.EXTRA_HTTPS_PORT, computer.httpsPort);
@@ -123,15 +128,13 @@ public class ServerHelper {
             e.printStackTrace();
         }
 
-        if (prefConfig.enableFullExDisplay) {
-            Display secondaryDisplay = getSecondaryDisplay(parent);
-            if (secondaryDisplay != null) {
-                int secondaryDisplayId = secondaryDisplay.getDisplayId();
-                gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, secondaryDisplayId);
-                Intent touchpadIntent = new Intent(parent, ExternalDisplayControlActivity.class);
-                touchpadIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent);
-                return touchpadIntent;
-            }
+        if (secondaryDisplay != null) {
+            int secondaryDisplayId = secondaryDisplay.getDisplayId();
+            gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY);
+            gameIntent.putExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, secondaryDisplayId);
+            Intent touchpadIntent = new Intent(parent, ExternalDisplayControlActivity.class);
+            touchpadIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent);
+            return touchpadIntent;
         }
 
         return gameIntent;

--- a/app/src/main/java/com/limelight/utils/StreamPresentationService.java
+++ b/app/src/main/java/com/limelight/utils/StreamPresentationService.java
@@ -1,0 +1,203 @@
+package com.limelight.utils;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.hardware.display.DisplayManager;
+import android.os.Binder;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+import android.view.Display;
+import android.view.Surface;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+import com.limelight.R;
+import com.limelight.preferences.PreferenceConfiguration;
+
+public class StreamPresentationService extends Service implements GamePresentation.OnSurfaceAvailableListener {
+    private static final String TAG = "MoonlightExtDisplay";
+    private static final String CHANNEL_ID = "stream_presentation_channel";
+    private static final int NOTIFICATION_ID = 2;
+
+    public static final String EXTRA_DISPLAY_ID = "displayId";
+    public static final String EXTRA_DISPLAY_MODE_ID = "displayModeId";
+
+    public interface PresentationStateListener {
+        void onPresentationFailure(String reason);
+        void onPresentationSurfaceDestroyed();
+    }
+
+    private final LocalBinder binder = new LocalBinder();
+    private GamePresentation gamePresentation;
+    private Surface availableSurface;
+    private Runnable pendingSurfaceCallback;
+    private PresentationStateListener presentationStateListener;
+    private String presentationFailureReason;
+
+    public class LocalBinder extends Binder {
+        public StreamPresentationService getService() {
+            return StreamPresentationService.this;
+        }
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+
+        Intent notifyIntent = new Intent(this, ExternalDisplayControlActivity.class);
+        notifyIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_SINGLE_TOP
+                | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notifyIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle("Artemis Streaming")
+                .setContentText("Streaming to external display")
+                .setSmallIcon(R.drawable.app_icon)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true);
+        builder.setContentIntent(pendingIntent);
+        startForeground(NOTIFICATION_ID, builder.build());
+        Log.i(TAG, "StreamPresentationService started");
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null && intent.hasExtra(EXTRA_DISPLAY_ID) && gamePresentation == null) {
+            attachToDisplay(
+                    intent.getIntExtra(EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY),
+                    intent.getIntExtra(EXTRA_DISPLAY_MODE_ID, 0));
+        }
+        return START_NOT_STICKY;
+    }
+
+    private void attachToDisplay(int displayId, int preferredDisplayModeId) {
+        if (gamePresentation != null) {
+            return;
+        }
+        DisplayManager displayManager = (DisplayManager) getSystemService(Context.DISPLAY_SERVICE);
+        if (displayManager == null) {
+            failPresentation("DisplayManager unavailable");
+            return;
+        }
+        Display targetDisplay = displayManager.getDisplay(displayId);
+        if (targetDisplay == null) {
+            failPresentation("Display id=" + displayId + " not found");
+            return;
+        }
+        Log.i(TAG, "Attaching GamePresentation to display id=" + displayId);
+        PreferenceConfiguration prefConfig = PreferenceConfiguration.readPreferences(this);
+        GamePresentation presentation = new GamePresentation(
+                this,
+                targetDisplay,
+                this,
+                prefConfig,
+                preferredDisplayModeId);
+        if (!presentation.showSafely()) {
+            failPresentation("Cannot show Presentation on display id=" + displayId);
+            return;
+        }
+        gamePresentation = presentation;
+    }
+
+    @Override
+    public void onSurfaceAvailable(Surface surface) {
+        availableSurface = surface;
+        Log.i(TAG, "Service: Presentation surface available");
+        if (pendingSurfaceCallback != null) {
+            Runnable callback = pendingSurfaceCallback;
+            pendingSurfaceCallback = null;
+            callback.run();
+        }
+    }
+
+    @Override
+    public void onSurfaceDestroyed() {
+        availableSurface = null;
+        pendingSurfaceCallback = null;
+        Log.i(TAG, "Service: Presentation surface destroyed");
+        if (presentationStateListener != null) {
+            presentationStateListener.onPresentationSurfaceDestroyed();
+        }
+    }
+
+    public Surface getSurface() {
+        return availableSurface;
+    }
+
+    public void requestSurface(Runnable callback) {
+        if (presentationFailureReason != null) {
+            if (presentationStateListener != null) {
+                presentationStateListener.onPresentationFailure(presentationFailureReason);
+            }
+            return;
+        }
+        if (availableSurface != null && availableSurface.isValid()) {
+            callback.run();
+        } else {
+            pendingSurfaceCallback = callback;
+        }
+    }
+
+    public void setPresentationStateListener(PresentationStateListener listener) {
+        presentationStateListener = listener;
+        if (presentationFailureReason != null && presentationStateListener != null) {
+            presentationStateListener.onPresentationFailure(presentationFailureReason);
+            stopSelf();
+        }
+    }
+
+    private void failPresentation(String reason) {
+        presentationFailureReason = reason;
+        pendingSurfaceCallback = null;
+        Log.w(TAG, reason);
+        if (presentationStateListener != null) {
+            presentationStateListener.onPresentationFailure(reason);
+            stopSelf();
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        if (gamePresentation != null) {
+            try {
+                gamePresentation.dismiss();
+            } catch (RuntimeException ignored) {
+            }
+            gamePresentation = null;
+        }
+        availableSurface = null;
+        pendingSurfaceCallback = null;
+        presentationStateListener = null;
+        Log.i(TAG, "StreamPresentationService destroyed");
+        super.onDestroy();
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            if (notificationManager != null) {
+                NotificationChannel channel = new NotificationChannel(
+                        CHANNEL_ID,
+                        "Stream Presentation",
+                        NotificationManager.IMPORTANCE_LOW);
+                channel.setShowBadge(false);
+                notificationManager.createNotificationChannel(channel);
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/ExternalDisplayControlActivityLaunchTest.java
+++ b/app/src/test/java/com/limelight/ExternalDisplayControlActivityLaunchTest.java
@@ -1,0 +1,144 @@
+package com.limelight;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Intent;
+import android.view.Display;
+import android.view.WindowManager;
+
+import com.limelight.utils.ExternalDisplayControlActivity;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowDisplayManager;
+
+@Config(sdk = {33}, shadows = {com.limelight.shadows.ShadowMoonBridge.class, com.limelight.shadows.ShadowGameManager.class})
+@RunWith(RobolectricTestRunner.class)
+public class ExternalDisplayControlActivityLaunchTest {
+    @BeforeClass
+    public static void suppressLogs() {
+        TestLogSuppressor.install();
+    }
+
+    @Before
+    public void setUp() {
+        ShadowDisplayManager.reset();
+        Game.instance = null;
+    }
+
+    @Test
+    public void startsWrappedGameIntentAsPresentationFallbackWithoutLaunchDisplayOptions() {
+        int displayId = ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+        Intent gameIntent = new Intent();
+        gameIntent.setClassName("com.limelight", Game.class.getName());
+
+        Intent wrapperIntent = new Intent();
+        wrapperIntent.setClassName("com.limelight", ExternalDisplayControlActivity.class.getName());
+        wrapperIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent);
+
+        ExternalDisplayControlActivity activity = Robolectric
+                .buildActivity(ExternalDisplayControlActivity.class, wrapperIntent)
+                .create()
+                .get();
+
+        ShadowActivity.IntentForResult started = Shadows.shadowOf(activity).getNextStartedActivityForResult();
+        assertNotNull(started);
+        assertEquals(Game.class.getName(), started.intent.getComponent().getClassName());
+        assertEquals(Display.DEFAULT_DISPLAY, started.intent.getIntExtra(Game.EXTRA_DISPLAY_ID, -1));
+        assertEquals(displayId, started.intent.getIntExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, -1));
+        assertNull(started.options);
+        assertNull(Shadows.shadowOf(activity).getNextStartedActivityForResult());
+    }
+
+    @Test
+    public void controllerWindowKeepsScreenOnDuringLaunch() {
+        ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+        Intent gameIntent = new Intent();
+        gameIntent.setClassName("com.limelight", Game.class.getName());
+
+        Intent wrapperIntent = new Intent();
+        wrapperIntent.setClassName("com.limelight", ExternalDisplayControlActivity.class.getName());
+        wrapperIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent);
+
+        ExternalDisplayControlActivity activity = Robolectric
+                .buildActivity(ExternalDisplayControlActivity.class, wrapperIntent)
+                .create()
+                .get();
+
+        assertTrue((activity.getWindow().getAttributes().flags
+                & WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) != 0);
+    }
+
+    @Test
+    public void reusedWrapperStartsWrappedGameIntentFromNewIntent() {
+        int displayId = ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+
+        Intent initialGameIntent = new Intent();
+        initialGameIntent.setClassName("com.limelight", Game.class.getName());
+
+        Intent initialWrapperIntent = new Intent();
+        initialWrapperIntent.setClassName("com.limelight", ExternalDisplayControlActivity.class.getName());
+        initialWrapperIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, initialGameIntent);
+
+        ActivityController<ExternalDisplayControlActivity> controller = Robolectric
+                .buildActivity(ExternalDisplayControlActivity.class, initialWrapperIntent)
+                .create();
+        ExternalDisplayControlActivity activity = controller.get();
+        Shadows.shadowOf(activity).getNextStartedActivityForResult();
+
+        Game.instance = null;
+
+        Intent secondGameIntent = new Intent();
+        secondGameIntent.setClassName("com.limelight", Game.class.getName());
+
+        Intent secondWrapperIntent = new Intent();
+        secondWrapperIntent.setClassName("com.limelight", ExternalDisplayControlActivity.class.getName());
+        secondWrapperIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, secondGameIntent);
+
+        controller.newIntent(secondWrapperIntent);
+
+        ShadowActivity.IntentForResult started = Shadows.shadowOf(activity).getNextStartedActivityForResult();
+        assertNotNull(started);
+        assertEquals(Game.class.getName(), started.intent.getComponent().getClassName());
+        assertEquals(Display.DEFAULT_DISPLAY, started.intent.getIntExtra(Game.EXTRA_DISPLAY_ID, -1));
+        assertEquals(displayId, started.intent.getIntExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, -1));
+        assertNull(started.options);
+        assertNull(Shadows.shadowOf(activity).getNextStartedActivityForResult());
+    }
+
+    @Test
+    public void startsPresentationFallbackIntentWithoutLaunchDisplayOptions() {
+        int displayId = ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+        Intent gameIntent = new Intent();
+        gameIntent.setClassName("com.limelight", Game.class.getName());
+        gameIntent.putExtra(Game.EXTRA_DISPLAY_ID, Display.DEFAULT_DISPLAY);
+        gameIntent.putExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, displayId);
+
+        Intent wrapperIntent = new Intent();
+        wrapperIntent.setClassName("com.limelight", ExternalDisplayControlActivity.class.getName());
+        wrapperIntent.putExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT, gameIntent);
+
+        ExternalDisplayControlActivity activity = Robolectric
+                .buildActivity(ExternalDisplayControlActivity.class, wrapperIntent)
+                .create()
+                .get();
+
+        ShadowActivity.IntentForResult started = Shadows.shadowOf(activity).getNextStartedActivityForResult();
+        assertNotNull(started);
+        assertEquals(Game.class.getName(), started.intent.getComponent().getClassName());
+        assertEquals(Display.DEFAULT_DISPLAY, started.intent.getIntExtra(Game.EXTRA_DISPLAY_ID, -1));
+        assertEquals(displayId, started.intent.getIntExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, -1));
+        assertNull(started.options);
+    }
+}

--- a/app/src/test/java/com/limelight/ExternalDisplayControlActivityLifecycleTest.java
+++ b/app/src/test/java/com/limelight/ExternalDisplayControlActivityLifecycleTest.java
@@ -1,0 +1,121 @@
+package com.limelight;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.limelight.utils.ExternalDisplayControlActivity;
+import com.limelight.utils.ExternalDisplayControlActivity.PresentationState;
+
+import org.junit.Test;
+
+public class ExternalDisplayControlActivityLifecycleTest {
+    @Test
+    public void presentationSessionStaysAliveDuringLaunchAndControllerTakeover() {
+        assertTrue(ExternalDisplayControlActivity.shouldKeepPresentationAlive(
+                PresentationState.LAUNCHING_GAME, true));
+        assertTrue(ExternalDisplayControlActivity.shouldKeepPresentationAlive(
+                PresentationState.WAITING_FOR_CONTROLLER_FOCUS, true));
+        assertTrue(ExternalDisplayControlActivity.shouldKeepPresentationAlive(
+                PresentationState.CONTROLLER_ACTIVE, true));
+        assertFalse(ExternalDisplayControlActivity.shouldKeepPresentationAlive(
+                PresentationState.ENDING, true));
+        assertFalse(ExternalDisplayControlActivity.shouldKeepPresentationAlive(
+                PresentationState.CONTROLLER_ACTIVE, false));
+    }
+
+    @Test
+    public void controllerStopEndsOnlyAfterActiveUserLeave() {
+        assertFalse(ExternalDisplayControlActivity.shouldEndPresentationOnControllerStop(
+                PresentationState.LAUNCHING_GAME, true, false));
+        assertFalse(ExternalDisplayControlActivity.shouldEndPresentationOnControllerStop(
+                PresentationState.WAITING_FOR_CONTROLLER_FOCUS, true, false));
+        assertFalse(ExternalDisplayControlActivity.shouldEndPresentationOnControllerStop(
+                PresentationState.CONTROLLER_ACTIVE, false, false));
+        assertFalse(ExternalDisplayControlActivity.shouldEndPresentationOnControllerStop(
+                PresentationState.CONTROLLER_ACTIVE, true, true));
+        assertTrue(ExternalDisplayControlActivity.shouldEndPresentationOnControllerStop(
+                PresentationState.CONTROLLER_ACTIVE, true, false));
+    }
+
+    @Test
+    public void controllerDestroyEndsLiveSessionUnlessGameAlreadyOwnsCleanup() {
+        assertTrue(ExternalDisplayControlActivity.shouldEndPresentationOnControllerDestroy(
+                PresentationState.LAUNCHING_GAME, false, false));
+        assertTrue(ExternalDisplayControlActivity.shouldEndPresentationOnControllerDestroy(
+                PresentationState.CONTROLLER_ACTIVE, false, false));
+        assertFalse(ExternalDisplayControlActivity.shouldEndPresentationOnControllerDestroy(
+                PresentationState.CONTROLLER_ACTIVE, true, false));
+        assertFalse(ExternalDisplayControlActivity.shouldEndPresentationOnControllerDestroy(
+                PresentationState.CONTROLLER_ACTIVE, false, true));
+        assertFalse(ExternalDisplayControlActivity.shouldEndPresentationOnControllerDestroy(
+                PresentationState.ENDING, false, false));
+    }
+
+    @Test
+    public void shouldRequestGameFocusForControllerInput_onlyOutsidePresentationMode() {
+        assertTrue(ExternalDisplayControlActivity.shouldRequestGameFocusForControllerInput(
+                true,
+                false,
+                1));
+
+        assertFalse(ExternalDisplayControlActivity.shouldRequestGameFocusForControllerInput(
+                true,
+                true,
+                1));
+        assertFalse(ExternalDisplayControlActivity.shouldRequestGameFocusForControllerInput(
+                false,
+                false,
+                1));
+        assertFalse(ExternalDisplayControlActivity.shouldRequestGameFocusForControllerInput(
+                true,
+                false,
+                -1));
+    }
+
+    @Test
+    public void shouldFinishWhenGameUnavailable_waitsDuringPendingLaunch() {
+        assertFalse(ExternalDisplayControlActivity.shouldFinishWhenGameUnavailable(
+                true,
+                false));
+        assertFalse(ExternalDisplayControlActivity.shouldFinishWhenGameUnavailable(
+                false,
+                true));
+        assertTrue(ExternalDisplayControlActivity.shouldFinishWhenGameUnavailable(
+                false,
+                false));
+    }
+
+    @Test
+    public void activatesControllerOnlyAfterPresentationRootHasWindowFocus() {
+        assertTrue(ExternalDisplayControlActivity.shouldActivatePresentationController(
+                PresentationState.WAITING_FOR_CONTROLLER_FOCUS,
+                true,
+                true,
+                true,
+                true));
+        assertTrue(ExternalDisplayControlActivity.shouldActivatePresentationController(
+                PresentationState.CONTROLLER_ACTIVE,
+                true,
+                true,
+                true,
+                true));
+        assertFalse(ExternalDisplayControlActivity.shouldActivatePresentationController(
+                PresentationState.LAUNCHING_GAME,
+                true,
+                true,
+                true,
+                true));
+        assertFalse(ExternalDisplayControlActivity.shouldActivatePresentationController(
+                PresentationState.WAITING_FOR_CONTROLLER_FOCUS,
+                true,
+                true,
+                false,
+                true));
+        assertFalse(ExternalDisplayControlActivity.shouldActivatePresentationController(
+                PresentationState.WAITING_FOR_CONTROLLER_FOCUS,
+                true,
+                true,
+                true,
+                false));
+    }
+}

--- a/app/src/test/java/com/limelight/ExternalDisplayControllerKeyForwardingTest.java
+++ b/app/src/test/java/com/limelight/ExternalDisplayControllerKeyForwardingTest.java
@@ -1,0 +1,65 @@
+package com.limelight;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.limelight.utils.ExternalDisplayControlActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ExternalDisplayControllerKeyForwardingTest {
+    @Test
+    public void forwardsEachSupportedKeyActionThroughOneGameHandler() {
+        Game game = mock(Game.class);
+        KeyEvent down = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A);
+        KeyEvent up = new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_A);
+        KeyEvent multiple = new KeyEvent(0, "a", 0, 0);
+        when(game.handleKeyDown(down)).thenReturn(true);
+        when(game.handleKeyUp(up)).thenReturn(true);
+        when(game.handleKeyMultiple(multiple)).thenReturn(true);
+
+        assertTrue(ExternalDisplayControlActivity.forwardControllerKeyEvent(game, down));
+        assertTrue(ExternalDisplayControlActivity.forwardControllerKeyEvent(game, up));
+        assertTrue(ExternalDisplayControlActivity.forwardControllerKeyEvent(game, multiple));
+
+        verify(game).handleKeyDown(down);
+        verify(game).handleKeyUp(up);
+        verify(game).handleKeyMultiple(multiple);
+        verifyNoMoreInteractions(game);
+    }
+
+    @Test
+    public void ignoresUnknownActionAndMissingGame() {
+        Game game = mock(Game.class);
+        KeyEvent unknown = new KeyEvent(99, KeyEvent.KEYCODE_A);
+
+        assertFalse(ExternalDisplayControlActivity.forwardControllerKeyEvent(game, unknown));
+        assertFalse(ExternalDisplayControlActivity.forwardControllerKeyEvent(null, unknown));
+        verifyNoMoreInteractions(game);
+    }
+
+    @Test
+    public void forwardsTheFirstTouchEventWithoutWaitingForPointerCapture() {
+        Game game = mock(Game.class);
+        View view = mock(View.class);
+        MotionEvent down = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 10, 10, 0);
+        when(game.handleMotionEvent(view, down)).thenReturn(true);
+
+        assertTrue(ExternalDisplayControlActivity.forwardControllerTouchEvent(game, view, down));
+
+        verify(game).handleMotionEvent(view, down);
+        verifyNoMoreInteractions(game);
+        down.recycle();
+    }
+}

--- a/app/src/test/java/com/limelight/ExternalPresentationLifecycleTest.java
+++ b/app/src/test/java/com/limelight/ExternalPresentationLifecycleTest.java
@@ -1,0 +1,72 @@
+package com.limelight;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ExternalPresentationLifecycleTest {
+    @Test
+    public void externalPresentationStaysAliveWhenControllerIsForeground() {
+        assertTrue(Game.shouldKeepExternalPresentationAliveOnStop(
+                true,
+                true,
+                true,
+                false,
+                false));
+    }
+
+    @Test
+    public void externalPresentationStopsWhenActivityIsFinishing() {
+        assertFalse(Game.shouldKeepExternalPresentationAliveOnStop(
+                true,
+                true,
+                true,
+                true,
+                false));
+    }
+
+    @Test
+    public void externalPresentationStaysAliveAcrossConfigurationTransition() {
+        assertTrue(Game.shouldKeepExternalPresentationAliveOnStop(
+                true,
+                true,
+                true,
+                false,
+                true));
+    }
+
+    @Test
+    public void externalPresentationStopsWhenControllerIsNotForeground() {
+        assertFalse(Game.shouldKeepExternalPresentationAliveOnStop(
+                true,
+                true,
+                false,
+                false,
+                false));
+    }
+
+    @Test
+    public void internalDisplayKeepsExistingStopBehavior() {
+        assertFalse(Game.shouldKeepExternalPresentationAliveOnStop(
+                false,
+                false,
+                false,
+                false,
+                false));
+    }
+
+    @Test
+    public void externalDisplayRemovalListenerRegistersOnlyOnce() {
+        assertTrue(Game.shouldRegisterExternalDisplayRemovalListener(true, false));
+        assertFalse(Game.shouldRegisterExternalDisplayRemovalListener(true, true));
+        assertFalse(Game.shouldRegisterExternalDisplayRemovalListener(false, false));
+    }
+
+    @Test
+    public void presentationControllerFocusForwardsOnlyWhenCaptureProviderExists() {
+        assertTrue(Game.shouldForwardPresentationControllerFocus(true, true));
+        assertFalse(Game.shouldForwardPresentationControllerFocus(false, true));
+        assertFalse(Game.shouldForwardPresentationControllerFocus(true, false));
+    }
+}

--- a/app/src/test/java/com/limelight/PresentationControllerFocusForwardingTest.java
+++ b/app/src/test/java/com/limelight/PresentationControllerFocusForwardingTest.java
@@ -1,0 +1,72 @@
+package com.limelight;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.limelight.binding.input.capture.InputCaptureProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Field;
+
+@RunWith(RobolectricTestRunner.class)
+public class PresentationControllerFocusForwardingTest {
+    @Test
+    public void presentationControllerFocusChange_forwardsToInputCaptureProvider() throws Exception {
+        Game game = Robolectric.buildActivity(Game.class).get();
+        RecordingInputCaptureProvider provider = new RecordingInputCaptureProvider();
+        setField(game, "inPresentationMode", true);
+        setField(game, "inputCaptureProvider", provider);
+
+        game.onPresentationControllerWindowFocusChanged(true);
+
+        assertEquals(1, provider.focusChangeCount);
+        assertTrue(provider.lastFocusActive);
+    }
+
+    @Test
+    public void presentationControllerFocusChange_ignoresNonPresentationGame() throws Exception {
+        Game game = Robolectric.buildActivity(Game.class).get();
+        RecordingInputCaptureProvider provider = new RecordingInputCaptureProvider();
+        setField(game, "inPresentationMode", false);
+        setField(game, "inputCaptureProvider", provider);
+
+        game.onPresentationControllerWindowFocusChanged(true);
+
+        assertEquals(0, provider.focusChangeCount);
+    }
+
+    @Test
+    public void presentationControllerFocusChange_forwardsFocusLossToo() throws Exception {
+        Game game = Robolectric.buildActivity(Game.class).get();
+        RecordingInputCaptureProvider provider = new RecordingInputCaptureProvider();
+        setField(game, "inPresentationMode", true);
+        setField(game, "inputCaptureProvider", provider);
+
+        game.onPresentationControllerWindowFocusChanged(false);
+
+        assertEquals(1, provider.focusChangeCount);
+        assertFalse(provider.lastFocusActive);
+    }
+
+    private static void setField(Game game, String fieldName, Object value) throws Exception {
+        Field field = Game.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(game, value);
+    }
+
+    private static final class RecordingInputCaptureProvider extends InputCaptureProvider {
+        private int focusChangeCount;
+        private boolean lastFocusActive;
+
+        @Override
+        public void onWindowFocusChanged(boolean focusActive) {
+            focusChangeCount++;
+            lastFocusActive = focusActive;
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/PresentationDisplaySelectionTest.java
+++ b/app/src/test/java/com/limelight/PresentationDisplaySelectionTest.java
@@ -1,0 +1,72 @@
+package com.limelight;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.view.Display;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowDisplayManager;
+
+@Config(sdk = {33}, shadows = {com.limelight.shadows.ShadowMoonBridge.class, com.limelight.shadows.ShadowGameManager.class})
+@RunWith(RobolectricTestRunner.class)
+public class PresentationDisplaySelectionTest {
+    private Activity activity;
+
+    @BeforeClass
+    public static void suppressLogs() {
+        TestLogSuppressor.install();
+    }
+
+    @Before
+    public void setUp() {
+        ShadowDisplayManager.reset();
+        activity = Robolectric.buildActivity(Activity.class).setup().get();
+    }
+
+    @Test
+    public void chooseRenderDisplayForPresentation_usesPresentationDisplayWhenAvailable() {
+        Display currentDisplay = activity.getWindowManager().getDefaultDisplay();
+        int presentationDisplayId = ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+        DisplayManager displayManager = (DisplayManager) activity.getSystemService(Context.DISPLAY_SERVICE);
+        Display presentationDisplay = displayManager.getDisplay(presentationDisplayId);
+
+        Display renderDisplay = Game.chooseRenderDisplayForPresentation(
+                currentDisplay,
+                presentationDisplay,
+                true);
+
+        assertSame(presentationDisplay, renderDisplay);
+    }
+
+    @Test
+    public void chooseRenderDisplayForPresentation_keepsCurrentDisplayOutsidePresentationMode() {
+        Display currentDisplay = activity.getWindowManager().getDefaultDisplay();
+        int presentationDisplayId = ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+        DisplayManager displayManager = (DisplayManager) activity.getSystemService(Context.DISPLAY_SERVICE);
+        Display presentationDisplay = displayManager.getDisplay(presentationDisplayId);
+
+        Display renderDisplay = Game.chooseRenderDisplayForPresentation(
+                currentDisplay,
+                presentationDisplay,
+                false);
+
+        assertSame(currentDisplay, renderDisplay);
+    }
+
+    @Test
+    public void shouldApplyDisplayModeToActivityWindow_onlyOutsidePresentationMode() {
+        assertTrue(Game.shouldApplyDisplayModeToActivityWindow(false));
+        assertFalse(Game.shouldApplyDisplayModeToActivityWindow(true));
+    }
+}

--- a/app/src/test/java/com/limelight/PresentationInputMappingTest.java
+++ b/app/src/test/java/com/limelight/PresentationInputMappingTest.java
@@ -1,0 +1,63 @@
+package com.limelight;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PresentationInputMappingTest {
+    @Test
+    public void scaleInputCoordinate_mapsCenterToTargetCenter() {
+        assertEquals(960.0f, Game.scaleInputCoordinate(540.0f, 1080, 1920), 0.001f);
+        assertEquals(540.0f, Game.scaleInputCoordinate(1200.0f, 2400, 1080), 0.001f);
+    }
+
+    @Test
+    public void scaleInputCoordinate_clampsNegativeAndOverflow() {
+        assertEquals(0.0f, Game.scaleInputCoordinate(-10.0f, 1080, 1920), 0.001f);
+        assertEquals(1920.0f, Game.scaleInputCoordinate(2000.0f, 1080, 1920), 0.001f);
+    }
+
+    @Test
+    public void scaleInputCoordinate_handlesZeroSourceOrTarget() {
+        assertEquals(1920.0f, Game.scaleInputCoordinate(10.0f, 0, 1920), 0.001f);
+        assertEquals(1.0f, Game.scaleInputCoordinate(10.0f, 1080, 0), 0.001f);
+    }
+
+    @Test
+    public void shouldScalePresentationInput_onlyForPresentationControllerInput() {
+        assertTrue(Game.shouldScalePresentationInput(true, true));
+        assertFalse(Game.shouldScalePresentationInput(false, true));
+        assertFalse(Game.shouldScalePresentationInput(true, false));
+    }
+
+    @Test
+    public void capturedMouseReference_usesPresentationDisplayWhenStreamViewIsHidden() {
+        assertEquals(3840,
+                Game.selectCapturedMouseReferenceDimension(true, 3840, 0));
+        assertEquals(2160,
+                Game.selectCapturedMouseReferenceDimension(true, 2160, 0));
+    }
+
+    @Test
+    public void capturedMouseReference_preservesStreamViewSizeOutsidePresentation() {
+        assertEquals(2246,
+                Game.selectCapturedMouseReferenceDimension(false, 3840, 2246));
+        assertEquals(1080,
+                Game.selectCapturedMouseReferenceDimension(false, 2160, 1080));
+    }
+
+    @Test
+    public void capturedMouseReference_clampsToProtocolRange() {
+        assertEquals(Short.MAX_VALUE,
+                Game.selectCapturedMouseReferenceDimension(true, 65535, 0));
+    }
+
+    @Test
+    public void capturedMouseReference_rejectsDimensionsBelowTwo() {
+        assertFalse(Game.isValidCapturedMouseReference(0, 2160));
+        assertFalse(Game.isValidCapturedMouseReference(3840, 1));
+        assertTrue(Game.isValidCapturedMouseReference(3840, 2160));
+    }
+}

--- a/app/src/test/java/com/limelight/PresentationServiceBindingTest.java
+++ b/app/src/test/java/com/limelight/PresentationServiceBindingTest.java
@@ -1,0 +1,28 @@
+package com.limelight;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PresentationServiceBindingTest {
+    @Test
+    public void shouldEndPresentationSession_whenSurfaceDestroyedAndNotAlreadyEnding() {
+        assertTrue(Game.shouldEndPresentationSessionForTest(true, false, false));
+    }
+
+    @Test
+    public void shouldNotEndPresentationSession_whenNotInPresentationMode() {
+        assertFalse(Game.shouldEndPresentationSessionForTest(false, false, false));
+    }
+
+    @Test
+    public void shouldNotEndPresentationSession_whenAlreadyEnding() {
+        assertFalse(Game.shouldEndPresentationSessionForTest(true, true, false));
+    }
+
+    @Test
+    public void shouldNotEndPresentationSession_whenActivityFinishing() {
+        assertFalse(Game.shouldEndPresentationSessionForTest(true, false, true));
+    }
+}

--- a/app/src/test/java/com/limelight/ServerHelperStartIntentTest.java
+++ b/app/src/test/java/com/limelight/ServerHelperStartIntentTest.java
@@ -1,0 +1,150 @@
+package com.limelight;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.view.Display;
+
+import androidx.preference.PreferenceManager;
+
+import com.limelight.computers.ComputerManagerService;
+import com.limelight.nvstream.http.ComputerDetails;
+import com.limelight.nvstream.http.NvApp;
+import com.limelight.utils.ExternalDisplayControlActivity;
+import com.limelight.utils.ServerHelper;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowDisplayManager;
+
+import java.util.ArrayList;
+
+@Config(sdk = {33}, shadows = {com.limelight.shadows.ShadowMoonBridge.class, com.limelight.shadows.ShadowGameManager.class})
+@RunWith(RobolectricTestRunner.class)
+public class ServerHelperStartIntentTest {
+    private Activity parent;
+    private NvApp app;
+    private ComputerDetails computer;
+    private ComputerManagerService.ComputerManagerBinder managerBinder;
+
+    @BeforeClass
+    public static void suppressLogs() {
+        TestLogSuppressor.install();
+    }
+
+    @Before
+    public void setUp() {
+        ShadowDisplayManager.reset();
+        parent = Robolectric.buildActivity(Activity.class).setup().get();
+
+        PreferenceManager.getDefaultSharedPreferences(parent)
+                .edit()
+                .clear()
+                .commit();
+
+        app = new NvApp("Test Game", "game-uuid", 1234, false);
+
+        computer = new ComputerDetails();
+        computer.activeAddress = new ComputerDetails.AddressTuple("192.0.2.10", 47989);
+        computer.httpsPort = 47984;
+        computer.uuid = "pc-uuid";
+        computer.name = "Test PC";
+        computer.serverCommands = new ArrayList<>();
+
+        managerBinder = mock(ComputerManagerService.ComputerManagerBinder.class);
+        when(managerBinder.getUniqueId()).thenReturn("test-unique-id");
+    }
+
+    @Test
+    public void createStartIntent_whenFullyExternalDisabled_returnsPlainGameIntent() {
+        setFullyExternalEnabled(false);
+        int displayId = ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+
+        Intent intent = ServerHelper.createStartIntent(parent, app, computer, managerBinder, false);
+
+        assertEquals(Game.class.getName(), intent.getComponent().getClassName());
+        assertFalse(intent.hasExtra(Game.EXTRA_DISPLAY_ID));
+        assertEquals(Display.DEFAULT_DISPLAY, parent.getWindowManager().getDefaultDisplay().getDisplayId());
+        assertTrue(displayId != Display.DEFAULT_DISPLAY);
+    }
+
+    @Test
+    public void createStartIntent_whenFullyExternalEnabledWithoutDisplay_returnsPlainGameIntent() {
+        setFullyExternalEnabled(true);
+
+        Intent intent = ServerHelper.createStartIntent(parent, app, computer, managerBinder, false);
+
+        assertEquals(Game.class.getName(), intent.getComponent().getClassName());
+        assertFalse(intent.hasExtra(Game.EXTRA_DISPLAY_ID));
+    }
+
+    @Test
+    public void createStartIntent_whenFullyExternalEnabledWithDisplay_wrapsPresentationFallbackGameIntent() {
+        setFullyExternalEnabled(true);
+        int displayId = ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+
+        Intent wrapperIntent = ServerHelper.createStartIntent(parent, app, computer, managerBinder, true);
+
+        assertEquals(ExternalDisplayControlActivity.class.getName(), wrapperIntent.getComponent().getClassName());
+
+        Intent gameIntent = wrapperIntent.getParcelableExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT);
+        assertNotNull(gameIntent);
+        assertEquals(Game.class.getName(), gameIntent.getComponent().getClassName());
+        assertEquals(Display.DEFAULT_DISPLAY, gameIntent.getIntExtra(Game.EXTRA_DISPLAY_ID, -1));
+        assertEquals(displayId, gameIntent.getIntExtra(Game.EXTRA_PRESENTATION_DISPLAY_ID, -1));
+        assertTrue(gameIntent.getBooleanExtra(Game.EXTRA_VDISPLAY, false));
+    }
+
+    @Test
+    public void createStartIntent_whenFullyExternalEnabledWithDisplay_doesNotUseNewTaskLaunchFlag() {
+        setFullyExternalEnabled(true);
+        ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+
+        Intent wrapperIntent = ServerHelper.createStartIntent(parent, app, computer, managerBinder, false);
+        Intent gameIntent = wrapperIntent.getParcelableExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT);
+
+        assertNotNull(gameIntent);
+        assertEquals(0, gameIntent.getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK);
+    }
+
+    @Test
+    public void createStartIntent_preservesCommonGameExtrasInsideWrapper() {
+        setFullyExternalEnabled(true);
+        ShadowDisplayManager.addDisplay("w1920dp-h1080dp");
+
+        Intent wrapperIntent = ServerHelper.createStartIntent(parent, app, computer, managerBinder, true);
+        Intent gameIntent = wrapperIntent.getParcelableExtra(ExternalDisplayControlActivity.EXTRA_LAUNCH_INTENT);
+
+        assertNotNull(gameIntent);
+        assertEquals("192.0.2.10", gameIntent.getStringExtra(Game.EXTRA_HOST));
+        assertEquals(47989, gameIntent.getIntExtra(Game.EXTRA_PORT, 0));
+        assertEquals(47984, gameIntent.getIntExtra(Game.EXTRA_HTTPS_PORT, 0));
+        assertEquals("Test Game", gameIntent.getStringExtra(Game.EXTRA_APP_NAME));
+        assertEquals("game-uuid", gameIntent.getStringExtra(Game.EXTRA_APP_UUID));
+        assertEquals(1234, gameIntent.getIntExtra(Game.EXTRA_APP_ID, 0));
+        assertEquals("test-unique-id", gameIntent.getStringExtra(Game.EXTRA_UNIQUEID));
+        assertEquals("pc-uuid", gameIntent.getStringExtra(Game.EXTRA_PC_UUID));
+        assertEquals("Test PC", gameIntent.getStringExtra(Game.EXTRA_PC_NAME));
+        assertTrue(gameIntent.getBooleanExtra(Game.EXTRA_VDISPLAY, false));
+        assertNull(gameIntent.getByteArrayExtra(Game.EXTRA_SERVER_CERT));
+    }
+
+    private void setFullyExternalEnabled(boolean enabled) {
+        PreferenceManager.getDefaultSharedPreferences(parent)
+                .edit()
+                .putBoolean("checkbox_enable_fullexdisplay", enabled)
+                .commit();
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProviderTest.java
+++ b/app/src/test/java/com/limelight/binding/input/capture/AndroidNativePointerCaptureProviderTest.java
@@ -1,0 +1,25 @@
+package com.limelight.binding.input.capture;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class AndroidNativePointerCaptureProviderTest {
+    @Test
+    public void captureIsActiveOnlyWhenTheFocusedAttachedViewOwnsPointerCapture() {
+        assertTrue(AndroidNativePointerCaptureProvider.isCaptureActive(
+                true, false, true, true, true));
+
+        assertFalse(AndroidNativePointerCaptureProvider.isCaptureActive(
+                false, false, true, true, true));
+        assertFalse(AndroidNativePointerCaptureProvider.isCaptureActive(
+                true, true, true, true, true));
+        assertFalse(AndroidNativePointerCaptureProvider.isCaptureActive(
+                true, false, false, true, true));
+        assertFalse(AndroidNativePointerCaptureProvider.isCaptureActive(
+                true, false, true, false, true));
+        assertFalse(AndroidNativePointerCaptureProvider.isCaptureActive(
+                true, false, true, true, false));
+    }
+}

--- a/app/src/test/java/com/limelight/binding/input/capture/InputCaptureManagerTargetTest.java
+++ b/app/src/test/java/com/limelight/binding/input/capture/InputCaptureManagerTargetTest.java
@@ -1,0 +1,49 @@
+package com.limelight.binding.input.capture;
+
+import static org.junit.Assert.assertNotNull;
+
+import android.app.Activity;
+import android.view.View;
+
+import com.limelight.binding.input.evdev.EvdevListener;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class InputCaptureManagerTargetTest {
+    @Test
+    public void getInputCaptureProvider_acceptsExplicitTargetView() {
+        Activity activity = Robolectric.buildActivity(Activity.class).setup().get();
+        View targetView = new View(activity);
+        EvdevListener listener = new NoOpEvdevListener();
+
+        InputCaptureProvider provider = InputCaptureManager.getInputCaptureProvider(activity, targetView, listener);
+
+        assertNotNull(provider);
+    }
+
+    private static final class NoOpEvdevListener implements EvdevListener {
+        @Override
+        public void mouseMove(int deltaX, int deltaY) {
+        }
+
+        @Override
+        public void mouseButtonEvent(int buttonId, boolean down) {
+        }
+
+        @Override
+        public void mouseVScroll(byte amount) {
+        }
+
+        @Override
+        public void mouseHScroll(byte amount) {
+        }
+
+        @Override
+        public void keyboardEvent(boolean buttonDown, short keyCode) {
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/MediaCodecDecoderRendererFrameRateTest.java
+++ b/app/src/test/java/com/limelight/binding/video/MediaCodecDecoderRendererFrameRateTest.java
@@ -1,0 +1,17 @@
+package com.limelight.binding.video;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MediaCodecDecoderRendererFrameRateTest {
+    @Test
+    public void normalizeSurfaceFrameRateConvertsMilliHzRefreshRateToHz() {
+        assertEquals(30.0f, MediaCodecDecoderRenderer.normalizeSurfaceFrameRate(30000), 0.001f);
+    }
+
+    @Test
+    public void normalizeSurfaceFrameRateKeepsWholeNumberHz() {
+        assertEquals(60.0f, MediaCodecDecoderRenderer.normalizeSurfaceFrameRate(60), 0.001f);
+    }
+}

--- a/app/src/test/java/com/limelight/ui/ExternalControllerViewGenericMotionTest.java
+++ b/app/src/test/java/com/limelight/ui/ExternalControllerViewGenericMotionTest.java
@@ -1,0 +1,166 @@
+package com.limelight.ui;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(RobolectricTestRunner.class)
+public class ExternalControllerViewGenericMotionTest {
+    @Test
+    public void dispatchGenericMotionEvent_forPointerHoverMove_usesInputCallback() {
+        ExternalControllerView view = new ExternalControllerView(RuntimeEnvironment.getApplication());
+        RecordingCallbacks callbacks = new RecordingCallbacks(true);
+        MotionEvent event = obtainMouseEvent(MotionEvent.ACTION_HOVER_MOVE);
+
+        view.setInputCallbacks(callbacks);
+
+        assertTrue(view.dispatchGenericMotionEvent(event));
+        assertTrue(callbacks.genericMotionCalled);
+        assertSame(view, callbacks.callbackView);
+        assertSame(event, callbacks.callbackEvent);
+    }
+
+    @Test
+    public void dispatchGenericMotionEvent_forPointerScroll_usesInputCallback() {
+        ExternalControllerView view = new ExternalControllerView(RuntimeEnvironment.getApplication());
+        RecordingCallbacks callbacks = new RecordingCallbacks(true);
+        MotionEvent event = obtainMouseEvent(MotionEvent.ACTION_SCROLL);
+
+        view.setInputCallbacks(callbacks);
+
+        assertTrue(view.dispatchGenericMotionEvent(event));
+        assertTrue(callbacks.genericMotionCalled);
+        assertSame(view, callbacks.callbackView);
+        assertSame(event, callbacks.callbackEvent);
+    }
+
+    @Test
+    public void onCapturedPointerEvent_forRelativeMouseMove_usesInputCallback() {
+        ExternalControllerView view = new ExternalControllerView(RuntimeEnvironment.getApplication());
+        RecordingCallbacks callbacks = new RecordingCallbacks(true);
+        MotionEvent event = obtainMouseEvent(MotionEvent.ACTION_MOVE);
+        event.setSource(InputDevice.SOURCE_MOUSE_RELATIVE);
+
+        view.setInputCallbacks(callbacks);
+
+        assertTrue(view.onCapturedPointerEvent(event));
+        assertTrue(callbacks.genericMotionCalled);
+        assertSame(view, callbacks.callbackView);
+        assertSame(event, callbacks.callbackEvent);
+    }
+
+    @Test
+    public void dispatchGenericMotionEvent_forJoystickMove_skipsInputCallback() {
+        ExternalControllerView view = new ExternalControllerView(RuntimeEnvironment.getApplication());
+        RecordingCallbacks callbacks = new RecordingCallbacks(true);
+        MotionEvent event = obtainMouseEvent(MotionEvent.ACTION_MOVE);
+        event.setSource(InputDevice.SOURCE_JOYSTICK);
+
+        view.setInputCallbacks(callbacks);
+        view.dispatchGenericMotionEvent(event);
+
+        assertFalse(callbacks.genericMotionCalled);
+    }
+
+    @Test
+    public void dispatchGenericMotionEvent_forPointerHoverMove_reportsUserActivity() {
+        ExternalControllerView view = new ExternalControllerView(RuntimeEnvironment.getApplication());
+        RecordingCallbacks callbacks = new RecordingCallbacks(true);
+        AtomicInteger userActivityCount = new AtomicInteger();
+        MotionEvent event = obtainMouseEvent(MotionEvent.ACTION_HOVER_MOVE);
+
+        view.setInputCallbacks(callbacks);
+        view.setUserActivityCallback(userActivityCount::incrementAndGet);
+
+        assertTrue(view.dispatchGenericMotionEvent(event));
+        assertEquals(1, userActivityCount.get());
+    }
+
+    @Test
+    public void onCapturedPointerEvent_forRelativeMouseMove_reportsUserActivity() {
+        ExternalControllerView view = new ExternalControllerView(RuntimeEnvironment.getApplication());
+        RecordingCallbacks callbacks = new RecordingCallbacks(true);
+        AtomicInteger userActivityCount = new AtomicInteger();
+        MotionEvent event = obtainMouseEvent(MotionEvent.ACTION_MOVE);
+        event.setSource(InputDevice.SOURCE_MOUSE_RELATIVE);
+
+        view.setInputCallbacks(callbacks);
+        view.setUserActivityCallback(userActivityCount::incrementAndGet);
+
+        assertTrue(view.onCapturedPointerEvent(event));
+        assertEquals(1, userActivityCount.get());
+    }
+
+    @Test
+    public void dispatchGenericMotionEvent_forJoystickMove_skipsUserActivity() {
+        ExternalControllerView view = new ExternalControllerView(RuntimeEnvironment.getApplication());
+        RecordingCallbacks callbacks = new RecordingCallbacks(true);
+        AtomicInteger userActivityCount = new AtomicInteger();
+        MotionEvent event = obtainMouseEvent(MotionEvent.ACTION_MOVE);
+        event.setSource(InputDevice.SOURCE_JOYSTICK);
+
+        view.setInputCallbacks(callbacks);
+        view.setUserActivityCallback(userActivityCount::incrementAndGet);
+
+        view.dispatchGenericMotionEvent(event);
+        assertEquals(0, userActivityCount.get());
+    }
+
+    private static MotionEvent obtainMouseEvent(int action) {
+        MotionEvent event = MotionEvent.obtain(0, 0, action, 10, 10, 0);
+        event.setSource(InputDevice.SOURCE_MOUSE);
+        return event;
+    }
+
+    private static final class RecordingCallbacks implements ExternalControllerView.InputCallbacks {
+        private final boolean consumeGenericMotion;
+        private boolean genericMotionCalled;
+        private View callbackView;
+        private MotionEvent callbackEvent;
+
+        private RecordingCallbacks(boolean consumeGenericMotion) {
+            this.consumeGenericMotion = consumeGenericMotion;
+        }
+
+        @Override
+        public boolean handleGenericMotion(View view, MotionEvent event) {
+            genericMotionCalled = true;
+            callbackView = view;
+            callbackEvent = event;
+            return consumeGenericMotion;
+        }
+
+        @Override
+        public boolean handleKeyUp(KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean handleKeyDown(KeyEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean handleCommitText(CharSequence text) {
+            return false;
+        }
+
+        @Override
+        public boolean handleDeleteSurroundingText(int beforeLength, int afterLength) {
+            return false;
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/utils/GamePresentationDisplayModeTest.java
+++ b/app/src/test/java/com/limelight/utils/GamePresentationDisplayModeTest.java
@@ -1,0 +1,14 @@
+package com.limelight.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class GamePresentationDisplayModeTest {
+    @Test
+    public void shouldApplyPreferredDisplayMode_onlyWhenModeIdIsProvided() {
+        assertFalse(GamePresentation.shouldApplyPreferredDisplayMode(0));
+        assertTrue(GamePresentation.shouldApplyPreferredDisplayMode(1));
+    }
+}


### PR DESCRIPTION
## Summary

- add an opt-in Samsung One UI fully external display path backed by a `Presentation`
- keep `Game` as the normal task/session owner and pass the external display ID explicitly
- route the render window, controller input, pointer capture, display mode, and lifecycle handling through the Presentation-owned window
- handle display removal, invalid displays, controller foreground state, and teardown without relaunching the global focus path

## Why

Launching `Game` directly on a secondary display is fragile on Samsung One UI. This uses the normal Activity launch path while a dedicated controller Activity and Presentation own the external-display surface.

This is intentionally separate from the codec low-latency work.

## Validation

- manually tested on a Samsung Galaxy S25+ (`SM-S936N`) connected to a real external monitor
- verified external Presentation startup, streaming, controller input, and session teardown
- `assembleNonRoot_gameDebug`: passed, including native builds for all configured ABIs
- JVM suite: 106 tests, 101 passed, 5 existing unrelated Robolectric failures, 0 errors, 0 skipped

The five failures are the existing layout/profile/startup baseline failures and are unchanged by this patch.

## Known startup behavior

The Presentation surface is opaque before the first decoded frame, so the monitor can briefly show black during session startup. In captured logs this was about 1.9-2.6 seconds. There was no HDMI hotplug, display mode restart, codec fallback, or decoder restart associated with that interval.

Related discussion: #579

