### PR TITLE
Improve capability-gated codec low latency and testing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,6 +103,16 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        lowLatencyDebug {
+            initWith debug
+            applicationIdSuffix = ".artemis.lowlatency.debug"
+            signingConfig signingConfigs.debug
+            debuggable true
+            resValue "string", "app_label", "Artemis Low Latency (Debug)"
+            resValue "string", "app_label_root", "Artemis Low Latency (Debug Root)"
+            resValue "string", "app_label_game", "Artemis Low Latency (Debug Game)"
+            matchingFallbacks = ['debug']
+        }
         release {
             // To whomever is releasing/using an APK in release mode with
             // Moonlight's official application ID, please stop. I see every

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -786,7 +786,6 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 .setVirtualDisplay(vDisplay)
                 .setResolutionScaleFactor(prefConfig.resolutionScaleFactor)
                 .setApp(app)
-                .setEnableUltraLowLatency(prefConfig.enableUltraLowLatency)
                 .setBitrate(isMetered ? prefConfig.meteredBitrate: prefConfig.bitrate)
                 .setEnableSops(prefConfig.enableSops)
                 .enableLocalAudioPlayback(prefConfig.playHostAudio)

--- a/app/src/main/java/com/limelight/binding/video/DecoderLatencySampler.java
+++ b/app/src/main/java/com/limelight/binding/video/DecoderLatencySampler.java
@@ -1,0 +1,105 @@
+package com.limelight.binding.video;
+
+import java.util.Arrays;
+
+final class DecoderLatencySampler {
+    static final int CAPACITY = 16_384;
+    static final String METRIC_NAME =
+            "decoder_input_queue_call_start_to_first_output_dequeue_us";
+
+    static final class Summary {
+        final int sampleCount;
+        final int p50Us;
+        final int p95Us;
+        final int p99Us;
+
+        private Summary(int sampleCount, int p50Us, int p95Us, int p99Us) {
+            this.sampleCount = sampleCount;
+            this.p50Us = p50Us;
+            this.p95Us = p95Us;
+            this.p99Us = p99Us;
+        }
+
+        boolean hasMeasurement() {
+            return sampleCount != 0;
+        }
+    }
+
+    private final int[] samples = new int[CAPACITY];
+    private int oldestIndex;
+    private int sampleCount;
+
+    void recordMicroseconds(int latencyUs) {
+        if (latencyUs < 0) {
+            return;
+        }
+
+        int writeIndex = (oldestIndex + sampleCount) % CAPACITY;
+        samples[writeIndex] = latencyUs;
+        if (sampleCount < CAPACITY) {
+            sampleCount++;
+        }
+        else {
+            oldestIndex = (oldestIndex + 1) % CAPACITY;
+        }
+    }
+
+    int recordDeltaNs(long queueCallStartNs, long firstOutputDequeueNs) {
+        long deltaNs = firstOutputDequeueNs - queueCallStartNs;
+        if (deltaNs < 0) {
+            return -1;
+        }
+
+        long latencyUs = deltaNs / 1_000L;
+        int clampedLatencyUs = latencyUs > Integer.MAX_VALUE ?
+                Integer.MAX_VALUE : (int) latencyUs;
+        recordMicroseconds(clampedLatencyUs);
+        return clampedLatencyUs;
+    }
+
+    int[] copySamples() {
+        int[] copy = new int[sampleCount];
+        int firstLength = Math.min(sampleCount, CAPACITY - oldestIndex);
+        System.arraycopy(samples, oldestIndex, copy, 0, firstLength);
+        if (firstLength < sampleCount) {
+            System.arraycopy(samples, 0, copy, firstLength, sampleCount - firstLength);
+        }
+        return copy;
+    }
+
+    void reset() {
+        oldestIndex = 0;
+        sampleCount = 0;
+    }
+
+    static Summary summarize(int[] sampleCopy) {
+        if (sampleCopy.length == 0) {
+            return new Summary(0, -1, -1, -1);
+        }
+
+        Arrays.sort(sampleCopy);
+        return new Summary(
+                sampleCopy.length,
+                nearestRank(sampleCopy, 50),
+                nearestRank(sampleCopy, 95),
+                nearestRank(sampleCopy, 99));
+    }
+
+    private static int nearestRank(int[] sortedSamples, int percentile) {
+        int rank = (sortedSamples.length * percentile + 99) / 100;
+        return sortedSamples[rank - 1];
+    }
+
+    static String formatSummary(Summary summary) {
+        return "CodecLatencySummary metric=" + METRIC_NAME +
+                " unit=us samples=" + summary.sampleCount +
+                " capacity=" + CAPACITY +
+                " p50Us=" + percentileValue(summary, summary.p50Us) +
+                " p95Us=" + percentileValue(summary, summary.p95Us) +
+                " p99Us=" + percentileValue(summary, summary.p99Us);
+    }
+
+    private static String percentileValue(Summary summary, int value) {
+        return summary.hasMeasurement() ? Integer.toString(value) : "NA";
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/LowLatencyProfilePlanner.java
+++ b/app/src/main/java/com/limelight/binding/video/LowLatencyProfilePlanner.java
@@ -1,0 +1,445 @@
+package com.limelight.binding.video;
+
+import android.media.MediaFormat;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+final class LowLatencyProfilePlanner {
+    static final String VDEC_LOW_LATENCY = "vdec-lowlatency";
+
+    static final String QTI_CORE = "vendor.qti-ext-dec-low-latency.enable";
+    static final String QTI_PICTURE_ORDER = "vendor.qti-ext-dec-picture-order.enable";
+    static final String QTI_SOFTWARE_FENCE =
+            "vendor.qti-ext-output-sw-fence-enable.value";
+    static final String QTI_OUTPUT_FENCE_ENABLE = "vendor.qti-ext-output-fence.enable";
+    static final String QTI_OUTPUT_FENCE_TYPE = "vendor.qti-ext-output-fence.fence_type";
+
+    static final String MTK_LOW_LATENCY_MODE = "vendor.mtk.vdec.low-latency.mode";
+    static final String MTK_DISABLE_IDLE = "vendor.mtk.vdec.disable-idle";
+    static final String MTK_VSYNC_ADJUST_ENABLE = "vendor.mtk.vdec.vsync.adjust.enable";
+    static final String MTK_ULTRA_LOW_LATENCY = "vendor.mtk.vdec.ultra-low-latency";
+    static final String MTK_PRELOAD_FRAME_COUNT = "vendor.mtk.vdec.preload.frame.count";
+    static final String MTK_INPUT_QUEUE_DEPTH = "vendor.mtk.vdec.input.max.queue.depth";
+    static final String MTK_OUTPUT_QUEUE_DEPTH = "vendor.mtk.vdec.output.max.queue.depth";
+    static final String MTK_FETCH_TIMEOUT = "vendor.mtk.vdec.buffer.fetch.timeout.ms";
+    static final String MTK_FETCH_TIMEOUT_VALUE = MTK_FETCH_TIMEOUT + ".value";
+    static final String MTK_GUARD_INTERVAL = "vendor.mtk.vdec.bq.guard.interval.time";
+    static final String MTK_GUARD_INTERVAL_VALUE = MTK_GUARD_INTERVAL + ".value";
+    static final String MTK_CPU_BOOST = "vendor.mtk.vdec.cpu.boost.mode";
+    static final String MTK_CPU_BOOST_VALUE = MTK_CPU_BOOST + ".value";
+    static final String MTK_DVFS_MODE = "vendor.mtk.vdec.dvfs.mode";
+    static final String MTK_DVFS_LEVEL = "vendor.mtk.vdec.dvfs.level";
+
+    enum DecoderFamily {
+        QUALCOMM,
+        MEDIATEK,
+        OTHER
+    }
+
+    enum PlanPurpose {
+        INITIAL_CONFIGURATION,
+        RUNTIME_RECOVERY
+    }
+
+    static final class Capabilities {
+        final DecoderFamily family;
+        final String decoderName;
+        final int sdkInt;
+        final boolean androidLowLatencySupported;
+        final boolean maxOperatingRateSupported;
+        final boolean legacyVdecLowLatencyAllowed;
+        final boolean vendorParameterEnumerationAvailable;
+        final Set<String> supportedVendorParameters;
+
+        Capabilities(DecoderFamily family,
+                     String decoderName,
+                     int sdkInt,
+                     boolean androidLowLatencySupported,
+                     boolean maxOperatingRateSupported,
+                     boolean legacyVdecLowLatencyAllowed,
+                     boolean vendorParameterEnumerationAvailable,
+                     Set<String> supportedVendorParameters) {
+            this.family = Objects.requireNonNull(family);
+            this.decoderName = Objects.requireNonNull(decoderName);
+            this.sdkInt = sdkInt;
+            this.androidLowLatencySupported = androidLowLatencySupported;
+            this.maxOperatingRateSupported = maxOperatingRateSupported;
+            this.legacyVdecLowLatencyAllowed = legacyVdecLowLatencyAllowed;
+            this.vendorParameterEnumerationAvailable = vendorParameterEnumerationAvailable;
+
+            TreeSet<String> normalizedParameters = new TreeSet<>();
+            for (String parameter : supportedVendorParameters) {
+                if (parameter != null) {
+                    normalizedParameters.add(parameter.toLowerCase(Locale.US));
+                }
+            }
+            this.supportedVendorParameters = Collections.unmodifiableSet(
+                    new LinkedHashSet<>(normalizedParameters));
+        }
+    }
+
+    static final class Profile {
+        final String name;
+        final Map<String, Integer> integerOptions;
+
+        private final List<Map.Entry<String, Integer>> orderedOptions;
+
+        Profile(String name, Map<String, Integer> integerOptions) {
+            this.name = Objects.requireNonNull(name);
+
+            LinkedHashMap<String, Integer> optionsCopy = new LinkedHashMap<>(integerOptions);
+            this.integerOptions = Collections.unmodifiableMap(optionsCopy);
+
+            List<Map.Entry<String, Integer>> entries = new ArrayList<>(optionsCopy.size());
+            for (Map.Entry<String, Integer> entry : optionsCopy.entrySet()) {
+                entries.add(new AbstractMap.SimpleImmutableEntry<>(entry));
+            }
+            this.orderedOptions = Collections.unmodifiableList(entries);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof Profile)) {
+                return false;
+            }
+
+            Profile otherProfile = (Profile) other;
+            return orderedOptions.equals(otherProfile.orderedOptions);
+        }
+
+        @Override
+        public int hashCode() {
+            return orderedOptions.hashCode();
+        }
+    }
+
+    static List<Profile> plan(Capabilities capabilities,
+                              boolean ultraLowLatency,
+                              PlanPurpose purpose) {
+        Objects.requireNonNull(capabilities);
+        Objects.requireNonNull(purpose);
+
+        if (purpose == PlanPurpose.RUNTIME_RECOVERY) {
+            List<Profile> recoveryProfiles = new ArrayList<>();
+            addProfile(recoveryProfiles, "android-standard", standardOptions(capabilities));
+            return deduplicateProfiles(recoveryProfiles);
+        }
+
+        if (capabilities.family == DecoderFamily.QUALCOMM) {
+            return planQualcomm(capabilities, ultraLowLatency);
+        }
+
+        if (capabilities.family == DecoderFamily.MEDIATEK) {
+            return planMediaTek(capabilities, ultraLowLatency);
+        }
+
+        if (capabilities.legacyVdecLowLatencyAllowed) {
+            return planGenericLegacy(capabilities);
+        }
+
+        List<Profile> profiles = new ArrayList<>();
+        addProfile(profiles, "android-standard", standardOptions(capabilities));
+        return deduplicateProfiles(profiles);
+    }
+
+    static DecoderFamily classifyDecoderFamily(String decoderName) {
+        String normalizedName = Objects.requireNonNull(decoderName).toLowerCase(Locale.US);
+        if (startsWithAny(normalizedName, "omx.qcom", "omx.qti", "c2.qti", "c2.qcom")) {
+            return DecoderFamily.QUALCOMM;
+        }
+        if (startsWithAny(normalizedName, "omx.mtk", "c2.mtk")) {
+            return DecoderFamily.MEDIATEK;
+        }
+        return DecoderFamily.OTHER;
+    }
+
+    static boolean isLegacyVdecLowLatencyAllowed(String decoderName,
+                                                  String manufacturer,
+                                                  int sdkInt) {
+        DecoderFamily family = classifyDecoderFamily(decoderName);
+        if (family == DecoderFamily.QUALCOMM) {
+            return false;
+        }
+        if ("xiaomi".equalsIgnoreCase(manufacturer) && sdkInt <= 23) {
+            return false;
+        }
+
+        String normalizedName = decoderName.toLowerCase(Locale.US);
+        return family == DecoderFamily.MEDIATEK ||
+                startsWithAny(normalizedName, "omx.amlogic", "c2.amlogic") ||
+                "amazon".equalsIgnoreCase(manufacturer);
+    }
+
+    static List<Profile> deduplicateProfiles(List<Profile> profiles) {
+        LinkedHashSet<Profile> uniqueProfiles = new LinkedHashSet<>(profiles);
+        return Collections.unmodifiableList(new ArrayList<>(uniqueProfiles));
+    }
+
+    private static List<Profile> planQualcomm(Capabilities capabilities,
+                                               boolean ultraLowLatency) {
+        boolean legacyQualcomm = capabilities.sdkInt >= 26 && capabilities.sdkInt < 31;
+        boolean qtiCore = legacyQualcomm || supportsVendorParameter(capabilities, QTI_CORE);
+        boolean pictureOrder = legacyQualcomm ||
+                supportsVendorParameter(capabilities, QTI_PICTURE_ORDER);
+
+        List<Profile> profiles = new ArrayList<>();
+        if (!ultraLowLatency) {
+            addProfile(profiles, "android-standard", standardOptions(capabilities));
+            addQtiCorePictureProfile(profiles, capabilities, qtiCore, pictureOrder);
+            addQtiCoreOnlyProfile(profiles, qtiCore);
+            return deduplicateProfiles(profiles);
+        }
+
+        boolean outputFence = supportsVendorParameter(capabilities, QTI_OUTPUT_FENCE_ENABLE) &&
+                supportsVendorParameter(capabilities, QTI_OUTPUT_FENCE_TYPE);
+        boolean softwareFence = supportsVendorParameter(capabilities, QTI_SOFTWARE_FENCE);
+
+        LinkedHashMap<String, Integer> full = qtiBaseOptions(
+                capabilities, qtiCore, pictureOrder);
+        addPreferredFence(full, outputFence, softwareFence);
+        addScheduler(full, capabilities);
+        addProfile(profiles, "qti-experimental-full", full);
+
+        if (outputFence && softwareFence) {
+            LinkedHashMap<String, Integer> alternateFence = qtiBaseOptions(
+                    capabilities, qtiCore, pictureOrder);
+            alternateFence.put(QTI_SOFTWARE_FENCE, 1);
+            addScheduler(alternateFence, capabilities);
+            addProfile(profiles, "qti-experimental-alt-fence", alternateFence);
+        }
+
+        LinkedHashMap<String, Integer> noScheduler = qtiBaseOptions(
+                capabilities, qtiCore, pictureOrder);
+        addPreferredFence(noScheduler, outputFence, softwareFence);
+        addProfile(profiles, "qti-experimental-no-scheduler", noScheduler);
+
+        addProfile(profiles, "qti-no-fence",
+                qtiBaseOptions(capabilities, qtiCore, pictureOrder));
+        addProfile(profiles, "android-standard", standardOptions(capabilities));
+        addQtiCorePictureProfile(profiles, capabilities, qtiCore, pictureOrder);
+        addQtiCoreOnlyProfile(profiles, qtiCore);
+
+        return deduplicateProfiles(profiles);
+    }
+
+    private static List<Profile> planMediaTek(Capabilities capabilities,
+                                               boolean ultraLowLatency) {
+        LinkedHashMap<String, Integer> standard = standardOptions(capabilities);
+        LinkedHashMap<String, Integer> legacy = legacyOptions(capabilities);
+        List<Profile> profiles = new ArrayList<>();
+
+        if (!ultraLowLatency) {
+            addProfile(profiles, "android-standard", standard);
+            addProfile(profiles, "mtk-legacy", legacy);
+            return deduplicateProfiles(profiles);
+        }
+
+        LinkedHashMap<String, Integer> scheduler = schedulerOptions(capabilities);
+        LinkedHashMap<String, Integer> experimental = combinedOptions(standard, legacy);
+        int nonVendorOptionCount = experimental.size();
+        addMediaTekVendorOptions(experimental, capabilities);
+        if (experimental.size() > nonVendorOptionCount) {
+            experimental.putAll(scheduler);
+            addProfile(profiles, "mtk-experimental-full", experimental);
+        }
+
+        if (!standard.isEmpty() && !legacy.isEmpty() && !scheduler.isEmpty()) {
+            addProfile(profiles, "mtk-standard-legacy-performance",
+                    combinedOptions(standard, legacy, scheduler));
+        }
+        if (!standard.isEmpty() && !scheduler.isEmpty()) {
+            addProfile(profiles, "mtk-standard-performance",
+                    combinedOptions(standard, scheduler));
+        }
+        addProfile(profiles, "android-standard", standard);
+        if (!legacy.isEmpty() && !scheduler.isEmpty()) {
+            addProfile(profiles, "mtk-legacy-performance",
+                    combinedOptions(legacy, scheduler));
+        }
+        addProfile(profiles, "mtk-legacy", legacy);
+        addProfile(profiles, "performance-only", scheduler);
+        return deduplicateProfiles(profiles);
+    }
+
+    private static List<Profile> planGenericLegacy(Capabilities capabilities) {
+        List<Profile> profiles = new ArrayList<>();
+        addProfile(profiles, "android-standard", standardOptions(capabilities));
+        addProfile(profiles, "legacy-vdec", legacyOptions(capabilities));
+        return deduplicateProfiles(profiles);
+    }
+
+    private static LinkedHashMap<String, Integer> qtiBaseOptions(
+            Capabilities capabilities,
+            boolean qtiCore,
+            boolean pictureOrder) {
+        LinkedHashMap<String, Integer> options = standardOptions(capabilities);
+        if (qtiCore) {
+            options.put(QTI_CORE, 1);
+        }
+        if (pictureOrder) {
+            options.put(QTI_PICTURE_ORDER,
+                    capabilities.decoderName.toLowerCase(Locale.US).startsWith("omx.qcom") ? 0 : 1);
+        }
+        return options;
+    }
+
+    private static void addQtiCorePictureProfile(List<Profile> profiles,
+                                                  Capabilities capabilities,
+                                                  boolean qtiCore,
+                                                  boolean pictureOrder) {
+        if (!qtiCore || !pictureOrder) {
+            return;
+        }
+
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        options.put(QTI_CORE, 1);
+        options.put(QTI_PICTURE_ORDER,
+                capabilities.decoderName.toLowerCase(Locale.US).startsWith("omx.qcom") ? 0 : 1);
+        addProfile(profiles, "qti-core-picture", options);
+    }
+
+    private static void addQtiCoreOnlyProfile(List<Profile> profiles, boolean qtiCore) {
+        if (!qtiCore) {
+            return;
+        }
+
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        options.put(QTI_CORE, 1);
+        addProfile(profiles, "qti-core-only", options);
+    }
+
+    private static LinkedHashMap<String, Integer> standardOptions(Capabilities capabilities) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        if (capabilities.androidLowLatencySupported) {
+            options.put(MediaFormat.KEY_LOW_LATENCY, 1);
+        }
+        return options;
+    }
+
+    private static LinkedHashMap<String, Integer> legacyOptions(Capabilities capabilities) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        if (capabilities.legacyVdecLowLatencyAllowed) {
+            options.put(VDEC_LOW_LATENCY, 1);
+        }
+        return options;
+    }
+
+    @SafeVarargs
+    private static LinkedHashMap<String, Integer> combinedOptions(
+            Map<String, Integer>... optionSets) {
+        LinkedHashMap<String, Integer> combined = new LinkedHashMap<>();
+        for (Map<String, Integer> optionSet : optionSets) {
+            combined.putAll(optionSet);
+        }
+        return combined;
+    }
+
+    private static LinkedHashMap<String, Integer> schedulerOptions(
+            Capabilities capabilities) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        addScheduler(options, capabilities);
+        return options;
+    }
+
+    private static void addMediaTekVendorOptions(LinkedHashMap<String, Integer> options,
+                                                  Capabilities capabilities) {
+        addAdvertisedOption(options, capabilities, MTK_LOW_LATENCY_MODE, 1);
+        addAdvertisedOption(options, capabilities, MTK_DISABLE_IDLE, 1);
+        addAdvertisedOption(options, capabilities, MTK_VSYNC_ADJUST_ENABLE, 0);
+        addAdvertisedOption(options, capabilities, MTK_ULTRA_LOW_LATENCY, 1);
+        addAdvertisedOption(options, capabilities, MTK_PRELOAD_FRAME_COUNT, 0);
+        addAdvertisedOption(options, capabilities, MTK_INPUT_QUEUE_DEPTH, 2);
+        addAdvertisedOption(options, capabilities, MTK_OUTPUT_QUEUE_DEPTH, 2);
+        addAdvertisedAlias(options, capabilities,
+                MTK_FETCH_TIMEOUT, MTK_FETCH_TIMEOUT_VALUE, 2);
+        addAdvertisedAlias(options, capabilities,
+                MTK_GUARD_INTERVAL, MTK_GUARD_INTERVAL_VALUE, 2);
+        addAdvertisedAlias(options, capabilities,
+                MTK_CPU_BOOST, MTK_CPU_BOOST_VALUE, 1);
+        addAdvertisedOption(options, capabilities, MTK_DVFS_MODE, 1);
+        addAdvertisedOption(options, capabilities, MTK_DVFS_LEVEL, 1);
+    }
+
+    private static void addAdvertisedOption(LinkedHashMap<String, Integer> options,
+                                             Capabilities capabilities,
+                                             String key,
+                                             int value) {
+        if (supportsVendorParameter(capabilities, key)) {
+            options.put(key, value);
+        }
+    }
+
+    private static void addAdvertisedAlias(LinkedHashMap<String, Integer> options,
+                                            Capabilities capabilities,
+                                            String primary,
+                                            String alternate,
+                                            int value) {
+        if (supportsVendorParameter(capabilities, alternate)) {
+            options.put(alternate, value);
+        }
+        else if (supportsVendorParameter(capabilities, primary)) {
+            options.put(primary, value);
+        }
+    }
+
+    private static void addPreferredFence(LinkedHashMap<String, Integer> options,
+                                          boolean outputFence,
+                                          boolean softwareFence) {
+        if (outputFence) {
+            options.put(QTI_OUTPUT_FENCE_ENABLE, 1);
+            options.put(QTI_OUTPUT_FENCE_TYPE, 1);
+        }
+        else if (softwareFence) {
+            options.put(QTI_SOFTWARE_FENCE, 1);
+        }
+    }
+
+    private static void addScheduler(LinkedHashMap<String, Integer> options,
+                                     Capabilities capabilities) {
+        if (capabilities.maxOperatingRateSupported) {
+            options.put(MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE);
+        }
+        else if (capabilities.sdkInt >= 23) {
+            options.put(MediaFormat.KEY_PRIORITY, 0);
+        }
+    }
+
+    private static boolean supportsVendorParameter(Capabilities capabilities, String parameter) {
+        return capabilities.sdkInt >= 31 &&
+                capabilities.vendorParameterEnumerationAvailable &&
+                capabilities.supportedVendorParameters.contains(parameter.toLowerCase(Locale.US));
+    }
+
+    private static boolean startsWithAny(String value, String... prefixes) {
+        for (String prefix : prefixes) {
+            if (value.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void addProfile(List<Profile> profiles,
+                                   String name,
+                                   LinkedHashMap<String, Integer> options) {
+        if (!options.isEmpty()) {
+            profiles.add(new Profile(name, options));
+        }
+    }
+
+    private LowLatencyProfilePlanner() {
+    }
+}

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java
@@ -5,7 +5,11 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -44,6 +48,435 @@ import android.view.Choreographer;
 import android.view.Surface;
 
 public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements Choreographer.FrameCallback {
+    private static final int MAX_DECODER_CONFIGURATION_ATTEMPTS = 12;
+    private static final int MAX_OPTION_PROFILE_ATTEMPTS =
+            MAX_DECODER_CONFIGURATION_ATTEMPTS - 1;
+
+    enum ActiveLowLatencyProfileKind {
+        NON_STANDARD,
+        ANDROID_STANDARD,
+        BASE
+    }
+
+    enum ConfigurationMode {
+        INITIAL,
+        RUNTIME_RECOVERY
+    }
+
+    enum ConfigurationFailureDisposition {
+        TRY_NEXT,
+        RETURN_MINUS_FIVE,
+        RETHROW
+    }
+
+    enum RecoveryStage {
+        TRANSIENT,
+        RESTART,
+        RESET,
+        FULL_RECREATION
+    }
+
+    enum RecoveryAction {
+        REUSE_ACTIVE_CONFIGURATION,
+        RUNTIME_DOWNGRADE
+    }
+
+    interface LowLatencyOptionSource {
+        MediaCodecHelper.AppliedLowLatencyOptions get(int profileIndex);
+    }
+
+    static final class DecoderConfigurationProfile {
+        final int profileIndex;
+        final String profileName;
+        final Map<String, Integer> integerOptions;
+        final ActiveLowLatencyProfileKind kind;
+
+        private DecoderConfigurationProfile(int profileIndex,
+                                            String profileName,
+                                            Map<String, Integer> integerOptions,
+                                            ActiveLowLatencyProfileKind kind) {
+            this.profileIndex = profileIndex;
+            this.profileName = Objects.requireNonNull(profileName);
+            this.integerOptions = Collections.unmodifiableMap(
+                    new LinkedHashMap<>(integerOptions));
+            this.kind = Objects.requireNonNull(kind);
+        }
+
+        static DecoderConfigurationProfile from(
+                MediaCodecHelper.AppliedLowLatencyOptions applied) {
+            ActiveLowLatencyProfileKind kind = "android-standard".equals(applied.profileName) ?
+                    ActiveLowLatencyProfileKind.ANDROID_STANDARD :
+                    ActiveLowLatencyProfileKind.NON_STANDARD;
+            return new DecoderConfigurationProfile(
+                    applied.profileIndex,
+                    applied.profileName,
+                    applied.integerOptions,
+                    kind);
+        }
+
+        static DecoderConfigurationProfile base() {
+            return new DecoderConfigurationProfile(
+                    -1,
+                    "base",
+                    Collections.emptyMap(),
+                    ActiveLowLatencyProfileKind.BASE);
+        }
+    }
+
+    static final class ConfiguredDecoderState {
+        final MediaFormat format;
+        final int profileIndex;
+        final String profileName;
+        final ActiveLowLatencyProfileKind kind;
+
+        private ConfiguredDecoderState(MediaFormat format,
+                                       DecoderConfigurationProfile profile) {
+            this.format = Objects.requireNonNull(format);
+            this.profileIndex = profile.profileIndex;
+            this.profileName = profile.profileName;
+            this.kind = profile.kind;
+        }
+    }
+
+    static final class DecoderLatencyState {
+        interface InputQueueCall {
+            void queue(long presentationTimeUs, int codecFlags);
+        }
+
+        static final class PendingInputToken {
+            final long presentationTimeUs;
+            final long capturedNs;
+            final long generation;
+            PendingInputToken next;
+
+            private PendingInputToken(long presentationTimeUs,
+                                      long capturedNs,
+                                      long generation) {
+                this.presentationTimeUs = presentationTimeUs;
+                this.capturedNs = capturedNs;
+                this.generation = generation;
+            }
+        }
+
+        private final Object lock;
+        // One token object replaces the boxed Long timestamp used previously. The second
+        // sparse array adds no per-input object and keeps duplicate-PTS append O(1).
+        private final LongSparseArray<PendingInputToken> pendingHeadByPtsUs =
+                new LongSparseArray<>();
+        private final LongSparseArray<PendingInputToken> pendingTailByPtsUs =
+                new LongSparseArray<>();
+        private final DecoderLatencySampler sampler = new DecoderLatencySampler();
+        private long pendingGeneration;
+        private int codecInvalidationDepth;
+        private boolean stopSummaryTaken;
+
+        DecoderLatencyState() {
+            this(new Object());
+        }
+
+        private DecoderLatencyState(Object lock) {
+            this.lock = lock;
+        }
+
+        PendingInputToken onInputQueueCallStarting(long presentationTimeUs,
+                                                   int codecFlags,
+                                                   long capturedNs) {
+            if ((codecFlags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                return null;
+            }
+            synchronized (lock) {
+                return codecInvalidationDepth == 0 ?
+                        appendPendingLocked(presentationTimeUs, capturedNs) : null;
+            }
+        }
+
+        private PendingInputToken appendPendingLocked(long presentationTimeUs,
+                                                       long capturedNs) {
+            PendingInputToken token = new PendingInputToken(
+                    presentationTimeUs, capturedNs, pendingGeneration);
+            PendingInputToken tail = pendingTailByPtsUs.get(presentationTimeUs);
+            if (tail == null) {
+                pendingHeadByPtsUs.put(presentationTimeUs, token);
+            }
+            else {
+                tail.next = token;
+            }
+            pendingTailByPtsUs.put(presentationTimeUs, token);
+            return token;
+        }
+
+        void onInputQueueFailed(PendingInputToken token) {
+            if (token == null) {
+                return;
+            }
+            synchronized (lock) {
+                removePendingTokenLocked(token);
+            }
+        }
+
+        private void removePendingTokenLocked(PendingInputToken token) {
+            if (token == null || token.generation != pendingGeneration) {
+                return;
+            }
+
+            PendingInputToken previous = null;
+            PendingInputToken current = pendingHeadByPtsUs.get(token.presentationTimeUs);
+            while (current != null && current != token) {
+                previous = current;
+                current = current.next;
+            }
+            if (current == null) {
+                return;
+            }
+
+            if (previous == null) {
+                if (current.next == null) {
+                    pendingHeadByPtsUs.delete(token.presentationTimeUs);
+                }
+                else {
+                    pendingHeadByPtsUs.put(token.presentationTimeUs, current.next);
+                }
+            }
+            else {
+                previous.next = current.next;
+            }
+
+            if (pendingTailByPtsUs.get(token.presentationTimeUs) == current) {
+                if (previous == null) {
+                    pendingTailByPtsUs.delete(token.presentationTimeUs);
+                }
+                else {
+                    pendingTailByPtsUs.put(token.presentationTimeUs, previous);
+                }
+            }
+            current.next = null;
+        }
+
+        void runInputQueueCall(long presentationTimeUs,
+                               int codecFlags,
+                               InputQueueCall inputQueueCall) {
+            if ((codecFlags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                inputQueueCall.queue(presentationTimeUs, codecFlags);
+                return;
+            }
+
+            PendingInputToken token;
+            synchronized (lock) {
+                token = codecInvalidationDepth == 0 ?
+                        appendPendingLocked(presentationTimeUs, System.nanoTime()) : null;
+            }
+            try {
+                inputQueueCall.queue(presentationTimeUs, codecFlags);
+            }
+            catch (RuntimeException e) {
+                onInputQueueFailed(token);
+                throw e;
+            }
+        }
+
+        int onOutputDequeued(long presentationTimeUs, long dequeuedNs) {
+            synchronized (lock) {
+                PendingInputToken token = pendingHeadByPtsUs.get(presentationTimeUs);
+                if (token == null) {
+                    return -1;
+                }
+
+                if (token.next == null) {
+                    pendingHeadByPtsUs.delete(presentationTimeUs);
+                    pendingTailByPtsUs.delete(presentationTimeUs);
+                }
+                else {
+                    pendingHeadByPtsUs.put(presentationTimeUs, token.next);
+                }
+                token.next = null;
+                return sampler.recordDeltaNs(token.capturedNs, dequeuedNs);
+            }
+        }
+
+        void clearPendingForCodecInvalidation() {
+            synchronized (lock) {
+                pendingGeneration++;
+                clearPendingLocked();
+            }
+        }
+
+        void clearPendingAndRunCodecInvalidation(Runnable codecInvalidation) {
+            synchronized (lock) {
+                pendingGeneration++;
+                codecInvalidationDepth++;
+                clearPendingLocked();
+            }
+            try {
+                codecInvalidation.run();
+            }
+            finally {
+                synchronized (lock) {
+                    codecInvalidationDepth--;
+                }
+            }
+        }
+
+        private void clearPendingLocked() {
+            // These chains are append-only and mutated only under lock, so each walk
+            // terminates. This O(number of pending inputs) work is lifecycle-only.
+            for (int i = 0; i < pendingHeadByPtsUs.size(); i++) {
+                PendingInputToken current = pendingHeadByPtsUs.valueAt(i);
+                while (current != null) {
+                    PendingInputToken next = current.next;
+                    current.next = null;
+                    current = next;
+                }
+            }
+            pendingHeadByPtsUs.clear();
+            pendingTailByPtsUs.clear();
+        }
+
+        void resetForNewSession() {
+            synchronized (lock) {
+                pendingGeneration++;
+                clearPendingLocked();
+                sampler.reset();
+                stopSummaryTaken = false;
+            }
+        }
+
+        int[] copySamplesForCrash() {
+            synchronized (lock) {
+                return sampler.copySamples();
+            }
+        }
+
+        int[] takeSamplesForStop() {
+            synchronized (lock) {
+                if (stopSummaryTaken) {
+                    return null;
+                }
+
+                stopSummaryTaken = true;
+                pendingGeneration++;
+                clearPendingLocked();
+                int[] samples = sampler.copySamples();
+                sampler.reset();
+                return samples;
+            }
+        }
+    }
+
+    static List<DecoderConfigurationProfile> selectConfigurationProfiles(
+            int startTry,
+            LowLatencyOptionSource optionSource) {
+        if (startTry < 0) {
+            throw new IllegalArgumentException("startTry must be non-negative");
+        }
+
+        List<DecoderConfigurationProfile> attempts = new ArrayList<>();
+        for (int profileIndex = startTry;
+             profileIndex < MAX_OPTION_PROFILE_ATTEMPTS;
+             profileIndex++) {
+            MediaCodecHelper.AppliedLowLatencyOptions applied = optionSource.get(profileIndex);
+            if (applied == null) {
+                break;
+            }
+            attempts.add(DecoderConfigurationProfile.from(applied));
+        }
+        attempts.add(DecoderConfigurationProfile.base());
+        return Collections.unmodifiableList(attempts);
+    }
+
+    static List<DecoderConfigurationProfile> selectRuntimeRecoveryProfiles(
+            ActiveLowLatencyProfileKind activeKind,
+            LowLatencyOptionSource recoveryOptionSource) {
+        if (activeKind != ActiveLowLatencyProfileKind.NON_STANDARD) {
+            return Collections.singletonList(DecoderConfigurationProfile.base());
+        }
+        return selectConfigurationProfiles(0, recoveryOptionSource);
+    }
+
+    static ConfiguredDecoderState commitConfiguredState(
+            ConfiguredDecoderState current,
+            MediaFormat format,
+            DecoderConfigurationProfile profile,
+            boolean configureAndStartSucceeded) {
+        return configureAndStartSucceeded ?
+                new ConfiguredDecoderState(format, profile) : current;
+    }
+
+    static RecoveryAction recoveryActionFor(RecoveryStage stage) {
+        return stage == RecoveryStage.FULL_RECREATION ?
+                RecoveryAction.RUNTIME_DOWNGRADE :
+                RecoveryAction.REUSE_ACTIVE_CONFIGURATION;
+    }
+
+    static ConfigurationFailureDisposition configurationFailureDisposition(
+            ConfigurationMode mode,
+            DecoderConfigurationProfile profile) {
+        if (profile.kind != ActiveLowLatencyProfileKind.BASE) {
+            return ConfigurationFailureDisposition.TRY_NEXT;
+        }
+        return mode == ConfigurationMode.RUNTIME_RECOVERY ?
+                ConfigurationFailureDisposition.RETHROW :
+                ConfigurationFailureDisposition.RETURN_MINUS_FIVE;
+    }
+
+    static ConfigurationMode configurationModeForInitializeDecoder(
+            boolean throwOnCodecError) {
+        return throwOnCodecError ?
+                ConfigurationMode.RUNTIME_RECOVERY :
+                ConfigurationMode.INITIAL;
+    }
+
+    static String finalConfigurationFailureMessage(
+            String decoderName,
+            DecoderConfigurationProfile profile,
+            boolean androidLowLatencySupported) {
+        return "Unable to configure decoder=" + decoderName +
+                " profileIndex=" + profile.profileIndex +
+                " profileName=" + profile.profileName +
+                " requestedOptions=" + profile.integerOptions +
+                " FEATURE_LowLatency=" + androidLowLatencySupported;
+    }
+
+    static String formatLowLatencyAttempt(int ordinal,
+                                          DecoderConfigurationProfile profile) {
+        return "CodecLLAttempt ordinal=" + ordinal +
+                " profileIndex=" + profile.profileIndex +
+                " profileName=" + profile.profileName +
+                " requestedOptions=" + profile.integerOptions;
+    }
+
+    static String formatLowLatencyFallback(DecoderConfigurationProfile profile,
+                                           Throwable failure) {
+        return "CodecLLFallback profileIndex=" + profile.profileIndex +
+                " profileName=" + profile.profileName +
+                " reason=" + failure.getClass().getSimpleName();
+    }
+
+    static String formatLowLatencySelected(DecoderConfigurationProfile profile) {
+        return "CodecLLSelected profileIndex=" + profile.profileIndex +
+                " profileName=" + profile.profileName;
+    }
+
+    static int aggregateDecoderLatencyMs(int latencyUs) {
+        if (latencyUs < 0) {
+            return -1;
+        }
+        int latencyMs = latencyUs / 1_000;
+        return latencyMs < 1_000 ? latencyMs : -1;
+    }
+
+    static String formatCrashLatencyDiagnostics(
+            ConfiguredDecoderState configuredState,
+            DecoderLatencySampler.Summary summary,
+            String delimiter) {
+        String activeProfileIndex = configuredState == null ?
+                "NA" : Integer.toString(configuredState.profileIndex);
+        String activeProfileName = configuredState == null ?
+                "NA" : configuredState.profileName;
+        return "Codec low-latency activeProfileIndex=" + activeProfileIndex +
+                " activeProfileName=" + activeProfileName + delimiter +
+                DecoderLatencySampler.formatSummary(summary);
+    }
+
     // Latency profile: favor minimal end-to-end delay over absolute smoothness.
     // Set true to enable a 'latest-only' fast path in the render loop.
     private boolean preferLowerDelays = false;
@@ -54,8 +487,9 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     /** Toggle tight frame pacing thresholds globally. */
     public void setForceTightThresholds(boolean v) { this.forceTightThresholds = v; }
     // Toggle at runtime if needed
-    // Decode latency tracking: map PTS(us) -> enqueue time (ns)
-    private final LongSparseArray<Long> enqueueNsByPtsUs = new LongSparseArray<>();
+    private final Object decoderLatencyLock = new Object();
+    private final DecoderLatencyState decoderLatencyState =
+            new DecoderLatencyState(decoderLatencyLock);
 
     // When preferLowerDelays=true we use this configurable timeout (µs) for output dequeue.
 // When preferLowerDelays=false we force 0µs (non-blocking, latest-frame rendering).
@@ -82,19 +516,20 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     }
     private int getOutputDequeueTimeoutUs(){ return preferLowerDelays ? Math.max(250, preferLowerDelaysTimeoutUs) : preferLowerDelaysTimeoutUs; }
 
-    // Update stats using real decode time: enqueue->dequeue, instead of uptime - PTS
-    private void updateDecodeLatencyStats(long presentationTimeUs) {
-        Long enqNs = enqueueNsByPtsUs.get(presentationTimeUs);
-        if (enqNs != null) {
-            enqueueNsByPtsUs.delete(presentationTimeUs);
-            long decMs = (System.nanoTime() - enqNs) / 1_000_000L;
-            if (decMs >= 0 && decMs < 1000) {
-                activeWindowVideoStats.decoderTimeMs += decMs;
+    private int dequeueOutputBufferWithLatency(BufferInfo info, long timeoutUs) {
+        int bufferIndex = videoDecoder.dequeueOutputBuffer(info, timeoutUs);
+        if (bufferIndex >= 0) {
+            int latencyUs = decoderLatencyState.onOutputDequeued(
+                    info.presentationTimeUs, System.nanoTime());
+            int latencyMs = aggregateDecoderLatencyMs(latencyUs);
+            if (latencyMs >= 0) {
+                activeWindowVideoStats.decoderTimeMs += latencyMs;
                 if (!USE_FRAME_RENDER_TIME) {
-                    activeWindowVideoStats.totalTimeMs += decMs;
+                    activeWindowVideoStats.totalTimeMs += latencyMs;
                 }
             }
         }
+        return bufferIndex;
     }
 
     public void setPreferLowerDelays(boolean v) { this.preferLowerDelays = v; }
@@ -122,6 +557,13 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
     private Context context;
     private Activity activity;
     private MediaCodec videoDecoder;
+    private final DecoderLatencyState.InputQueueCall decoderInputQueueCall =
+            (presentationTimeUs, codecFlags) -> videoDecoder.queueInputBuffer(
+                    nextInputBufferIndex,
+                    0,
+                    nextInputBuffer.position(),
+                    presentationTimeUs,
+                    codecFlags);
     private Thread rendererThread;
     private boolean needsSpsBitstreamFixup, isExynos4;
     private boolean adaptivePlayback, directSubmit, fusedIdrFrame;
@@ -160,7 +602,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
     private MediaFormat inputFormat;
     private MediaFormat outputFormat;
-    private MediaFormat configuredFormat;
+    private ConfiguredDecoderState configuredDecoderState;
 
     private boolean needsBaselineSpsHack;
     private SeqParameterSet savedSps;
@@ -617,10 +1059,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         } catch (Throwable t) {
             LimeLog.info("Decoder name: <unavailable>");
         }
-
-
-        configuredFormat = format;
-
         // After reconfiguration, we must resubmit CSD buffers
         submittedCsd = false;
         vpsBuffers.clear();
@@ -654,25 +1092,34 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         }
     }
 
-    private boolean tryConfigureDecoder(MediaCodecInfo selectedDecoderInfo, MediaFormat format, boolean throwOnCodecError) {
+    private boolean tryConfigureDecoder(MediaCodecInfo selectedDecoderInfo,
+                                        MediaFormat format,
+                                        DecoderConfigurationProfile profile,
+                                        boolean throwOnCodecError) {
         boolean configured = false;
         try {
             videoDecoder = MediaCodec.createByCodecName(selectedDecoderInfo.getName());
             configureAndStartDecoder(format);
             LimeLog.info("Using codec " + selectedDecoderInfo.getName() + " for hardware decoding " + format.getString(MediaFormat.KEY_MIME));
             configured = true;
+            configuredDecoderState = commitConfiguredState(
+                    configuredDecoderState, format, profile, true);
+            LimeLog.info(formatLowLatencySelected(profile));
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
+            LimeLog.warning(formatLowLatencyFallback(profile, e));
             if (throwOnCodecError) {
                 throw e;
             }
         } catch (IllegalStateException e) {
             e.printStackTrace();
+            LimeLog.warning(formatLowLatencyFallback(profile, e));
             if (throwOnCodecError) {
                 throw e;
             }
         } catch (IOException e) {
             e.printStackTrace();
+            LimeLog.warning(formatLowLatencyFallback(profile, e));
             if (throwOnCodecError) {
                 throw new RuntimeException(e);
             }
@@ -685,7 +1132,20 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         return configured;
     }
 
+    private void reconfigureActiveDecoder(RecoveryStage stage) {
+        if (recoveryActionFor(stage) != RecoveryAction.REUSE_ACTIVE_CONFIGURATION ||
+                configuredDecoderState == null) {
+            throw new IllegalStateException("No active decoder configuration to reuse for " + stage);
+        }
+        configureAndStartDecoder(configuredDecoderState.format);
+    }
+
     public int initializeDecoder(boolean throwOnCodecError) {
+        return initializeDecoder(
+                configurationModeForInitializeDecoder(throwOnCodecError));
+    }
+
+    private int initializeDecoder(ConfigurationMode configurationMode) {
         String mimeType;
         MediaCodecInfo selectedDecoderInfo;
 
@@ -753,26 +1213,65 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         adaptivePlayback = MediaCodecHelper.decoderSupportsAdaptivePlayback(selectedDecoderInfo, mimeType);
         fusedIdrFrame = MediaCodecHelper.decoderSupportsFusedIdrFrame(selectedDecoderInfo, mimeType);
 
-        for (int tryNumber = 0;; tryNumber++) {
-            LimeLog.info("Decoder configuration try: "+tryNumber);
+        ActiveLowLatencyProfileKind activeKindBeforeConfiguration =
+                configuredDecoderState == null ? ActiveLowLatencyProfileKind.BASE :
+                        configuredDecoderState.kind;
+        MediaCodecHelper.LowLatencyConfigurationPlan lowLatencyPlan =
+                MediaCodecHelper.createDecoderLowLatencyPlan(
+                        selectedDecoderInfo,
+                        mimeType,
+                        prefs.enableUltraLowLatency,
+                        configurationMode == ConfigurationMode.RUNTIME_RECOVERY ?
+                                LowLatencyProfilePlanner.PlanPurpose.RUNTIME_RECOVERY :
+                                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+        LimeLog.info(MediaCodecHelper.formatCapabilityLog(lowLatencyPlan));
+        LowLatencyOptionSource optionSource = lowLatencyPlan::getProfile;
+        List<DecoderConfigurationProfile> configurationProfiles =
+                configurationMode == ConfigurationMode.RUNTIME_RECOVERY ?
+                        selectRuntimeRecoveryProfiles(
+                                activeKindBeforeConfiguration, optionSource) :
+                        selectConfigurationProfiles(0, optionSource);
+        boolean androidLowLatencySupported = lowLatencyPlan.featureLowLatency;
+
+        for (int attemptOrdinal = 0;
+             attemptOrdinal < configurationProfiles.size();
+             attemptOrdinal++) {
+            DecoderConfigurationProfile profile = configurationProfiles.get(attemptOrdinal);
+            LimeLog.info(formatLowLatencyAttempt(attemptOrdinal, profile));
 
             MediaFormat mediaFormat = createBaseMediaFormat(mimeType);
-            // This will try low latency options until we find one that works (or we give up).
-            boolean newFormat = MediaCodecHelper.setDecoderLowLatencyOptions(mediaFormat, selectedDecoderInfo, prefs.enableUltraLowLatency, tryNumber);
+            for (Map.Entry<String, Integer> option : profile.integerOptions.entrySet()) {
+                mediaFormat.setInteger(option.getKey(), option.getValue());
+            }
             //todo 色彩格式
 //            MediaCodecInfo.CodecCapabilities codecCapabilities = selectedDecoderInfo.getCapabilitiesForType(mimeType);
 //            int[] colorFormats=codecCapabilities.colorFormats;
 //            for (int colorFormat : colorFormats) {
 //                LimeLog.info("Decoder configuration colorFormats: "+colorFormat);
 //            }
-            // Throw the underlying codec exception on the last attempt if the caller requested it
-            if (tryConfigureDecoder(selectedDecoderInfo, mediaFormat, !newFormat && throwOnCodecError)) {
+            ConfigurationFailureDisposition failureDisposition =
+                    configurationFailureDisposition(configurationMode, profile);
+            boolean configured;
+            try {
+                configured = tryConfigureDecoder(
+                        selectedDecoderInfo,
+                        mediaFormat,
+                        profile,
+                        failureDisposition == ConfigurationFailureDisposition.RETHROW);
+            }
+            catch (RuntimeException e) {
+                LimeLog.severe(finalConfigurationFailureMessage(
+                        selectedDecoderInfo.getName(), profile, androidLowLatencySupported));
+                throw e;
+            }
+            if (configured) {
                 // Success!
                 break;
             }
 
-            if (!newFormat) {
-                // We couldn't even configure a decoder without any low latency options
+            if (failureDisposition == ConfigurationFailureDisposition.RETURN_MINUS_FIVE) {
+                LimeLog.severe(finalConfigurationFailureMessage(
+                        selectedDecoderInfo.getName(), profile, androidLowLatencySupported));
                 return -5;
             }
         }
@@ -796,6 +1295,8 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
     @Override
     public int setup(int format, int width, int height, int redrawRate) {
+        decoderLatencyState.resetForNewSession();
+
         this.targetFps = (redrawRate > 0 ? redrawRate : 60);
         this.initialWidth = invertResolution ? height : width;
         this.initialHeight = invertResolution ? width : height;
@@ -825,6 +1326,8 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
             // This is the final thread to quiesce, so let's perform the codec recovery now.
             if (codecRecoveryThreadQuiescedFlags == CR_FLAG_ALL) {
+                decoderLatencyState.clearPendingForCodecInvalidation();
+
                 // Input and output buffers are invalidated by stop() and reset().
                 nextInputBuffer = null;
                 nextInputBufferIndex = -1;
@@ -856,7 +1359,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     LimeLog.warning("Trying to restart decoder after CodecException");
                     try {
                         videoDecoder.stop();
-                        configureAndStartDecoder(configuredFormat);
+                        reconfigureActiveDecoder(RecoveryStage.RESTART);
                         codecRecoveryType.set(CR_RECOVERY_TYPE_NONE);
                     } catch (IllegalArgumentException e) {
                         e.printStackTrace();
@@ -879,7 +1382,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     LimeLog.warning("Trying to reset decoder after CodecException");
                     try {
                         videoDecoder.reset();
-                        configureAndStartDecoder(configuredFormat);
+                        reconfigureActiveDecoder(RecoveryStage.RESET);
                         codecRecoveryType.set(CR_RECOVERY_TYPE_NONE);
                     } catch (IllegalArgumentException e) {
                         e.printStackTrace();
@@ -1213,7 +1716,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     if (!preferLowerDelays) {
                         try {
                             android.media.MediaCodec.BufferInfo __tmpInfo = new android.media.MediaCodec.BufferInfo();
-                            int __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+                            int __idx = dequeueOutputBufferWithLatency(__tmpInfo, 0);
                             int __last = -1;
                             long __lastPtsUs = -1L;
 
@@ -1224,7 +1727,7 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                 }
                                 __last = __idx;
                                 __lastPtsUs = __tmpInfo.presentationTimeUs;
-                                __idx = videoDecoder.dequeueOutputBuffer(__tmpInfo, 0);
+                                __idx = dequeueOutputBufferWithLatency(__tmpInfo, 0);
                             }
 
                             if (__last >= 0) {
@@ -1237,7 +1740,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                 if (__lastPtsUs >= 0) {
                                     long __d2pNs = __nowNs - (__lastPtsUs * 1000L);
                                     ewmaDecodeToPresentNs += EWMA_ALPHA * (__d2pNs - ewmaDecodeToPresentNs);
-                                    try { updateDecodeLatencyStats(__lastPtsUs); } catch (Throwable ignored) {}
                                 }
 
                                 continue; // handled this iteration
@@ -1249,22 +1751,19 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
                     try {
                         // Try to output a frame
-                        int outIndex = videoDecoder.dequeueOutputBuffer(info, getOutputDequeueTimeoutUs());
+                        int outIndex = dequeueOutputBufferWithLatency(
+                                info, getOutputDequeueTimeoutUs());
 
                         if (outIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
                             // reduced backoff 0–500 µs
                             tryAgainStreak++;
                             int backoffUs = (tryAgainStreak <= 2) ? 250 : 500;
-                            outIndex = videoDecoder.dequeueOutputBuffer(info, backoffUs);
+                            outIndex = dequeueOutputBufferWithLatency(info, backoffUs);
                         } else {
                             tryAgainStreak = 0;
                         }
 
                         if (outIndex >= 0) {
-                            // --- flags per gestire le statistiche in modo robusto ---
-                            boolean statsUpdated = false;
-                            boolean frameDropped = false;
-
                             long presentationTimeUs = info.presentationTimeUs;
                             int lastIndex = outIndex;
 
@@ -1283,9 +1782,9 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                             // Render the latest frame now if frame pacing isn't in balanced mode
                             if (prefs.framePacing != PreferenceConfiguration.FRAME_PACING_BALANCED) {
                                 // Get the last output buffer in the queue
-                                while ((outIndex = videoDecoder.dequeueOutputBuffer(info, getOutputDequeueTimeoutUs())) >= 0) {
+                                while ((outIndex = dequeueOutputBufferWithLatency(
+                                        info, getOutputDequeueTimeoutUs())) >= 0) {
                                     videoDecoder.releaseOutputBuffer(lastIndex, false);
-                                    frameDropped = true; // we're discarding the oldest one
 
                                     numFramesOut++;
                                     lastIndex = outIndex;
@@ -1314,7 +1813,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                                 videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
                                             }
 
-                                            frameDropped = true;
                                             lastDropNs = nowNs;
                                             recentDrops = Math.min(10, recentDrops + 1);
                                             continue;
@@ -1330,10 +1828,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                         lastPresentNs = nowNs;
                                         recentDrops = Math.max(0, recentDrops - 1);
 
-                                        // [STATS] update subito dopo il present
-                                        updateDecodeLatencyStats(presentationTimeUs);
-                                        statsUpdated = true;
-
                                     } else {
                                         if (android.os.Build.VERSION.SDK_INT >= 21) {
                                             long __ts = System.nanoTime();
@@ -1345,9 +1839,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                             }
                                         }
 
-                                        // [STATS] anche su pre-Lollipop, dopo presentazione
-                                        updateDecodeLatencyStats(presentationTimeUs);
-                                        statsUpdated = true;
                                     }
                                 }
                                 else {
@@ -1387,7 +1878,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                                 videoDecoder.releaseOutputBuffer(lastIndex, /* render */ false);
                                             }
 
-                                            frameDropped = true;
                                             lastDropNs = nowNs;
                                             recentDrops = Math.min(10, recentDrops + 1);
                                             continue; // niente stats sui frame droppati
@@ -1404,10 +1894,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                         if (!isLate) lateStreak = 0;
                                         recentDrops = Math.max(0, recentDrops - 1);
 
-                                        // [STATS] update subito dopo il present
-                                        updateDecodeLatencyStats(presentationTimeUs);
-                                        statsUpdated = true;
-
                                     } else {
                                         if (android.os.Build.VERSION.SDK_INT >= 21) {
                                             long __ts = System.nanoTime();
@@ -1419,9 +1905,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                             }
                                         }
 
-                                        // [STATS] anche su pre-Lollipop, dopo presentazione
-                                        updateDecodeLatencyStats(presentationTimeUs);
-                                        statsUpdated = true;
                                     }
                                 }
 
@@ -1439,7 +1922,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                 if (outputBufferQueue.size() == OUTPUT_BUFFER_QUEUE_LIMIT) {
                                     try {
                                         videoDecoder.releaseOutputBuffer(outputBufferQueue.take(), false);
-                                        frameDropped = true;
                                     } catch (InterruptedException e) {
                                         return;
                                     }
@@ -1448,12 +1930,6 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                                 // Add this buffer
                                 outputBufferQueue.add(lastIndex);
                                 // NB: in BALANCED non presentiamo qui; lasciamo il fallback stats sotto
-                            }
-
-                            // --- Fallback stats update ---
-                            // If we didn't update the stats in-branch and the frame wasn't dropped,
-                            if (!statsUpdated && !frameDropped) {
-                                updateDecodeLatencyStats(presentationTimeUs);
                             }
 
                         } else {
@@ -1482,7 +1958,8 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     if (__nowNs - lastOutputNs > 1_200_000_000L) { // ~1.2s without output → likely C2 sleep
                         LimeLog.warning("Decoder watchdog: no output >1.2s, flushing codec to recover...");
                         try {
-                            videoDecoder.flush();
+                            decoderLatencyState.clearPendingAndRunCodecInvalidation(
+                                    videoDecoder::flush);
                         } catch (Throwable ignored) {}
                         try {
                             android.os.Bundle __poke = new android.os.Bundle();
@@ -1614,36 +2091,51 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         // May be called already, but we'll call it now to be safe
         prepareForStop();
 
-        // Wait for the Choreographer looper to shut down (if we have one)
-        if (choreographerHandlerThread != null) {
-            try {
-                choreographerHandlerThread.join();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+        // Join fully before taking the one-shot session snapshot. If stop() is interrupted,
+        // preserve that status for the caller after the worker has actually terminated.
+        joinThreadPreservingInterrupt(choreographerHandlerThread);
+        joinThreadPreservingInterrupt(rendererThread);
 
-                // InterruptedException clears the thread's interrupt status. Since we can't
-                // handle that here, we will re-interrupt the thread to set the interrupt
-                // status back to true.
-                Thread.currentThread().interrupt();
+        logAndResetDecoderLatencySummary();
+    }
+
+    static void joinThreadPreservingInterrupt(Thread thread) {
+        if (thread == null) {
+            return;
+        }
+
+        boolean interrupted = false;
+        while (thread.isAlive()) {
+            try {
+                thread.join();
+            }
+            catch (InterruptedException e) {
+                interrupted = true;
             }
         }
 
-        // Wait for the renderer thread to shut down
-        try {
-            rendererThread.join();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-
-            // InterruptedException clears the thread's interrupt status. Since we can't
-            // handle that here, we will re-interrupt the thread to set the interrupt
-            // status back to true.
+        if (interrupted) {
             Thread.currentThread().interrupt();
         }
     }
 
     @Override
     public void cleanup() {
-        videoDecoder.release();
+        logAndResetDecoderLatencySummary();
+        if (videoDecoder != null) {
+            videoDecoder.release();
+            videoDecoder = null;
+        }
+    }
+
+    private void logAndResetDecoderLatencySummary() {
+        int[] samples = decoderLatencyState.takeSamplesForStop();
+        if (samples == null) {
+            return;
+        }
+
+        DecoderLatencySampler.Summary summary = DecoderLatencySampler.summarize(samples);
+        LimeLog.info(DecoderLatencySampler.formatSummary(summary));
     }
 
     @Override
@@ -1680,12 +2172,8 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
         boolean codecRecovered;
 
         try {
-            videoDecoder.queueInputBuffer(nextInputBufferIndex,
-                    0, nextInputBuffer.position(),
-                    timestampUs, codecFlags);
-
-            // Track enqueue time for this PTS
-            try { enqueueNsByPtsUs.put(timestampUs, System.nanoTime()); } catch (Throwable ignored) {}
+            decoderLatencyState.runInputQueueCall(
+                    timestampUs, codecFlags, decoderInputQueueCall);
 
             // We need a new buffer now
             nextInputBufferIndex = -1;
@@ -2288,6 +2776,8 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
 
         private String generateText(MediaCodecDecoderRenderer renderer, Exception originalException) {
             String str;
+            DecoderLatencySampler.Summary latencySummary = DecoderLatencySampler.summarize(
+                    renderer.decoderLatencyState.copySamplesForCrash());
 
             if (renderer.numVpsIn == 0 && renderer.numSpsIn == 0 && renderer.numPpsIn == 0) {
                 str = "PreSPSError";
@@ -2351,7 +2841,11 @@ public class MediaCodecDecoderRenderer extends VideoDecoderRenderer implements C
                     }
                 }
             }
-            str += "Configured format: "+renderer.configuredFormat+DELIMITER;
+            str += "Configured format: "+
+                    (renderer.configuredDecoderState == null ? "<none>" :
+                            renderer.configuredDecoderState.format)+DELIMITER;
+            str += formatCrashLatencyDiagnostics(
+                    renderer.configuredDecoderState, latencySummary, DELIMITER) + DELIMITER;
             str += "Input format: "+renderer.inputFormat+DELIMITER;
             str += "Output format: "+renderer.outputFormat+DELIMITER;
             str += "Adaptive playback: "+renderer.adaptivePlayback+DELIMITER;

--- a/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
+++ b/app/src/main/java/com/limelight/binding/video/MediaCodecHelper.java
@@ -3,10 +3,18 @@ package com.limelight.binding.video;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,6 +62,122 @@ public class MediaCodecHelper {
     private static boolean isLowEndSnapdragon = false;
     private static boolean isAdreno620 = false;
     private static boolean initialized = false;
+
+    interface VendorParameterSession {
+        List<String> getSupportedVendorParameters() throws Exception;
+        void release();
+    }
+
+    interface VendorParameterProvider {
+        VendorParameterSession open(String decoderName) throws Exception;
+    }
+
+    enum VendorEnumerationStatus {
+        NOT_SUPPORTED("not_supported"),
+        SUCCESS("success"),
+        FAILURE("failure");
+
+        final String logValue;
+
+        VendorEnumerationStatus(String logValue) {
+            this.logValue = logValue;
+        }
+    }
+
+    static final class VendorParameterSnapshot {
+        final VendorEnumerationStatus status;
+        final boolean enumerationAvailable;
+        final Set<String> supportedParameters;
+
+        private VendorParameterSnapshot(VendorEnumerationStatus status,
+                                         Set<String> supportedParameters) {
+            this.status = Objects.requireNonNull(status);
+            this.enumerationAvailable = status == VendorEnumerationStatus.SUCCESS;
+            this.supportedParameters = Collections.unmodifiableSet(
+                    new LinkedHashSet<>(supportedParameters));
+        }
+
+        private static VendorParameterSnapshot notSupported() {
+            return new VendorParameterSnapshot(
+                    VendorEnumerationStatus.NOT_SUPPORTED, Collections.emptySet());
+        }
+
+        private static VendorParameterSnapshot failure() {
+            return new VendorParameterSnapshot(
+                    VendorEnumerationStatus.FAILURE, Collections.emptySet());
+        }
+    }
+
+    static final class VendorParameterCapabilityStore {
+        private final VendorParameterProvider provider;
+        private final Map<String, VendorParameterSnapshot> cache = new HashMap<>();
+
+        VendorParameterCapabilityStore(VendorParameterProvider provider) {
+            this.provider = provider;
+        }
+
+        synchronized VendorParameterSnapshot getSnapshot(String decoderName, int sdkInt) {
+            if (sdkInt < Build.VERSION_CODES.S) {
+                return VendorParameterSnapshot.notSupported();
+            }
+
+            String normalizedDecoderName = decoderName.toLowerCase(Locale.US);
+            VendorParameterSnapshot cachedSnapshot = cache.get(normalizedDecoderName);
+            if (cachedSnapshot != null) {
+                return cachedSnapshot;
+            }
+
+            VendorParameterSession session = null;
+            try {
+                session = provider.open(decoderName);
+                TreeSet<String> normalizedParameters = new TreeSet<>();
+                for (String parameter : session.getSupportedVendorParameters()) {
+                    if (parameter != null) {
+                        normalizedParameters.add(parameter.toLowerCase(Locale.US));
+                    }
+                }
+
+                VendorParameterSnapshot snapshot =
+                        new VendorParameterSnapshot(
+                                VendorEnumerationStatus.SUCCESS, normalizedParameters);
+                cache.put(normalizedDecoderName, snapshot);
+                return snapshot;
+            }
+            catch (Exception e) {
+                LimeLog.warning("Unable to enumerate vendor parameters for " + decoderName +
+                        ": " + e.getMessage());
+                return VendorParameterSnapshot.failure();
+            }
+            finally {
+                if (session != null) {
+                    try {
+                        session.release();
+                    }
+                    catch (RuntimeException e) {
+                        LimeLog.warning("Unable to release vendor parameter probe for " +
+                                decoderName + ": " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    private static final VendorParameterCapabilityStore vendorParameterCapabilities =
+            new VendorParameterCapabilityStore(decoderName -> {
+                final MediaCodec codec = MediaCodec.createByCodecName(decoderName);
+                return new VendorParameterSession() {
+                    @Override
+                    @androidx.annotation.RequiresApi(api = Build.VERSION_CODES.S)
+                    public List<String> getSupportedVendorParameters() {
+                        return codec.getSupportedVendorParameters();
+                    }
+
+                    @Override
+                    public void release() {
+                        codec.release();
+                    }
+                };
+            });
 
     static {
         directSubmitPrefixes = new LinkedList<>();
@@ -220,8 +344,31 @@ public class MediaCodecHelper {
     static {
         knownVendorLowLatencyOptions = new LinkedList<>();
 
-        knownVendorLowLatencyOptions.add("vendor.qti-ext-dec-low-latency.enable");
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.QTI_CORE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.QTI_PICTURE_ORDER);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_LOW_LATENCY_MODE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_DISABLE_IDLE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_VSYNC_ADJUST_ENABLE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_ULTRA_LOW_LATENCY);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_PRELOAD_FRAME_COUNT);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_INPUT_QUEUE_DEPTH);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_OUTPUT_QUEUE_DEPTH);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_FETCH_TIMEOUT);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_FETCH_TIMEOUT_VALUE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_GUARD_INTERVAL);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_GUARD_INTERVAL_VALUE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_CPU_BOOST);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_CPU_BOOST_VALUE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_DVFS_MODE);
+        knownVendorLowLatencyOptions.add(LowLatencyProfilePlanner.MTK_DVFS_LEVEL);
+        knownVendorLowLatencyOptions.add("media.low-latency.enable");
+        knownVendorLowLatencyOptions.add("disable-output-reorder");
+        knownVendorLowLatencyOptions.add("vendor.nvidia.disable-output-reorder");
         knownVendorLowLatencyOptions.add("vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-req");
+        knownVendorLowLatencyOptions.add("vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-rdy");
         knownVendorLowLatencyOptions.add("vendor.rtc-ext-dec-low-latency.enable");
         knownVendorLowLatencyOptions.add("vendor.low-latency.enable");
     }
@@ -467,7 +614,7 @@ public class MediaCodecHelper {
         return false;
     }
 
-    private static boolean decoderSupportsAndroidRLowLatency(MediaCodecInfo decoderInfo, String mimeType) {
+    static boolean decoderSupportsAndroidRLowLatency(MediaCodecInfo decoderInfo, String mimeType) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             try {
                 if (decoderInfo.getCapabilitiesForType(mimeType).isFeatureSupported(CodecCapabilities.FEATURE_LowLatency)) {
@@ -484,31 +631,21 @@ public class MediaCodecHelper {
     }
 
     private static boolean decoderSupportsKnownVendorLowLatencyOption(String decoderName) {
-        // It's only possible to probe vendor parameters on Android 12 and above.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            MediaCodec testCodec = null;
-            try {
-                // Unfortunately we have to create an actual codec instance to get supported options.
-                testCodec = MediaCodec.createByCodecName(decoderName);
+        VendorParameterSnapshot snapshot = vendorParameterCapabilities.getSnapshot(
+                decoderName, Build.VERSION.SDK_INT);
+        if (!snapshot.enumerationAvailable) {
+            return false;
+        }
 
-                // See if any of the vendor parameters match ones we know about
-                for (String supportedOption : testCodec.getSupportedVendorParameters()) {
-                    for (String knownLowLatencyOption : knownVendorLowLatencyOptions) {
-                        if (supportedOption.equalsIgnoreCase(knownLowLatencyOption)) {
-                            LimeLog.info(decoderName + " supports known low latency option: " + supportedOption);
-                            return true;
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                // Tolerate buggy codecs
-                e.printStackTrace();
-            } finally {
-                if (testCodec != null) {
-                    testCodec.release();
-                }
+        for (String knownLowLatencyOption : knownVendorLowLatencyOptions) {
+            if (snapshot.supportedParameters.contains(
+                    knownLowLatencyOption.toLowerCase(Locale.US))) {
+                LimeLog.info(decoderName + " supports known low latency option: " +
+                        knownLowLatencyOption);
+                return true;
             }
         }
+
         return false;
     }
 
@@ -530,175 +667,361 @@ public class MediaCodecHelper {
                 ) && !isAdreno620;
     }
 
-    public static boolean setDecoderLowLatencyOptions(MediaFormat videoFormat, MediaCodecInfo decoderInfo, boolean ultraLowLatency, int tryNumber) {
-        // Options here should be tried in the order of most to least risky. The decoder will use
-        // the first MediaFormat that doesn't fail in configure().
+    static final class AppliedLowLatencyOptions {
+        final int profileIndex;
+        final String profileName;
+        final Map<String, Integer> integerOptions;
 
-        boolean setNewOption = false;
+        AppliedLowLatencyOptions(int profileIndex,
+                                 String profileName,
+                                 Map<String, Integer> integerOptions) {
+            if (profileIndex < 0) {
+                throw new IllegalArgumentException("profileIndex must be non-negative");
+            }
+            if (integerOptions.isEmpty()) {
+                throw new IllegalArgumentException("Low-latency option profile must not be empty");
+            }
 
-//derflacco
-        // NVIDIA Tegra extra low-latency toggles
+            this.profileIndex = profileIndex;
+            this.profileName = Objects.requireNonNull(profileName);
+            this.integerOptions = Collections.unmodifiableMap(
+                    new LinkedHashMap<>(integerOptions));
+        }
+    }
+
+    static final class LowLatencyConfigurationPlan {
+        final String decoderName;
+        final String mimeType;
+        final boolean featureLowLatency;
+        final VendorEnumerationStatus vendorEnumerationStatus;
+        final List<String> advertisedLowLatencyParameters;
+        final boolean ullPreference;
+        private final List<AppliedLowLatencyOptions> profiles;
+
+        private LowLatencyConfigurationPlan(
+                String decoderName,
+                String mimeType,
+                boolean featureLowLatency,
+                VendorEnumerationStatus vendorEnumerationStatus,
+                List<String> advertisedLowLatencyParameters,
+                boolean ullPreference,
+                List<LowLatencyProfilePlanner.Profile> plannedProfiles) {
+            this.decoderName = Objects.requireNonNull(decoderName);
+            this.mimeType = Objects.requireNonNull(mimeType);
+            this.featureLowLatency = featureLowLatency;
+            this.vendorEnumerationStatus = Objects.requireNonNull(vendorEnumerationStatus);
+            this.advertisedLowLatencyParameters = Collections.unmodifiableList(
+                    new ArrayList<>(advertisedLowLatencyParameters));
+            this.ullPreference = ullPreference;
+
+            List<AppliedLowLatencyOptions> appliedProfiles =
+                    new ArrayList<>(plannedProfiles.size());
+            for (int profileIndex = 0;
+                 profileIndex < plannedProfiles.size();
+                 profileIndex++) {
+                LowLatencyProfilePlanner.Profile profile = plannedProfiles.get(profileIndex);
+                appliedProfiles.add(new AppliedLowLatencyOptions(
+                        profileIndex, profile.name, profile.integerOptions));
+            }
+            this.profiles = Collections.unmodifiableList(appliedProfiles);
+        }
+
+        AppliedLowLatencyOptions getProfile(int profileIndex) {
+            return profileIndex >= 0 && profileIndex < profiles.size() ?
+                    profiles.get(profileIndex) : null;
+        }
+    }
+
+    static String formatCapabilityLog(LowLatencyConfigurationPlan plan) {
+        return "CodecLLCapability decoder=" + plan.decoderName +
+                " mime=" + plan.mimeType +
+                " featureLowLatency=" + plan.featureLowLatency +
+                " vendorEnumeration=" + plan.vendorEnumerationStatus.logValue +
+                " advertisedLowLatencyParameters=" +
+                plan.advertisedLowLatencyParameters +
+                " ullPreference=" + plan.ullPreference;
+    }
+
+    public static AppliedLowLatencyOptions setDecoderLowLatencyOptions(
+            MediaFormat videoFormat,
+            MediaCodecInfo decoderInfo,
+            boolean ultraLowLatency,
+            int profileIndex) {
+        AppliedLowLatencyOptions applied = getDecoderLowLatencyOptions(
+                decoderInfo,
+                videoFormat.getString(MediaFormat.KEY_MIME),
+                ultraLowLatency,
+                profileIndex,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+        applyLowLatencyOptions(videoFormat, applied);
+        return applied;
+    }
+
+    static AppliedLowLatencyOptions getDecoderLowLatencyOptions(
+            MediaCodecInfo decoderInfo,
+            String mimeType,
+            boolean ultraLowLatency,
+            int profileIndex,
+            LowLatencyProfilePlanner.PlanPurpose purpose) {
+        return createDecoderLowLatencyPlan(
+                decoderInfo,
+                mimeType,
+                ultraLowLatency,
+                purpose,
+                vendorParameterCapabilities,
+                Build.VERSION.SDK_INT,
+                decoderSupportsAndroidRLowLatency(decoderInfo, mimeType),
+                decoderSupportsMaxOperatingRate(decoderInfo.getName()),
+                Build.MANUFACTURER,
+                false).getProfile(profileIndex);
+    }
+
+    static AppliedLowLatencyOptions setDecoderLowLatencyOptions(
+            MediaFormat videoFormat,
+            MediaCodecInfo decoderInfo,
+            boolean ultraLowLatency,
+            int profileIndex,
+            VendorParameterCapabilityStore capabilityStore,
+            int sdkInt,
+            boolean androidLowLatencySupported,
+            boolean maxOperatingRateSupported) {
+        return setDecoderLowLatencyOptions(
+                videoFormat,
+                decoderInfo,
+                ultraLowLatency,
+                profileIndex,
+                capabilityStore,
+                sdkInt,
+                androidLowLatencySupported,
+                maxOperatingRateSupported,
+                Build.MANUFACTURER);
+    }
+
+    static AppliedLowLatencyOptions setDecoderLowLatencyOptions(
+            MediaFormat videoFormat,
+            MediaCodecInfo decoderInfo,
+            boolean ultraLowLatency,
+            int profileIndex,
+            VendorParameterCapabilityStore capabilityStore,
+            int sdkInt,
+            boolean androidLowLatencySupported,
+            boolean maxOperatingRateSupported,
+            String manufacturer) {
+        AppliedLowLatencyOptions applied = createDecoderLowLatencyPlan(
+                decoderInfo,
+                videoFormat.getString(MediaFormat.KEY_MIME),
+                ultraLowLatency,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION,
+                capabilityStore,
+                sdkInt,
+                androidLowLatencySupported,
+                maxOperatingRateSupported,
+                manufacturer,
+                false).getProfile(profileIndex);
+        applyLowLatencyOptions(videoFormat, applied);
+        return applied;
+    }
+
+    static LowLatencyConfigurationPlan createDecoderLowLatencyPlan(
+            MediaCodecInfo decoderInfo,
+            String mimeType,
+            boolean ultraLowLatency,
+            LowLatencyProfilePlanner.PlanPurpose purpose) {
+        return createDecoderLowLatencyPlan(
+                decoderInfo,
+                mimeType,
+                ultraLowLatency,
+                purpose,
+                vendorParameterCapabilities,
+                Build.VERSION.SDK_INT,
+                decoderSupportsAndroidRLowLatency(decoderInfo, mimeType),
+                decoderSupportsMaxOperatingRate(decoderInfo.getName()),
+                Build.MANUFACTURER);
+    }
+
+    static LowLatencyConfigurationPlan createDecoderLowLatencyPlan(
+            MediaCodecInfo decoderInfo,
+            String mimeType,
+            boolean ultraLowLatency,
+            LowLatencyProfilePlanner.PlanPurpose purpose,
+            VendorParameterCapabilityStore capabilityStore,
+            int sdkInt,
+            boolean androidLowLatencySupported,
+            boolean maxOperatingRateSupported,
+            String manufacturer) {
+        return createDecoderLowLatencyPlan(
+                decoderInfo,
+                mimeType,
+                ultraLowLatency,
+                purpose,
+                capabilityStore,
+                sdkInt,
+                androidLowLatencySupported,
+                maxOperatingRateSupported,
+                manufacturer,
+                true);
+    }
+
+    private static LowLatencyConfigurationPlan createDecoderLowLatencyPlan(
+            MediaCodecInfo decoderInfo,
+            String mimeType,
+            boolean ultraLowLatency,
+            LowLatencyProfilePlanner.PlanPurpose purpose,
+            VendorParameterCapabilityStore capabilityStore,
+            int sdkInt,
+            boolean androidLowLatencySupported,
+            boolean maxOperatingRateSupported,
+            String manufacturer,
+            boolean enumerateOtherVendorParameters) {
+        String decoderName = decoderInfo.getName();
+        LowLatencyProfilePlanner.DecoderFamily decoderFamily =
+                LowLatencyProfilePlanner.classifyDecoderFamily(decoderName);
+        boolean legacyVdecLowLatencyAllowed =
+                LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                        decoderName, manufacturer, sdkInt);
+        VendorParameterSnapshot snapshot =
+                decoderFamily == LowLatencyProfilePlanner.DecoderFamily.OTHER &&
+                        !enumerateOtherVendorParameters ?
+                        VendorParameterSnapshot.notSupported() :
+                        capabilityStore.getSnapshot(decoderName, sdkInt);
+        LowLatencyProfilePlanner.Capabilities capabilities =
+                new LowLatencyProfilePlanner.Capabilities(
+                        decoderFamily,
+                        decoderName,
+                        sdkInt,
+                        androidLowLatencySupported,
+                        maxOperatingRateSupported,
+                        legacyVdecLowLatencyAllowed,
+                        snapshot.enumerationAvailable,
+                        snapshot.supportedParameters);
+
+        List<LowLatencyProfilePlanner.Profile> profiles;
+        if (purpose == LowLatencyProfilePlanner.PlanPurpose.RUNTIME_RECOVERY ||
+                decoderFamily != LowLatencyProfilePlanner.DecoderFamily.OTHER ||
+                legacyVdecLowLatencyAllowed) {
+            profiles = LowLatencyProfilePlanner.plan(capabilities, ultraLowLatency, purpose);
+        }
+        else {
+            profiles = planLegacyNonPlannerProfiles(
+                    capabilities, decoderInfo, ultraLowLatency, sdkInt);
+        }
+
+        return new LowLatencyConfigurationPlan(
+                decoderName,
+                mimeType,
+                androidLowLatencySupported,
+                snapshot.status,
+                filteredAdvertisedLowLatencyParameters(snapshot),
+                ultraLowLatency,
+                profiles);
+    }
+
+    private static List<String> filteredAdvertisedLowLatencyParameters(
+            VendorParameterSnapshot snapshot) {
+        if (snapshot.status != VendorEnumerationStatus.SUCCESS) {
+            return Collections.emptyList();
+        }
+
+        TreeSet<String> normalizedKnownParameters = new TreeSet<>();
+        for (String parameter : knownVendorLowLatencyOptions) {
+            normalizedKnownParameters.add(parameter.toLowerCase(Locale.US));
+        }
+
+        List<String> filteredParameters = new ArrayList<>();
+        for (String parameter : snapshot.supportedParameters) {
+            if (normalizedKnownParameters.contains(parameter)) {
+                filteredParameters.add(parameter);
+            }
+        }
+        return filteredParameters;
+    }
+
+    private static List<LowLatencyProfilePlanner.Profile> planLegacyNonPlannerProfiles(
+            LowLatencyProfilePlanner.Capabilities capabilities,
+            MediaCodecInfo decoderInfo,
+            boolean ultraLowLatency,
+            int sdkInt) {
+        List<LowLatencyProfilePlanner.Profile> profiles = new ArrayList<>();
+        LinkedHashMap<String, Integer> standard = new LinkedHashMap<>();
+        if (capabilities.androidLowLatencySupported) {
+            standard.put(MediaFormat.KEY_LOW_LATENCY, 1);
+        }
+
+        LinkedHashMap<String, Integer> vendor = new LinkedHashMap<>();
+        String familyProfileName = null;
         if (isNvidiaDecoder(decoderInfo.getName())) {
-            safeSet(videoFormat, "media.low-latency.enable", 1);
-            safeSet(videoFormat, "vendor.low-latency.enable", 1);
-            safeSet(videoFormat, "disable-output-reorder", 1);
-            safeSet(videoFormat, "vendor.nvidia.disable-output-reorder", 1);
-            setNewOption = true;
+            familyProfileName = "nvidia-legacy";
+            vendor.put("media.low-latency.enable", 1);
+            vendor.put("vendor.low-latency.enable", 1);
+            vendor.put("disable-output-reorder", 1);
+            vendor.put("vendor.nvidia.disable-output-reorder", 1);
         }
-        if (tryNumber < 1) {
-            // Official Android 11+ low latency option (KEY_LOW_LATENCY).
-            videoFormat.setInteger("low-latency", 1);
-            setNewOption = true;
-
-            // If this decoder officially supports FEATURE_LowLatency, we will just use that alone
-            // for try 0. Otherwise, we'll include it as best effort with other options.
-            if (!ultraLowLatency && decoderSupportsAndroidRLowLatency(decoderInfo, videoFormat.getString(MediaFormat.KEY_MIME))) {
-                return true;
-            }
-
-            // ALONSOJR1980: "low-latency" is not enough, continuing to add specific extensions
+        else if (sdkInt >= Build.VERSION_CODES.O &&
+                isDecoderInList(kirinDecoderPrefixes, decoderInfo.getName())) {
+            familyProfileName = "kirin-legacy";
+            vendor.put("vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-req", 1);
+            vendor.put("vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-rdy", -1);
+        }
+        else if (sdkInt >= Build.VERSION_CODES.O &&
+                isDecoderInList(exynosDecoderPrefixes, decoderInfo.getName())) {
+            familyProfileName = "exynos-legacy";
+            vendor.put("vendor.rtc-ext-dec-low-latency.enable", 1);
         }
 
-        if (tryNumber < 2 &&
-                (!Build.MANUFACTURER.equalsIgnoreCase("xiaomi") || Build.VERSION.SDK_INT > Build.VERSION_CODES.M)) {
-            // MediaTek decoders don't use vendor-defined keys for low latency mode. Instead, they have a modified
-            // version of AOSP's ACodec.cpp which supports the "vdec-lowlatency" option. This option is passed down
-            // to the decoder as OMX.MTK.index.param.video.LowLatencyDecode.
-            //
-            // This option is also plumbed for Amazon Amlogic-based devices like the Fire TV 3. Not only does it
-            // reduce latency on Amlogic, it fixes the HEVC bug that causes the decoder to not output any frames.
-            // Unfortunately, it does the exact opposite for the Xiaomi MITV4-ANSM0, breaking it in the way that
-            // Fire TV was broken prior to vdec-lowlatency :(
-            //
-            // On Fire TV 3, vdec-lowlatency is translated to OMX.amazon.fireos.index.video.lowLatencyDecode.
-            //
-            // https://github.com/yuan1617/Framwork/blob/master/frameworks/av/media/libstagefright/ACodec.cpp
-            // https://github.com/iykex/vendor_mediatek_proprietary_hardware/blob/master/libomx/video/MtkOmxVdecEx/MtkOmxVdecEx.h
-            videoFormat.setInteger("vdec-lowlatency", 1);
-            setNewOption = true;
+        LinkedHashMap<String, Integer> scheduler = new LinkedHashMap<>();
+        if (capabilities.maxOperatingRateSupported) {
+            scheduler.put(MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE);
+        }
+        else if (sdkInt >= Build.VERSION_CODES.M) {
+            scheduler.put(MediaFormat.KEY_PRIORITY, 0);
         }
 
-        if (tryNumber < 3) {
-            if (MediaCodecHelper.decoderSupportsMaxOperatingRate(decoderInfo.getName())) {
-                videoFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE);
-                setNewOption = true;
+        if (ultraLowLatency && !vendor.isEmpty()) {
+            if (!standard.isEmpty() && !scheduler.isEmpty()) {
+                addLegacyProfile(profiles, familyProfileName + "-full",
+                        standard, vendor, scheduler);
             }
-            else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                videoFormat.setInteger(MediaFormat.KEY_PRIORITY, 0);
-                setNewOption = true;
+            if (!standard.isEmpty()) {
+                addLegacyProfile(profiles, familyProfileName + "-standard",
+                        standard, vendor);
             }
+            addLegacyProfile(profiles, "android-standard", standard);
+            if (!scheduler.isEmpty()) {
+                addLegacyProfile(profiles, familyProfileName + "-performance",
+                        vendor, scheduler);
+            }
+            addLegacyProfile(profiles, familyProfileName, vendor);
+            addLegacyProfile(profiles, "performance-only", scheduler);
         }
-
-        // MediaCodec supports vendor-defined format keys using the "vendor.<extension name>.<parameter name>" syntax.
-        // These allow access to functionality that is not exposed through documented MediaFormat.KEY_* values.
-        // https://cs.android.com/android/platform/superproject/+/master:hardware/qcom/sdm845/media/mm-video-v4l2/vidc/common/inc/vidc_vendor_extensions.h;l=67
-        //
-        // MediaCodec vendor extension support was introduced in Android 8.0:
-        // https://cs.android.com/android/_/android/platform/frameworks/av/+/01c10f8cdcd58d1e7025f426a72e6e75ba5d7fc2
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            // Try vendor-specific low latency options
-            //
-            // NOTE: Update knownVendorLowLatencyOptions if you modify this code!
-            if (isDecoderInList(qualcommDecoderPrefixes, decoderInfo.getName())) {
-                // Examples of Qualcomm's vendor extensions for Snapdragon 845:
-                // https://cs.android.com/android/platform/superproject/+/master:hardware/qcom/sdm845/media/mm-video-v4l2/vidc/vdec/src/omx_vdec_extensions.hpp
-                // https://cs.android.com/android/_/android/platform/hardware/qcom/sm8150/media/+/0621ceb1c1b19564999db8293574a0e12952ff6c
-                //
-                // We will first try both, then try vendor.qti-ext-dec-low-latency.enable alone if that fails
-                if (tryNumber < 4) {
-                    // Adjust picture-order flag: 0 for OMX.qcom (disable reordering), 1 for C2.*
-                    boolean __isOmxQcom = decoderInfo.getName() != null &&
-                            decoderInfo.getName().toLowerCase(java.util.Locale.US).startsWith("omx.qcom");
-                    safeSet(videoFormat, "vendor.qti-ext-dec-picture-order.enable", __isOmxQcom ? 0 : 1);
-                    setNewOption = true;
-                }
-                if (tryNumber < 5) {
-                    videoFormat.setInteger("vendor.qti-ext-dec-low-latency.enable", 1);
-
-                    //ALONSOJR1980 - CONFIRMED WORKING: Snapdragon Elite, SD8 gen 3, SD8 gen 2
-                    //latency-wise, software fencing is the most important flag for latest Snapdragons
-                    videoFormat.setInteger("vendor.qti-ext-output-sw-fence-enable.value", 1); //Snapdragon 8 gen 2
-                    videoFormat.setInteger("vendor.qti-ext-output-fence.enable", 1); // Snapdragon 8s Gen 3 and Elite
-                    videoFormat.setInteger("vendor.qti-ext-output-fence.fence_type", 1); // Snapdragon 8s Gen 3 and ELite / 0 = none, 1 = sw, 2 = hw, 3 = hybrid. Best option = 1
-                    ////////////////////////////////////////////////////////////////////////////////
-
-                    setNewOption = true;
-                }
-            }
-            // ALONSOJR1980
-//            else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
-//                if (tryNumber < 4) {
-//
-//                    videoFormat.setInteger("vendor.mtk.vdec.cpu.boost.mode.value", 2);
-//                    videoFormat.setInteger("vendor.mtk.ext.dolby.vision.cpu-boost", 1);
-//                    videoFormat.setInteger("vendor.mtk.vdec.bq.guard.interval.time.value", 2);
-//                    videoFormat.setInteger("vendor.mtk.vdec.buffer.fetch.timeout.ms.value", 2);
-            else if (isDecoderInList(mtkDecoderPrefixes, decoderInfo.getName())) {
-                if (tryNumber < 4) {
-                    // --- PRESET: MTK Low-Latency (safe & balanced, no duplicates) ---
-
-                    // Boost/DVFS: moderate profile
-                    safeSet(videoFormat, "vdec-lowlatency", 1);
-                    safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode", 1);
-                    safeSet(videoFormat, "vendor.mtk.vdec.cpu.boost.mode.value", 1);
-                    safeSet(videoFormat, "vendor.mtk.vdec.dvfs.mode", 1);
-                    safeSet(videoFormat, "vendor.mtk.vdec.dvfs.level", 1);
-
-                    // Pipeline / code path
-                    safeSet(videoFormat, "vendor.mtk.vdec.low-latency.mode", 1);    // Enable low-latency path
-                    safeSet(videoFormat, "vendor.mtk.vdec.ultra-low-latency", 0);   // ULL off for stability
-                    safeSet(videoFormat, "vendor.mtk.vdec.disable-idle", 1);        // Prevent clock downscaling
-                    safeSet(videoFormat, "vendor.mtk.vdec.preload.frame.count", 1); // Light prebuffering
-
-                    // Queue / timeouts (moderate)
-                    safeSet(videoFormat, "vendor.mtk.vdec.buffer.fetch.timeout.ms", 4);
-                    safeSet(videoFormat, "vendor.mtk.vdec.bq.guard.interval.time", 4);
-                    safeSet(videoFormat, "vendor.mtk.vdec.input.max.queue.depth", 3);
-                    safeSet(videoFormat, "vendor.mtk.vdec.output.max.queue.depth", 3);
-
-                    // Pacing: controlled by the app
-                    safeSet(videoFormat, "vendor.mtk.vdec.vsync.adjust.enable", 0);
-
-                    // Skip/drop: only NVOP
-                    safeSet(videoFormat, "vendor.mtk.vdec.nvop.skip", 1);
-                    safeSet(videoFormat, "vendor.mtk.vdec.skip.mode", 0);
-                    safeSet(videoFormat, "vendor.mtk.vdec.drop.nonref.frame", 0);
-                    safeSet(videoFormat, "vendor.mtk.vdec.frame-drop.policy", 0);
-
-                    // Standard Android hints
-                    safeSet(videoFormat, MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE);
-                    safeSet(videoFormat, MediaFormat.KEY_PRIORITY, 0);
-                }
-                setNewOption = true;
-            }
-
-            else if (isDecoderInList(kirinDecoderPrefixes, decoderInfo.getName())) {
-                if (tryNumber < 4) {
-                    // Kirin low latency options
-                    // https://developer.huawei.com/consumer/cn/forum/topic/0202325564295980115
-                    videoFormat.setInteger("vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-req", 1);
-                    videoFormat.setInteger("vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-rdy", -1);
-                    setNewOption = true;
-                }
-            }
-            else if (isDecoderInList(exynosDecoderPrefixes, decoderInfo.getName())) {
-                if (tryNumber < 4) {
-                    // Exynos low latency option for H.264 decoder
-                    videoFormat.setInteger("vendor.rtc-ext-dec-low-latency.enable", 1);
-                    setNewOption = true;
-                }
-            }
-            else if (isDecoderInList(amlogicDecoderPrefixes, decoderInfo.getName())) {
-                if (tryNumber < 4) {
-                    // Amlogic low latency vendor extension
-                    // https://github.com/codewalkerster/android_vendor_amlogic_common_prebuilt_libstagefrighthw/commit/41fefc4e035c476d58491324a5fe7666bfc2989e
-                    videoFormat.setInteger("vendor.low-latency.enable", 1);
-                    setNewOption = true;
-                }
-            }
+        else {
+            addLegacyProfile(profiles, "android-standard", standard);
+            addLegacyProfile(profiles, "performance-only", scheduler);
         }
+        return LowLatencyProfilePlanner.deduplicateProfiles(profiles);
+    }
 
-        return setNewOption;
+    @SafeVarargs
+    private static void addLegacyProfile(
+            List<LowLatencyProfilePlanner.Profile> profiles,
+            String name,
+            Map<String, Integer>... optionMaps) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        for (Map<String, Integer> optionMap : optionMaps) {
+            options.putAll(optionMap);
+        }
+        if (!options.isEmpty()) {
+            profiles.add(new LowLatencyProfilePlanner.Profile(name, options));
+        }
+    }
+
+    static void applyLowLatencyOptions(MediaFormat videoFormat,
+                                       AppliedLowLatencyOptions applied) {
+        if (applied == null) {
+            return;
+        }
+        for (Map.Entry<String, Integer> option : applied.integerOptions.entrySet()) {
+            videoFormat.setInteger(option.getKey(), option.getValue());
+        }
     }
 
     public static boolean decoderSupportsFusedIdrFrame(MediaCodecInfo decoderInfo, String mimeType) {

--- a/app/src/main/java/com/limelight/nvstream/StreamConfiguration.java
+++ b/app/src/main/java/com/limelight/nvstream/StreamConfiguration.java
@@ -30,7 +30,6 @@ public class StreamConfiguration {
     private int colorRange;
     private int colorSpace;
     private boolean persistGamepadsAfterDisconnect;
-    private boolean enableUltraLowLatency;
 
     public static class Builder {
         private StreamConfiguration config = new StreamConfiguration();
@@ -141,11 +140,6 @@ public class StreamConfiguration {
             return this;
         }
 
-        public StreamConfiguration.Builder setEnableUltraLowLatency(boolean enable) {
-            config.enableUltraLowLatency = enable;
-            return this;
-        }
-
         public StreamConfiguration build() {
             return config;
         }
@@ -168,7 +162,6 @@ public class StreamConfiguration {
         this.audioConfiguration = MoonBridge.AUDIO_CONFIGURATION_STEREO;
         this.supportedVideoFormats = MoonBridge.VIDEO_FORMAT_H264;
         this.attachedGamepadMask = 0;
-        this.enableUltraLowLatency = false;
     }
     
     public int getWidth() {
@@ -255,7 +248,4 @@ public class StreamConfiguration {
         return colorSpace;
     }
 
-    public boolean getEnableUltraLowLatency() {
-        return enableUltraLowLatency;
-    }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -493,8 +493,8 @@
     <string name="summary_checkbox_gamepad_enable_battery_report">Signaler l\'état de la batterie de la manette lorsque cela est possible.\nLa désactivation de cette option peut aider si vous rencontrez des problèmes de bégaiement avec l\'entrée tactile/trackpad/stylet/souris.</string>
     <string name="title_checkbox_enforce_display_mode">Forcer le mode d\'affichage</string>
     <string name="summary_checkbox_enforce_display_mode">Forcer la surface à utiliser le mode d\'affichage optimal.\nRequis par certains systèmes (comme ColorOS) pour définir correctement la résolution/le taux de rafraîchissement.</string>
-    <string name="title_checkbox_ultra_low_latency">Latence ultra faible (expérimental)</string>
-    <string name="summary_checkbox_ultra_low_latency">Efficace uniquement pour SD8Gen2/8(s)Gen3/8Elite.</string>
+    <string name="title_checkbox_ultra_low_latency">Optimisations de latence ultra-faible du fournisseur (expérimental)</string>
+    <string name="summary_checkbox_ultra_low_latency">La faible latence standard d’Android est activée automatiquement lorsqu’elle est prise en charge. Cette option ajoute des optimisations de décodeur propres au fournisseur, vérifiées selon les capacités.</string>
     <string name="title_checkbox_use_virtual_display">Utiliser l\'affichage virtuel</string>
     <string name="summary_checkbox_use_virtual_display">Utiliser l\'affichage virtuel par défaut.\nL\'affichage virtuel peut correspondre automatiquement à la résolution et au taux de rafraîchissement de votre appareil, offrant une expérience de streaming fluide.\nNécessite Apollo comme logiciel de streaming hôte.</string>
     <string name="title_checkbox_resume_without_confirm">Reprise rapide</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -500,8 +500,8 @@
     <string name="summary_checkbox_gamepad_enable_battery_report">Отправлять информацию о заряде батареи геймпада, если это возможно.\nОтключение может помочь при редких фризах ввода (тач/трекпад/стилус/мышь).</string>
     <string name="title_checkbox_enforce_display_mode">Принудительный режим дисплея</string>
     <string name="summary_checkbox_enforce_display_mode">Принудительно использовать оптимальный режим отображения.\nТребуется в некоторых системах (например, ColorOS) для корректной установки частоты/разрешения.\nНе включайте на ChromeCast 4K может вызвать ошибки.</string>
-    <string name="title_checkbox_ultra_low_latency">Сверхнизкая задержка (экспериментально)</string>
-    <string name="summary_checkbox_ultra_low_latency">Эффективно только на SD8Gen2 / 8(s)Gen3 / 8Elite</string>
+    <string name="title_checkbox_ultra_low_latency">Оптимизации сверхнизкой задержки от производителя (экспериментально)</string>
+    <string name="summary_checkbox_ultra_low_latency">Стандартный режим низкой задержки Android включается автоматически, если поддерживается. Этот параметр добавляет оптимизации декодера от производителя, проверяемые по возможностям.</string>
     <string name="summary_checkbox_forceTightThresholds">Более строгие пороги вертикальной синхронизации для снижения задержки; может увеличить количество сбоев.</string>
     <string name="title_checkbox_use_virtual_display">Использовать виртуальный дисплей</string>
     <string name="summary_checkbox_use_virtual_display">Использовать виртуальный дисплей по умолчанию.\nВиртуальный дисплей автоматически подбирает клиентское разрешение и частоту, обеспечивая плавный стрим.\nТребует Apollo на хосте.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -522,8 +522,8 @@
     <string name="summary_checkbox_gamepad_enable_battery_report">在可用时汇报手柄电池状态。\n如果在使用触摸屏/触摸板/手写笔/鼠标时偶尔有卡顿现象发生，关闭此选项可能会有用。</string>
     <string name="title_checkbox_enforce_display_mode">强制设置显示模式</string>
     <string name="summary_checkbox_enforce_display_mode">强制使用最佳显示模式。\n在某些系统(如ColorOS等)上必须启用才能正确设置刷新率/分辨率。\n请勿在ChromeCast 4K上启用此选项，可能会导致bug。</string>
-    <string name="title_checkbox_ultra_low_latency">超低延迟（实验性）</string>
-    <string name="summary_checkbox_ultra_low_latency">仅对高通8Gen2/8(s)Gen3/8Elite有效。</string>
+    <string name="title_checkbox_ultra_low_latency">厂商超低延迟优化（实验性）</string>
+    <string name="summary_checkbox_ultra_low_latency">支持时会自动启用 Android 标准低延迟。此选项会添加经过能力检查的厂商解码器优化。</string>
     <string name="title_checkbox_use_virtual_display">使用虚拟显示器</string>
     <string name="summary_checkbox_use_virtual_display">默认使用虚拟显示器。\n虚拟显示器可以自动匹配设备端的分辨率与刷新率设置，提供无缝的串流体验。\n需要使用 Apollo 作为服务端串流软件。</string>
     <string name="title_checkbox_enable_sticky_modifier_key_virtual_keyboard">粘滞修饰键</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -604,8 +604,8 @@
 	<string name="title_checkbox_enforce_display_mode">強制顯示模式</string>
 	<string name="summary_checkbox_enforce_display_mode">強制 Surface 使用最佳顯示模式。\n部分系統（如 ColorOS）需要此選項才能正確設定更新率/解析度。\n請勿在 ChromeCast 4K 上啟用，可能導致問題。</string>
 
-	<string name="title_checkbox_ultra_low_latency">超低延遲（實驗性）</string>
-	<string name="summary_checkbox_ultra_low_latency">僅對 SD8Gen2/8(s)Gen3/8Elite 與 MTK 裝置有效。</string>
+	<string name="title_checkbox_ultra_low_latency">廠商超低延遲最佳化（實驗性）</string>
+	<string name="summary_checkbox_ultra_low_latency">支援時會自動啟用 Android 標準低延遲。此選項會加入經能力檢查的廠商解碼器最佳化。</string>
 
 	<string name="title_checkbox_forceTightThresholds">緊密 VSync（實驗性）</string>
 	<string name="summary_checkbox_forceTightThresholds">更緊的 VSync 門檻以降低延遲；可能增加掉幀。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -558,8 +558,8 @@
     <string name="summary_checkbox_gamepad_enable_battery_report">Report gamepad battery status when possible.\nDisable this option might help if you experience stutter with touch screen/touch pad/stylus/mouse input occasionally.</string>
     <string name="title_checkbox_enforce_display_mode">Enforce Display Mode</string>
     <string name="summary_checkbox_enforce_display_mode">Force surface to use the optimal display mode.\nRequired by some systems (such as ColorOS) to set refresh rate/resolution properly.\nDo not enable on ChromeCast 4K as it might lead to bugs.</string>
-    <string name="title_checkbox_ultra_low_latency">Ultra Low Latency (experimental)</string>
-    <string name="summary_checkbox_ultra_low_latency">Only effective for SD8Gen2/8(s)Gen3/8Elite and MTK devices.</string>
+    <string name="title_checkbox_ultra_low_latency">Vendor ultra-low-latency optimizations (experimental)</string>
+    <string name="summary_checkbox_ultra_low_latency">Android standard low latency is enabled automatically when supported. This option adds capability-checked vendor decoder optimizations.</string>
    	<string name="title_checkbox_forceTightThresholds">Tight Vsync (Experimental)</string>
     <string name="summary_checkbox_forceTightThresholds">Tighter VSYNC thresholds for lower latency; may increase drops.</string>
     <string name="title_checkbox_use_virtual_display">Use Virtual Display</string>

--- a/app/src/test/java/com/limelight/binding/video/DecoderLatencySamplerTest.java
+++ b/app/src/test/java/com/limelight/binding/video/DecoderLatencySamplerTest.java
@@ -1,0 +1,592 @@
+package com.limelight.binding.video;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {33})
+public class DecoderLatencySamplerTest {
+    @Test
+    public void percentilesUseMicrosecondsAndNearestRank() {
+        DecoderLatencySampler sampler = new DecoderLatencySampler();
+        sampler.recordMicroseconds(100);
+        sampler.recordMicroseconds(200);
+        sampler.recordMicroseconds(300);
+        sampler.recordMicroseconds(400);
+
+        DecoderLatencySampler.Summary summary =
+                DecoderLatencySampler.summarize(sampler.copySamples());
+
+        assertEquals(4, summary.sampleCount);
+        assertEquals(200, summary.p50Us);
+        assertEquals(400, summary.p95Us);
+        assertEquals(400, summary.p99Us);
+    }
+
+    @Test
+    public void circularBufferKeepsMostRecentSamples() {
+        DecoderLatencySampler sampler = new DecoderLatencySampler();
+        for (int value = 0; value <= DecoderLatencySampler.CAPACITY; value++) {
+            sampler.recordMicroseconds(value);
+        }
+
+        int[] samples = sampler.copySamples();
+        DecoderLatencySampler.Summary summary = DecoderLatencySampler.summarize(samples);
+
+        assertEquals(DecoderLatencySampler.CAPACITY, samples.length);
+        assertEquals(1, samples[0]);
+        assertEquals(DecoderLatencySampler.CAPACITY,
+                samples[DecoderLatencySampler.CAPACITY - 1]);
+        assertEquals(DecoderLatencySampler.CAPACITY, summary.sampleCount);
+        assertEquals(8192, summary.p50Us);
+        assertEquals(15565, summary.p95Us);
+        assertEquals(16221, summary.p99Us);
+    }
+
+    @Test
+    public void emptySamplerReturnsNoMeasurement() {
+        DecoderLatencySampler sampler = new DecoderLatencySampler();
+
+        DecoderLatencySampler.Summary summary =
+                DecoderLatencySampler.summarize(sampler.copySamples());
+
+        assertFalse(summary.hasMeasurement());
+        assertEquals(
+                "CodecLatencySummary metric=" + DecoderLatencySampler.METRIC_NAME +
+                        " unit=us samples=0 capacity=16384 p50Us=NA p95Us=NA p99Us=NA",
+                DecoderLatencySampler.formatSummary(summary));
+    }
+
+    @Test
+    public void recordingBeyondCapacityKeepsFixedSampleCount() {
+        DecoderLatencySampler sampler = new DecoderLatencySampler();
+        for (int value = 0; value < DecoderLatencySampler.CAPACITY * 3; value++) {
+            sampler.recordMicroseconds(value);
+        }
+
+        assertEquals(DecoderLatencySampler.CAPACITY, sampler.copySamples().length);
+    }
+
+    @Test
+    public void resetAndSnapshotsAreDefensiveAndDeterministic() {
+        DecoderLatencySampler sampler = new DecoderLatencySampler();
+        sampler.recordMicroseconds(30);
+        sampler.recordMicroseconds(10);
+        sampler.recordMicroseconds(20);
+
+        int[] firstCopy = sampler.copySamples();
+        firstCopy[0] = 999;
+        DecoderLatencySampler.Summary first =
+                DecoderLatencySampler.summarize(sampler.copySamples());
+        DecoderLatencySampler.Summary second =
+                DecoderLatencySampler.summarize(sampler.copySamples());
+
+        assertEquals(20, first.p50Us);
+        assertEquals(first.sampleCount, second.sampleCount);
+        assertEquals(first.p50Us, second.p50Us);
+        assertEquals(first.p95Us, second.p95Us);
+        assertEquals(first.p99Us, second.p99Us);
+
+        sampler.reset();
+        assertEquals(0, sampler.copySamples().length);
+    }
+
+    @Test
+    public void deltaRecordingRejectsNegativeAndClampsToIntegerMax() {
+        DecoderLatencySampler sampler = new DecoderLatencySampler();
+
+        assertEquals(-1, sampler.recordDeltaNs(2_000L, 1_000L));
+        assertEquals(Integer.MAX_VALUE,
+                sampler.recordDeltaNs(0L, ((long) Integer.MAX_VALUE + 1L) * 1_000L));
+
+        assertArrayEquals(new int[]{Integer.MAX_VALUE}, sampler.copySamples());
+    }
+
+    @Test
+    public void firstOutputDequeueRecordsPendingPtsExactlyOnce() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(77L, 0, 1_000L);
+
+        assertEquals(200, state.onOutputDequeued(77L, 201_000L));
+        assertEquals(-1, state.onOutputDequeued(77L, 401_000L));
+
+        DecoderLatencySampler.Summary summary = DecoderLatencySampler.summarize(
+                state.copySamplesForCrash());
+        assertEquals(1, summary.sampleCount);
+        assertEquals(200, summary.p50Us);
+    }
+
+    @Test
+    public void failedQueueCancelsOnlyTheExactPendingEntry() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken first =
+                state.onInputQueueCallStarting(77L, 0, 1_000L);
+        state.onInputQueueCallStarting(77L, 0, 2_000L);
+
+        state.onInputQueueFailed(first);
+        assertEquals(3, state.onOutputDequeued(77L, 5_000L));
+
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken failed =
+                state.onInputQueueCallStarting(88L, 0, 10_000L);
+        state.onInputQueueFailed(failed);
+        assertEquals(-1, state.onOutputDequeued(88L, 20_000L));
+
+        try {
+            state.runInputQueueCall(99L, 0, (presentationTimeUs, codecFlags) -> {
+                throw new IllegalStateException("queue failed");
+            });
+        }
+        catch (IllegalStateException expected) {
+            assertEquals("queue failed", expected.getMessage());
+        }
+        assertEquals(-1, state.onOutputDequeued(99L, System.nanoTime()));
+    }
+
+    @Test
+    public void duplicatePtsFailureRemovesOnlyTheFailedOperationToken() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(77L, 0, 1_000L);
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken second =
+                state.onInputQueueCallStarting(77L, 0, 2_000L);
+
+        state.onInputQueueFailed(second);
+
+        assertEquals(100, state.onOutputDequeued(77L, 101_000L));
+        assertEquals(-1, state.onOutputDequeued(77L, 201_000L));
+    }
+
+    @Test
+    public void duplicatePtsOutputsConsumeSuccessfulOperationsInFifoOrder() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(77L, 0, 10_000L);
+        state.onInputQueueCallStarting(77L, 0, 20_000L);
+
+        assertEquals(100, state.onOutputDequeued(77L, 110_000L));
+        assertEquals(200, state.onOutputDequeued(77L, 220_000L));
+        assertArrayEquals(new int[]{100, 200}, state.copySamplesForCrash());
+    }
+
+    @Test
+    public void codecConfigInputIsExcluded() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        AtomicBoolean queueCalled = new AtomicBoolean();
+
+        state.runInputQueueCall(
+                0L,
+                MediaCodec.BUFFER_FLAG_CODEC_CONFIG,
+                (presentationTimeUs, codecFlags) -> queueCalled.set(true));
+
+        assertTrue(queueCalled.get());
+        assertEquals(-1, state.onOutputDequeued(0L, 2_000L));
+        assertEquals(0, state.copySamplesForCrash().length);
+    }
+
+    @Test
+    public void recoveryClearsPendingWhileRetainingSessionSamples() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(1L, 0, 1_000L);
+        assertEquals(100, state.onOutputDequeued(1L, 101_000L));
+        state.onInputQueueCallStarting(2L, 0, 2_000L);
+
+        state.clearPendingForCodecInvalidation();
+
+        assertEquals(-1, state.onOutputDequeued(2L, 202_000L));
+        assertEquals(1, state.copySamplesForCrash().length);
+    }
+
+    @Test
+    public void recoveryClearSeversEveryRetainedDuplicatePtsLink() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken first =
+                state.onInputQueueCallStarting(77L, 0, 1_000L);
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken second =
+                state.onInputQueueCallStarting(77L, 0, 2_000L);
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken third =
+                state.onInputQueueCallStarting(77L, 0, 3_000L);
+        assertSame(second, first.next);
+        assertSame(third, second.next);
+
+        state.clearPendingForCodecInvalidation();
+
+        assertNull(first.next);
+        assertNull(second.next);
+        assertNull(third.next);
+        assertEquals(-1, state.onOutputDequeued(77L, 103_000L));
+    }
+
+    @Test
+    public void newSessionResetClearsPendingSamplesAndSummaryGuard() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(1L, 0, 1_000L);
+        state.onOutputDequeued(1L, 101_000L);
+        assertNotNull(state.takeSamplesForStop());
+
+        state.resetForNewSession();
+
+        assertEquals(0, state.copySamplesForCrash().length);
+        assertNotNull(state.takeSamplesForStop());
+    }
+
+    @Test
+    public void newSessionResetSeversEveryRetainedDuplicatePtsLink() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken first =
+                state.onInputQueueCallStarting(77L, 0, 1_000L);
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken second =
+                state.onInputQueueCallStarting(77L, 0, 2_000L);
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken third =
+                state.onInputQueueCallStarting(77L, 0, 3_000L);
+        assertSame(second, first.next);
+        assertSame(third, second.next);
+
+        state.resetForNewSession();
+
+        assertNull(first.next);
+        assertNull(second.next);
+        assertNull(third.next);
+        assertEquals(-1, state.onOutputDequeued(77L, 103_000L));
+    }
+
+    @Test
+    public void stopSnapshotAndResetIsIdempotentAndCrashSnapshotIsCopyOnly() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(1L, 0, 1_000L);
+        state.onOutputDequeued(1L, 101_000L);
+
+        int[] firstCrash = state.copySamplesForCrash();
+        firstCrash[0] = 999;
+        assertArrayEquals(new int[]{100}, state.copySamplesForCrash());
+
+        assertArrayEquals(new int[]{100}, state.takeSamplesForStop());
+        assertNull(state.takeSamplesForStop());
+        assertEquals(0, state.copySamplesForCrash().length);
+    }
+
+    @Test
+    public void stopSnapshotSeversEveryRetainedDuplicatePtsLink() {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken first =
+                state.onInputQueueCallStarting(77L, 0, 1_000L);
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken second =
+                state.onInputQueueCallStarting(77L, 0, 2_000L);
+        MediaCodecDecoderRenderer.DecoderLatencyState.PendingInputToken third =
+                state.onInputQueueCallStarting(77L, 0, 3_000L);
+        assertSame(second, first.next);
+        assertSame(third, second.next);
+
+        assertNotNull(state.takeSamplesForStop());
+
+        assertNull(first.next);
+        assertNull(second.next);
+        assertNull(third.next);
+        assertEquals(-1, state.onOutputDequeued(77L, 103_000L));
+    }
+
+    @Test
+    public void interruptedJoinWaitsForTerminationAndRestoresInterrupt() throws Exception {
+        CountDownLatch releaseWorker = new CountDownLatch(1);
+        CountDownLatch joinerEntered = new CountDownLatch(1);
+        CountDownLatch joinerReturned = new CountDownLatch(1);
+        AtomicBoolean interruptRestored = new AtomicBoolean();
+        Thread worker = new Thread(() -> awaitUnchecked(releaseWorker));
+        Thread joiner = new Thread(() -> {
+            Thread.currentThread().interrupt();
+            joinerEntered.countDown();
+            MediaCodecDecoderRenderer.joinThreadPreservingInterrupt(worker);
+            interruptRestored.set(Thread.currentThread().isInterrupted());
+            joinerReturned.countDown();
+        });
+
+        worker.start();
+        joiner.start();
+        try {
+            assertTrue(joinerEntered.await(5, TimeUnit.SECONDS));
+            assertFalse(joinerReturned.await(100, TimeUnit.MILLISECONDS));
+        }
+        finally {
+            releaseWorker.countDown();
+        }
+
+        assertTrue(joinerReturned.await(5, TimeUnit.SECONDS));
+        worker.join();
+        joiner.join();
+        assertFalse(worker.isAlive());
+        assertTrue(interruptRestored.get());
+    }
+
+    @Test
+    public void blockedInputQueueCallDoesNotBlockUnrelatedOutputConsumption()
+            throws Exception {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(11L, 0, 1_000L);
+        CountDownLatch queueCallEntered = new CountDownLatch(1);
+        CountDownLatch releaseQueueCall = new CountDownLatch(1);
+        CountDownLatch outputReturned = new CountDownLatch(1);
+        AtomicInteger latencyUs = new AtomicInteger(-2);
+        Thread queueThread = new Thread(() -> state.runInputQueueCall(
+                22L,
+                0,
+                (presentationTimeUs, codecFlags) -> {
+                    queueCallEntered.countDown();
+                    awaitUnchecked(releaseQueueCall);
+                }));
+        Thread outputThread = new Thread(() -> {
+            latencyUs.set(state.onOutputDequeued(11L, 101_000L));
+            outputReturned.countDown();
+        });
+
+        queueThread.start();
+        assertTrue(queueCallEntered.await(5, TimeUnit.SECONDS));
+        outputThread.start();
+        boolean outputCompleted;
+        try {
+            outputCompleted = outputReturned.await(5, TimeUnit.SECONDS);
+        }
+        finally {
+            releaseQueueCall.countDown();
+        }
+
+        queueThread.join();
+        outputThread.join();
+        assertTrue(outputCompleted);
+        assertEquals(100, latencyUs.get());
+    }
+
+    @Test
+    public void invalidationClearsPendingBeforeCodecCallWithoutHoldingLatencyLock()
+            throws Exception {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        state.onInputQueueCallStarting(33L, 0, 1_000L);
+        CountDownLatch invalidationEntered = new CountDownLatch(1);
+        CountDownLatch releaseInvalidation = new CountDownLatch(1);
+        CountDownLatch outputReturned = new CountDownLatch(1);
+        AtomicInteger latencyUs = new AtomicInteger(-2);
+        Thread invalidationThread = new Thread(() ->
+                state.clearPendingAndRunCodecInvalidation(() -> {
+                    invalidationEntered.countDown();
+                    awaitUnchecked(releaseInvalidation);
+                }));
+        Thread outputThread = new Thread(() -> {
+            latencyUs.set(state.onOutputDequeued(33L, 101_000L));
+            outputReturned.countDown();
+        });
+
+        invalidationThread.start();
+        assertTrue(invalidationEntered.await(5, TimeUnit.SECONDS));
+        outputThread.start();
+        boolean outputCompleted;
+        try {
+            outputCompleted = outputReturned.await(5, TimeUnit.SECONDS);
+        }
+        finally {
+            releaseInvalidation.countDown();
+        }
+
+        invalidationThread.join();
+        outputThread.join();
+        assertTrue(outputCompleted);
+        assertEquals(-1, latencyUs.get());
+    }
+
+    @Test
+    public void inputQueueCallOverlappingInvalidationRunsButIsNotTracked()
+            throws Exception {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        CountDownLatch invalidationEntered = new CountDownLatch(1);
+        CountDownLatch releaseInvalidation = new CountDownLatch(1);
+        CountDownLatch queueCallEntered = new CountDownLatch(1);
+        Thread invalidationThread = new Thread(() ->
+                state.clearPendingAndRunCodecInvalidation(() -> {
+                    invalidationEntered.countDown();
+                    awaitUnchecked(releaseInvalidation);
+                }));
+        Thread queueThread = new Thread(() -> state.runInputQueueCall(
+                44L, 0, (presentationTimeUs, codecFlags) ->
+                        queueCallEntered.countDown()));
+
+        invalidationThread.start();
+        assertTrue(invalidationEntered.await(5, TimeUnit.SECONDS));
+        queueThread.start();
+        boolean queueCallCompleted;
+        try {
+            queueCallCompleted = queueCallEntered.await(5, TimeUnit.SECONDS);
+        }
+        finally {
+            releaseInvalidation.countDown();
+        }
+
+        invalidationThread.join();
+        queueThread.join();
+        assertTrue(queueCallCompleted);
+        assertEquals(-1, state.onOutputDequeued(44L, System.nanoTime()));
+    }
+
+    @Test
+    public void codecConfigQueueCallDoesNotAcquireLatencyLockDuringInvalidation()
+            throws Exception {
+        MediaCodecDecoderRenderer.DecoderLatencyState state =
+                new MediaCodecDecoderRenderer.DecoderLatencyState();
+        CountDownLatch invalidationEntered = new CountDownLatch(1);
+        CountDownLatch releaseInvalidation = new CountDownLatch(1);
+        CountDownLatch queueCallEntered = new CountDownLatch(1);
+        Thread invalidationThread = new Thread(() ->
+                state.clearPendingAndRunCodecInvalidation(() -> {
+                    invalidationEntered.countDown();
+                    awaitUnchecked(releaseInvalidation);
+                }));
+        Thread queueThread = new Thread(() -> state.runInputQueueCall(
+                0L,
+                MediaCodec.BUFFER_FLAG_CODEC_CONFIG,
+                (presentationTimeUs, codecFlags) -> queueCallEntered.countDown()));
+
+        invalidationThread.start();
+        assertTrue(invalidationEntered.await(5, TimeUnit.SECONDS));
+        queueThread.start();
+        boolean queueCallCompleted;
+        try {
+            queueCallCompleted = queueCallEntered.await(5, TimeUnit.SECONDS);
+        }
+        finally {
+            releaseInvalidation.countDown();
+        }
+
+        invalidationThread.join();
+        queueThread.join();
+        assertTrue(queueCallCompleted);
+    }
+
+    @Test
+    public void aggregateLatencyKeepsExistingMillisecondWindowSemanticsAtDequeue() {
+        assertEquals(0,
+                MediaCodecDecoderRenderer.aggregateDecoderLatencyMs(999));
+        assertEquals(999,
+                MediaCodecDecoderRenderer.aggregateDecoderLatencyMs(999_999));
+        assertEquals(-1,
+                MediaCodecDecoderRenderer.aggregateDecoderLatencyMs(1_000_000));
+        assertEquals(-1,
+                MediaCodecDecoderRenderer.aggregateDecoderLatencyMs(-1));
+    }
+
+    @Test
+    public void allFiveOutputDequeueSitesUseImmediateLatencyWrapper() throws IOException {
+        String source = readRendererSource();
+
+        assertEquals(1, occurrences(source, "videoDecoder.dequeueOutputBuffer("));
+        Matcher wrapperCalls = Pattern.compile(
+                "(?<!int )dequeueOutputBufferWithLatency\\(").matcher(source);
+        int callCount = 0;
+        while (wrapperCalls.find()) {
+            callCount++;
+        }
+        assertEquals(5, callCount);
+        assertEquals(0, occurrences(source, "updateDecodeLatencyStats("));
+    }
+
+    @Test
+    public void crashDiagnosticsUseOnlyActiveSuccessfulProfileAndCopyOnlySummary() {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        options.put(MediaFormat.KEY_LOW_LATENCY, 1);
+        MediaCodecDecoderRenderer.DecoderConfigurationProfile profile =
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.from(
+                        new MediaCodecHelper.AppliedLowLatencyOptions(
+                                2, "android-standard", options));
+        MediaCodecDecoderRenderer.ConfiguredDecoderState state =
+                MediaCodecDecoderRenderer.commitConfiguredState(
+                        null,
+                        MediaFormat.createVideoFormat("video/avc", 1920, 1080),
+                        profile,
+                        true);
+        DecoderLatencySampler sampler = new DecoderLatencySampler();
+        sampler.recordMicroseconds(100);
+        sampler.recordMicroseconds(300);
+        DecoderLatencySampler.Summary summary =
+                DecoderLatencySampler.summarize(sampler.copySamples());
+
+        assertEquals(
+                "Codec low-latency activeProfileIndex=2 activeProfileName=android-standard|" +
+                        "CodecLatencySummary metric=" + DecoderLatencySampler.METRIC_NAME +
+                        " unit=us samples=2 capacity=16384 p50Us=100 p95Us=300 p99Us=300",
+                MediaCodecDecoderRenderer.formatCrashLatencyDiagnostics(
+                        state, summary, "|"));
+        assertEquals(2, sampler.copySamples().length);
+    }
+
+    private static String readRendererSource() throws IOException {
+        File directory = new File(System.getProperty("user.dir"));
+        for (int depth = 0; depth < 6 && directory != null; depth++) {
+            File appRelative = new File(directory,
+                    "app/src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java");
+            if (appRelative.isFile()) {
+                return new String(Files.readAllBytes(appRelative.toPath()),
+                        StandardCharsets.UTF_8);
+            }
+            File moduleRelative = new File(directory,
+                    "src/main/java/com/limelight/binding/video/MediaCodecDecoderRenderer.java");
+            if (moduleRelative.isFile()) {
+                return new String(Files.readAllBytes(moduleRelative.toPath()),
+                        StandardCharsets.UTF_8);
+            }
+            directory = directory.getParentFile();
+        }
+        throw new IOException("Unable to locate MediaCodecDecoderRenderer.java");
+    }
+
+    private static int occurrences(String source, String needle) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = source.indexOf(needle, offset)) >= 0) {
+            count++;
+            offset += needle.length();
+        }
+        return count;
+    }
+
+    private static void awaitUnchecked(CountDownLatch latch) {
+        try {
+            latch.await();
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/LowLatencyProfilePlannerTest.java
+++ b/app/src/test/java/com/limelight/binding/video/LowLatencyProfilePlannerTest.java
@@ -1,0 +1,1015 @@
+package com.limelight.binding.video;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.media.MediaCodecInfo;
+import android.media.MediaFormat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {33})
+public class LowLatencyProfilePlannerTest {
+    private static final String MTK_LOW_LATENCY_MODE =
+            "vendor.mtk.vdec.low-latency.mode";
+    private static final String MTK_DISABLE_IDLE = "vendor.mtk.vdec.disable-idle";
+    private static final String MTK_VSYNC_ADJUST =
+            "vendor.mtk.vdec.vsync.adjust.enable";
+    private static final String MTK_ULTRA_LOW_LATENCY =
+            "vendor.mtk.vdec.ultra-low-latency";
+    private static final String MTK_PRELOAD_FRAME_COUNT =
+            "vendor.mtk.vdec.preload.frame.count";
+    private static final String MTK_INPUT_QUEUE_DEPTH =
+            "vendor.mtk.vdec.input.max.queue.depth";
+    private static final String MTK_OUTPUT_QUEUE_DEPTH =
+            "vendor.mtk.vdec.output.max.queue.depth";
+    private static final String MTK_FETCH_TIMEOUT =
+            "vendor.mtk.vdec.buffer.fetch.timeout.ms";
+    private static final String MTK_FETCH_TIMEOUT_VALUE = MTK_FETCH_TIMEOUT + ".value";
+    private static final String MTK_GUARD_INTERVAL =
+            "vendor.mtk.vdec.bq.guard.interval.time";
+    private static final String MTK_GUARD_INTERVAL_VALUE = MTK_GUARD_INTERVAL + ".value";
+    private static final String MTK_CPU_BOOST = "vendor.mtk.vdec.cpu.boost.mode";
+    private static final String MTK_CPU_BOOST_VALUE = MTK_CPU_BOOST + ".value";
+    private static final String MTK_DVFS_MODE = "vendor.mtk.vdec.dvfs.mode";
+    private static final String MTK_DVFS_LEVEL = "vendor.mtk.vdec.dvfs.level";
+
+    private static final List<String> FORBIDDEN_MTK_KEYS = Arrays.asList(
+            "media.low-latency.enable",
+            "vendor.low-latency.enable",
+            "vendor.mtk.vdec.nvop.skip",
+            "vendor.mtk.vdec.skip.mode",
+            "vendor.mtk.vdec.drop.nonref.frame",
+            "vendor.mtk.vdec.frame-drop.policy");
+
+    private static final Set<String> S25_VENDOR_PARAMETERS = parameters(
+            LowLatencyProfilePlanner.QTI_PICTURE_ORDER,
+            LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE,
+            LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE);
+
+    @Test
+    public void profileOptionsAreOrderedAndImmutable() {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        options.put("low-latency", 1);
+        options.put("vendor.test.option", 2);
+
+        LowLatencyProfilePlanner.Profile profile =
+                new LowLatencyProfilePlanner.Profile("test-profile", options);
+        options.put("added-after-construction", 3);
+
+        assertEquals(
+                Arrays.asList("low-latency", "vendor.test.option"),
+                new ArrayList<>(profile.integerOptions.keySet()));
+
+        try {
+            profile.integerOptions.put("mutation", 4);
+            fail("Profile options must be immutable");
+        }
+        catch (UnsupportedOperationException expected) {
+            // Expected.
+        }
+    }
+
+    @Test
+    public void duplicateOrderedOptionsAreRemoved() {
+        LowLatencyProfilePlanner.Profile first = profile(
+                "first", "low-latency", 1, "vendor.test.option", 2);
+        LowLatencyProfilePlanner.Profile duplicate = profile(
+                "duplicate", "low-latency", 1, "vendor.test.option", 2);
+        LowLatencyProfilePlanner.Profile reverseOrder = profile(
+                "reverse-order", "vendor.test.option", 2, "low-latency", 1);
+
+        List<LowLatencyProfilePlanner.Profile> profiles =
+                LowLatencyProfilePlanner.deduplicateProfiles(
+                        Arrays.asList(first, duplicate, reverseOrder));
+
+        assertEquals(2, profiles.size());
+        assertEquals("first", profiles.get(0).name);
+        assertEquals("reverse-order", profiles.get(1).name);
+    }
+
+    @Test
+    public void standardOffReturnsAndroidStandardOptionProfileOnly() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities("vendor.decoder", 36, true, false, true, Collections.emptySet()),
+                false,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertEquals(1, profiles.size());
+        assertEquals("android-standard", profiles.get(0).name);
+        assertEquals(singleOption(MediaFormat.KEY_LOW_LATENCY, 1), profiles.get(0).integerOptions);
+    }
+
+    @Test
+    public void runtimeRecoveryReturnsOnlyStandardWhenSupported() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities("c2.qti.avc.decoder", 36, true, true, true, S25_VENDOR_PARAMETERS),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.RUNTIME_RECOVERY);
+
+        assertEquals(1, profiles.size());
+        assertEquals("android-standard", profiles.get(0).name);
+        assertEquals(singleOption(MediaFormat.KEY_LOW_LATENCY, 1), profiles.get(0).integerOptions);
+    }
+
+    @Test
+    public void capabilitiesNormalizeAndDefensivelyCopyVendorParameters() {
+        Set<String> parameters = parameters("Vendor.QTI-Ext-Dec-Low-Latency.Enable");
+        LowLatencyProfilePlanner.Capabilities capabilities = capabilities(
+                "c2.qti.avc.decoder", 36, true, true, true, parameters);
+        parameters.add("vendor.added.after.construction");
+
+        assertEquals(parameters(LowLatencyProfilePlanner.QTI_CORE),
+                capabilities.supportedVendorParameters);
+        try {
+            capabilities.supportedVendorParameters.add("mutation");
+            fail("Capabilities must be immutable");
+        }
+        catch (UnsupportedOperationException expected) {
+            // Expected.
+        }
+    }
+
+    @Test
+    public void qtiS25UsesOnlyAdvertisedOutputFenceFamily() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities("c2.qti.hevc.decoder.low_latency", 36, true, true, true,
+                        S25_VENDOR_PARAMETERS),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertEquals(Arrays.asList(
+                        "qti-experimental-full",
+                        "qti-experimental-no-scheduler",
+                        "qti-no-fence",
+                        "android-standard"),
+                profileNames(profiles));
+
+        Map<String, Integer> full = profiles.get(0).integerOptions;
+        assertFalse(full.containsKey(LowLatencyProfilePlanner.VDEC_LOW_LATENCY));
+        assertFalse(full.containsKey(LowLatencyProfilePlanner.QTI_CORE));
+        assertFalse(full.containsKey(LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE));
+        assertEquals(1, full.get(LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE).intValue());
+        assertEquals(1, full.get(LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE).intValue());
+        assertEquals(Arrays.asList(
+                        MediaFormat.KEY_LOW_LATENCY,
+                        LowLatencyProfilePlanner.QTI_PICTURE_ORDER,
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE,
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE,
+                        MediaFormat.KEY_OPERATING_RATE),
+                new ArrayList<>(full.keySet()));
+    }
+
+    @Test
+    public void qtiAdvertisedCoreIncludesTrueCoreOnlyFallback() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities("c2.qti.avc.decoder", 36, true, true, true,
+                        parameters(LowLatencyProfilePlanner.QTI_CORE,
+                                LowLatencyProfilePlanner.QTI_PICTURE_ORDER)),
+                false,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertEquals(Arrays.asList("android-standard", "qti-core-picture", "qti-core-only"),
+                profileNames(profiles));
+        assertEquals(singleOption(LowLatencyProfilePlanner.QTI_CORE, 1),
+                profiles.get(2).integerOptions);
+    }
+
+    @Test
+    public void qtiNeverMixesSoftwareAndOutputFenceFamilies() {
+        Set<String> advertised = parameters(
+                LowLatencyProfilePlanner.QTI_CORE,
+                LowLatencyProfilePlanner.QTI_PICTURE_ORDER,
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE,
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE,
+                LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE);
+
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities("c2.qti.avc.decoder", 36, true, true, true, advertised),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertEquals("qti-experimental-full", profiles.get(0).name);
+        assertEquals("qti-experimental-alt-fence", profiles.get(1).name);
+        assertTrue(profiles.get(0).integerOptions.containsKey(
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE));
+        assertFalse(profiles.get(0).integerOptions.containsKey(
+                LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE));
+        assertTrue(profiles.get(1).integerOptions.containsKey(
+                LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE));
+        assertFalse(profiles.get(1).integerOptions.containsKey(
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE));
+
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            assertFalse(profile.integerOptions.containsKey(
+                            LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE) &&
+                    profile.integerOptions.containsKey(
+                            LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE));
+        }
+    }
+
+    @Test
+    public void qtiPartialOutputFencePairIsNotUsed() {
+        for (String partialKey : Arrays.asList(
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE,
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE)) {
+            List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                    capabilities("c2.qti.avc.decoder", 36, true, true, true,
+                            parameters(partialKey)),
+                    true,
+                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+            for (LowLatencyProfilePlanner.Profile profile : profiles) {
+                assertFalse(profile.integerOptions.containsKey(
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE));
+                assertFalse(profile.integerOptions.containsKey(
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE));
+            }
+        }
+    }
+
+    @Test
+    public void qtiPartialOutputFenceFallsBackToAdvertisedSoftwareFence() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities("c2.qti.avc.decoder", 36, true, true, true,
+                        parameters(LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE,
+                                LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE)),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertTrue(profiles.get(0).integerOptions.containsKey(
+                LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE));
+        assertFalse(profiles.get(0).integerOptions.containsKey(
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE));
+        assertFalse(profiles.get(0).integerOptions.containsKey(
+                LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE));
+    }
+
+    @Test
+    public void qtiApi31EmptyOrFailedEnumerationUsesNoVendorKeys() {
+        for (boolean enumerationAvailable : Arrays.asList(true, false)) {
+            List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                    capabilities("c2.qti.avc.decoder", 31, true, true,
+                            enumerationAvailable, Collections.emptySet()),
+                    true,
+                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+            for (LowLatencyProfilePlanner.Profile profile : profiles) {
+                for (String key : profile.integerOptions.keySet()) {
+                    assertFalse(key.startsWith("vendor.qti-"));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void qtiLegacyApi26To30UsesCoreAndPictureButNeverFences() {
+        for (int sdkInt : Arrays.asList(26, 30)) {
+            List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                    capabilities("c2.qti.avc.decoder", sdkInt, false, false,
+                            false, Collections.emptySet()),
+                    false,
+                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+            assertEquals(Arrays.asList("qti-core-picture", "qti-core-only"),
+                    profileNames(profiles));
+            assertTrue(profiles.get(0).integerOptions.containsKey(
+                    LowLatencyProfilePlanner.QTI_CORE));
+            assertTrue(profiles.get(0).integerOptions.containsKey(
+                    LowLatencyProfilePlanner.QTI_PICTURE_ORDER));
+            assertNoFenceKeys(profiles);
+        }
+    }
+
+    @Test
+    public void qtiPictureOrderMatchesOmxAndCodec2Contracts() {
+        assertEquals(0, pictureOrderFor("OMX.qcom.video.decoder.avc"));
+        assertEquals(1, pictureOrderFor("c2.qti.avc.decoder"));
+        assertEquals(1, pictureOrderFor("c2.qcom.avc.decoder"));
+    }
+
+    @Test
+    public void qtiNeverUsesVdecLowLatency() {
+        List<LowLatencyProfilePlanner.Capabilities> fixtures = Arrays.asList(
+                capabilities("OMX.qcom.video.decoder.avc", 26, false, true,
+                        false, Collections.emptySet()),
+                capabilities("c2.qti.avc.decoder", 36, true, true, true,
+                        parameters(LowLatencyProfilePlanner.QTI_CORE,
+                                LowLatencyProfilePlanner.QTI_PICTURE_ORDER,
+                                LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE)));
+
+        for (LowLatencyProfilePlanner.Capabilities fixture : fixtures) {
+            for (boolean ultraLowLatency : Arrays.asList(false, true)) {
+                List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                        fixture,
+                        ultraLowLatency,
+                        LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+                for (LowLatencyProfilePlanner.Profile profile : profiles) {
+                    assertFalse(profile.integerOptions.containsKey(
+                            LowLatencyProfilePlanner.VDEC_LOW_LATENCY));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void qtiSchedulerUsesOperatingRateOrPriorityButNeverBoth() {
+        List<LowLatencyProfilePlanner.Profile> operatingRateProfiles =
+                LowLatencyProfilePlanner.plan(
+                        capabilities("c2.qti.avc.decoder", 36, true, true, true,
+                                S25_VENDOR_PARAMETERS),
+                        true,
+                        LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+        Map<String, Integer> operatingRate = operatingRateProfiles.get(0).integerOptions;
+        assertEquals((int) Short.MAX_VALUE,
+                operatingRate.get(MediaFormat.KEY_OPERATING_RATE).intValue());
+        assertFalse(operatingRate.containsKey(MediaFormat.KEY_PRIORITY));
+
+        List<LowLatencyProfilePlanner.Profile> priorityProfiles =
+                LowLatencyProfilePlanner.plan(
+                        capabilities("c2.qti.avc.decoder", 36, true, false, true,
+                                S25_VENDOR_PARAMETERS),
+                        true,
+                        LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+        Map<String, Integer> priority = priorityProfiles.get(0).integerOptions;
+        assertEquals(0, priority.get(MediaFormat.KEY_PRIORITY).intValue());
+        assertFalse(priority.containsKey(MediaFormat.KEY_OPERATING_RATE));
+    }
+
+    @Test
+    public void plannerNeverReturnsEmptyBaseProfile() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities("c2.qti.avc.decoder", 36, false, false,
+                        true, Collections.emptySet()),
+                false,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertTrue(profiles.isEmpty());
+    }
+
+    @Test
+    public void decoderFamilyClassificationIsCaseInsensitiveAndIndependentOfInitialization() {
+        assertEquals(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                LowLatencyProfilePlanner.classifyDecoderFamily("C2.MTK.AVC.Decoder"));
+        assertEquals(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                LowLatencyProfilePlanner.classifyDecoderFamily("omx.mTk.video.decoder.hevc"));
+        assertEquals(LowLatencyProfilePlanner.DecoderFamily.QUALCOMM,
+                LowLatencyProfilePlanner.classifyDecoderFamily("C2.QTI.AVC.Decoder"));
+        assertEquals(LowLatencyProfilePlanner.DecoderFamily.QUALCOMM,
+                LowLatencyProfilePlanner.classifyDecoderFamily("omx.QCOM.video.decoder.avc"));
+        assertEquals(LowLatencyProfilePlanner.DecoderFamily.QUALCOMM,
+                LowLatencyProfilePlanner.classifyDecoderFamily("C2.QCOM.HEVC.Decoder"));
+        assertEquals(LowLatencyProfilePlanner.DecoderFamily.QUALCOMM,
+                LowLatencyProfilePlanner.classifyDecoderFamily("OMX.QTI.video.decoder.avc"));
+        assertEquals(LowLatencyProfilePlanner.DecoderFamily.OTHER,
+                LowLatencyProfilePlanner.classifyDecoderFamily("c2.exynos.avc.decoder"));
+    }
+
+    @Test
+    public void legacyVdecEligibilityIsScopedAndNeverIncludesQualcomm() {
+        assertTrue(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "c2.mtk.avc.decoder", "Samsung", 33));
+        assertTrue(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "OMX.AMLOGIC.video.decoder.avc", "Google", 30));
+        assertTrue(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "c2.exynos.avc.decoder", "aMaZoN", 33));
+
+        assertFalse(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "c2.qti.avc.decoder", "Amazon", 33));
+        assertFalse(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "OMX.QTI.video.decoder.avc", "Amazon", 33));
+        assertFalse(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "c2.mtk.avc.decoder", "Xiaomi", 23));
+        assertTrue(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "c2.mtk.avc.decoder", "Xiaomi", 24));
+        assertFalse(LowLatencyProfilePlanner.isLegacyVdecLowLatencyAllowed(
+                "c2.exynos.avc.decoder", "Samsung", 33));
+    }
+
+    @Test
+    public void mediatekUllOffUsesOnlyStandardThenLegacy() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                        "c2.mtk.avc.decoder", 33, true, true, true, true,
+                        parameters(MTK_LOW_LATENCY_MODE, MTK_ULTRA_LOW_LATENCY)),
+                false,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertEquals(Arrays.asList("android-standard", "mtk-legacy"), profileNames(profiles));
+        assertEquals(options(MediaFormat.KEY_LOW_LATENCY, 1),
+                profiles.get(0).integerOptions);
+        assertEquals(options(LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1),
+                profiles.get(1).integerOptions);
+        assertNoMtkVendorOrSchedulerOptions(profiles);
+    }
+
+    @Test
+    public void mediatekFullAdvertisedPlanHasExactRiskOrderAndKeyMaps() {
+        Set<String> advertised = parameters(
+                MTK_LOW_LATENCY_MODE,
+                MTK_DISABLE_IDLE,
+                MTK_VSYNC_ADJUST,
+                MTK_ULTRA_LOW_LATENCY,
+                MTK_PRELOAD_FRAME_COUNT,
+                MTK_INPUT_QUEUE_DEPTH,
+                MTK_OUTPUT_QUEUE_DEPTH,
+                MTK_FETCH_TIMEOUT,
+                MTK_FETCH_TIMEOUT_VALUE,
+                MTK_GUARD_INTERVAL,
+                MTK_GUARD_INTERVAL_VALUE,
+                MTK_CPU_BOOST,
+                MTK_CPU_BOOST_VALUE,
+                MTK_DVFS_MODE,
+                MTK_DVFS_LEVEL);
+
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                        "c2.mtk.hevc.decoder", 33, true, true, true, true, advertised),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertEquals(Arrays.asList(
+                        "mtk-experimental-full",
+                        "mtk-standard-legacy-performance",
+                        "mtk-standard-performance",
+                        "android-standard",
+                        "mtk-legacy-performance",
+                        "mtk-legacy",
+                        "performance-only"),
+                profileNames(profiles));
+        assertEquals(options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1,
+                        MTK_LOW_LATENCY_MODE, 1,
+                        MTK_DISABLE_IDLE, 1,
+                        MTK_VSYNC_ADJUST, 0,
+                        MTK_ULTRA_LOW_LATENCY, 1,
+                        MTK_PRELOAD_FRAME_COUNT, 0,
+                        MTK_INPUT_QUEUE_DEPTH, 2,
+                        MTK_OUTPUT_QUEUE_DEPTH, 2,
+                        MTK_FETCH_TIMEOUT_VALUE, 2,
+                        MTK_GUARD_INTERVAL_VALUE, 2,
+                        MTK_CPU_BOOST_VALUE, 1,
+                        MTK_DVFS_MODE, 1,
+                        MTK_DVFS_LEVEL, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                profiles.get(0).integerOptions);
+        assertEquals(options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                profiles.get(1).integerOptions);
+        assertEquals(options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                profiles.get(2).integerOptions);
+        assertEquals(options(MediaFormat.KEY_LOW_LATENCY, 1),
+                profiles.get(3).integerOptions);
+        assertEquals(options(
+                        LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                profiles.get(4).integerOptions);
+        assertEquals(options(LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1),
+                profiles.get(5).integerOptions);
+        assertEquals(options(MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                profiles.get(6).integerOptions);
+        assertMtkProfilesAreSafeUniqueAndBounded(profiles);
+    }
+
+    @Test
+    public void mediatekAliasesSelectAvailableKeyAndPreferValueAlias() {
+        List<Set<String>> advertisedFixtures = Arrays.asList(
+                parameters(MTK_FETCH_TIMEOUT, MTK_GUARD_INTERVAL, MTK_CPU_BOOST),
+                parameters(MTK_FETCH_TIMEOUT_VALUE, MTK_GUARD_INTERVAL_VALUE,
+                        MTK_CPU_BOOST_VALUE),
+                parameters(MTK_FETCH_TIMEOUT, MTK_FETCH_TIMEOUT_VALUE,
+                        MTK_GUARD_INTERVAL, MTK_GUARD_INTERVAL_VALUE,
+                        MTK_CPU_BOOST, MTK_CPU_BOOST_VALUE));
+        List<List<String>> expectedAliases = Arrays.asList(
+                Arrays.asList(MTK_FETCH_TIMEOUT, MTK_GUARD_INTERVAL, MTK_CPU_BOOST),
+                Arrays.asList(MTK_FETCH_TIMEOUT_VALUE, MTK_GUARD_INTERVAL_VALUE,
+                        MTK_CPU_BOOST_VALUE),
+                Arrays.asList(MTK_FETCH_TIMEOUT_VALUE, MTK_GUARD_INTERVAL_VALUE,
+                        MTK_CPU_BOOST_VALUE));
+
+        for (int i = 0; i < advertisedFixtures.size(); i++) {
+            List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                    capabilities(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                            "OMX.MTK.video.decoder.avc", 31, true, true, true, true,
+                            advertisedFixtures.get(i)),
+                    true,
+                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+            Map<String, Integer> full = profiles.get(0).integerOptions;
+
+            assertEquals("mtk-experimental-full", profiles.get(0).name);
+            assertEquals(expectedAliases.get(i), advertisedMtkAliases(full));
+            assertEquals(2, full.get(expectedAliases.get(i).get(0)).intValue());
+            assertEquals(2, full.get(expectedAliases.get(i).get(1)).intValue());
+            assertEquals(1, full.get(expectedAliases.get(i).get(2)).intValue());
+        }
+    }
+
+    @Test
+    public void mediatekApi31EmptyOrFailedEnumerationNeverSpeculatesVendorKeys() {
+        for (boolean enumerationAvailable : Arrays.asList(true, false)) {
+            List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                    capabilities(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                            "c2.mtk.avc.decoder", 31, true, false, true,
+                            enumerationAvailable, Collections.emptySet()),
+                    true,
+                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+            assertEquals(Arrays.asList(
+                            "mtk-standard-legacy-performance",
+                            "mtk-standard-performance",
+                            "android-standard",
+                            "mtk-legacy-performance",
+                            "mtk-legacy",
+                            "performance-only"),
+                    profileNames(profiles));
+            assertNoMtkVendorOptions(profiles);
+            assertMtkProfilesAreSafeUniqueAndBounded(profiles);
+        }
+    }
+
+    @Test
+    public void mediatekApi26And30UseOnlyStandardLegacyAndScheduler() {
+        for (int sdkInt : Arrays.asList(26, 30)) {
+            List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                    capabilities(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                            "OMX.MTK.video.decoder.avc", sdkInt, true, true, true, true,
+                            parameters(MTK_LOW_LATENCY_MODE, MTK_ULTRA_LOW_LATENCY)),
+                    true,
+                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+            assertEquals(Arrays.asList(
+                            "mtk-standard-legacy-performance",
+                            "mtk-standard-performance",
+                            "android-standard",
+                            "mtk-legacy-performance",
+                            "mtk-legacy",
+                            "performance-only"),
+                    profileNames(profiles));
+            assertNoMtkVendorOptions(profiles);
+            assertMtkProfilesAreSafeUniqueAndBounded(profiles);
+        }
+    }
+
+    @Test
+    public void mediatekUllKeyIsOneWhenAdvertisedAndNeverWrittenAsZero() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                        "c2.mtk.avc.decoder", 33, true, true, true, true,
+                        parameters(MTK_ULTRA_LOW_LATENCY)),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        assertEquals(1, profiles.get(0).integerOptions.get(MTK_ULTRA_LOW_LATENCY).intValue());
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            Integer ullValue = profile.integerOptions.get(MTK_ULTRA_LOW_LATENCY);
+            assertTrue(ullValue == null || ullValue == 1);
+        }
+    }
+
+    @Test
+    public void mediatekProfilesNeverUseGenericOrSkipDropKeysAndSchedulerIsExclusive() {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities(LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                        "c2.mtk.avc.decoder", 33, true, false, true, true,
+                        parameters(MTK_LOW_LATENCY_MODE, MTK_ULTRA_LOW_LATENCY)),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            for (String forbiddenKey : FORBIDDEN_MTK_KEYS) {
+                assertFalse(profile.integerOptions.containsKey(forbiddenKey));
+            }
+            assertFalse(profile.integerOptions.containsKey(MediaFormat.KEY_OPERATING_RATE) &&
+                    profile.integerOptions.containsKey(MediaFormat.KEY_PRIORITY));
+        }
+        assertEquals(0, profiles.get(0).integerOptions.get(MediaFormat.KEY_PRIORITY).intValue());
+    }
+
+    @Test
+    public void mediatekProfilesStayUniqueNonEmptyAndBoundedAcrossCapabilityCombinations() {
+        Set<String> allVendorOptions = parameters(
+                MTK_LOW_LATENCY_MODE,
+                MTK_DISABLE_IDLE,
+                MTK_VSYNC_ADJUST,
+                MTK_ULTRA_LOW_LATENCY,
+                MTK_PRELOAD_FRAME_COUNT,
+                MTK_INPUT_QUEUE_DEPTH,
+                MTK_OUTPUT_QUEUE_DEPTH,
+                MTK_FETCH_TIMEOUT,
+                MTK_FETCH_TIMEOUT_VALUE,
+                MTK_GUARD_INTERVAL,
+                MTK_GUARD_INTERVAL_VALUE,
+                MTK_CPU_BOOST,
+                MTK_CPU_BOOST_VALUE,
+                MTK_DVFS_MODE,
+                MTK_DVFS_LEVEL);
+
+        for (int sdkInt : Arrays.asList(22, 23, 26, 30, 31, 36)) {
+            for (boolean standard : Arrays.asList(false, true)) {
+                for (boolean maxOperatingRate : Arrays.asList(false, true)) {
+                    for (boolean legacy : Arrays.asList(false, true)) {
+                        for (boolean enumerationAvailable : Arrays.asList(false, true)) {
+                            for (Set<String> advertised : Arrays.asList(
+                                    Collections.<String>emptySet(), allVendorOptions)) {
+                                for (boolean ultraLowLatency : Arrays.asList(false, true)) {
+                                    List<LowLatencyProfilePlanner.Profile> profiles =
+                                            LowLatencyProfilePlanner.plan(
+                                                    capabilities(
+                                                            LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                                                            "c2.mtk.avc.decoder",
+                                                            sdkInt,
+                                                            standard,
+                                                            maxOperatingRate,
+                                                            legacy,
+                                                            enumerationAvailable,
+                                                            advertised),
+                                                    ultraLowLatency,
+                                                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+                                    assertMtkProfilesAreSafeUniqueAndBounded(profiles);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void genericLegacyOtherUsesStandardThenVdecRegardlessOfUll() {
+        for (boolean ultraLowLatency : Arrays.asList(false, true)) {
+            List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                    capabilities(LowLatencyProfilePlanner.DecoderFamily.OTHER,
+                            "OMX.amlogic.avc.decoder", 33, true, true, true, false,
+                            Collections.emptySet()),
+                    ultraLowLatency,
+                    LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+
+            assertEquals(Arrays.asList("android-standard", "legacy-vdec"),
+                    profileNames(profiles));
+            assertEquals(options(MediaFormat.KEY_LOW_LATENCY, 1),
+                    profiles.get(0).integerOptions);
+            assertEquals(options(LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1),
+                    profiles.get(1).integerOptions);
+        }
+
+        List<LowLatencyProfilePlanner.Profile> legacyOnly = LowLatencyProfilePlanner.plan(
+                capabilities(LowLatencyProfilePlanner.DecoderFamily.OTHER,
+                        "c2.vendor.decoder", 30, false, true, true, false,
+                        Collections.emptySet()),
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+        assertEquals(Collections.singletonList("legacy-vdec"), profileNames(legacyOnly));
+        assertEquals(options(LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1),
+                legacyOnly.get(0).integerOptions);
+    }
+
+    @Test
+    public void capabilityLogFiltersSortsAndFormatsSuccessfulEnumerationExactly() {
+        AtomicInteger opens = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    opens.incrementAndGet();
+                    return session(Arrays.asList(
+                            "vendor.unknown.parameter",
+                            LowLatencyProfilePlanner.QTI_PICTURE_ORDER,
+                            "Vendor.QTI-Ext-Dec-Low-Latency.Enable"));
+                });
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("c2.qti.avc.decoder");
+
+        MediaCodecHelper.LowLatencyConfigurationPlan plan =
+                MediaCodecHelper.createDecoderLowLatencyPlan(
+                        decoderInfo,
+                        "video/avc",
+                        true,
+                        LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION,
+                        store,
+                        33,
+                        true,
+                        true,
+                        "Samsung");
+
+        assertEquals(1, opens.get());
+        assertEquals(MediaCodecHelper.VendorEnumerationStatus.SUCCESS,
+                plan.vendorEnumerationStatus);
+        assertEquals(Arrays.asList(
+                        LowLatencyProfilePlanner.QTI_CORE,
+                        LowLatencyProfilePlanner.QTI_PICTURE_ORDER),
+                plan.advertisedLowLatencyParameters);
+        assertEquals(
+                "CodecLLCapability decoder=c2.qti.avc.decoder mime=video/avc " +
+                        "featureLowLatency=true vendorEnumeration=success " +
+                        "advertisedLowLatencyParameters=[vendor.qti-ext-dec-low-latency.enable, " +
+                        "vendor.qti-ext-dec-picture-order.enable] ullPreference=true",
+                MediaCodecHelper.formatCapabilityLog(plan));
+
+        assertNotNull(plan.getProfile(0));
+        assertNotNull(plan.getProfile(1));
+        assertEquals(1, opens.get());
+    }
+
+    @Test
+    public void capabilityEnumerationIsTriStateAndFailureRetriesOnlyOnLaterPlan() {
+        AtomicInteger opens = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore failingStore =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    opens.incrementAndGet();
+                    throw new Exception("enumeration failed");
+                });
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("c2.qti.avc.decoder");
+
+        MediaCodecHelper.LowLatencyConfigurationPlan first = createPlan(
+                decoderInfo, failingStore, 33);
+        assertEquals(MediaCodecHelper.VendorEnumerationStatus.FAILURE,
+                first.vendorEnumerationStatus);
+        assertEquals(Collections.emptyList(), first.advertisedLowLatencyParameters);
+        assertNotNull(first.getProfile(0));
+        assertNull(first.getProfile(100));
+        assertEquals(1, opens.get());
+
+        MediaCodecHelper.LowLatencyConfigurationPlan second = createPlan(
+                decoderInfo, failingStore, 33);
+        assertEquals(MediaCodecHelper.VendorEnumerationStatus.FAILURE,
+                second.vendorEnumerationStatus);
+        assertEquals(2, opens.get());
+
+        AtomicInteger unsupportedOpens = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore unsupportedStore =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    unsupportedOpens.incrementAndGet();
+                    throw new AssertionError("API 30 must not enumerate vendor parameters");
+                });
+        MediaCodecHelper.LowLatencyConfigurationPlan unsupported = createPlan(
+                decoderInfo, unsupportedStore, 30);
+        assertEquals(MediaCodecHelper.VendorEnumerationStatus.NOT_SUPPORTED,
+                unsupported.vendorEnumerationStatus);
+        assertEquals(0, unsupportedOpens.get());
+        assertTrue(MediaCodecHelper.formatCapabilityLog(unsupported).contains(
+                "vendorEnumeration=not_supported"));
+    }
+
+    @Test
+    public void configurationPlanEnumeratesKnownParametersForOtherDecoderFamilies() {
+        AtomicInteger opens = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    opens.incrementAndGet();
+                    return session(Arrays.asList(
+                            "vendor.rtc-ext-dec-low-latency.enable",
+                            "vendor.nvidia.disable-output-reorder",
+                            "vendor.unrelated.option"));
+                });
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("c2.vendor.avc.decoder");
+
+        MediaCodecHelper.LowLatencyConfigurationPlan plan =
+                MediaCodecHelper.createDecoderLowLatencyPlan(
+                        decoderInfo,
+                        "video/avc",
+                        true,
+                        LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION,
+                        store,
+                        33,
+                        true,
+                        true,
+                        "Amazon");
+
+        assertEquals(1, opens.get());
+        assertEquals(MediaCodecHelper.VendorEnumerationStatus.SUCCESS,
+                plan.vendorEnumerationStatus);
+        assertEquals(Arrays.asList(
+                        "vendor.nvidia.disable-output-reorder",
+                        "vendor.rtc-ext-dec-low-latency.enable"),
+                plan.advertisedLowLatencyParameters);
+    }
+
+    @Test
+    public void diagnosticAttemptFallbackAndSelectionFormattingIsExactAndOrdered() {
+        MediaCodecDecoderRenderer.DecoderConfigurationProfile profile =
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.from(
+                        new MediaCodecHelper.AppliedLowLatencyOptions(
+                                3,
+                                "qti-core-picture",
+                                options(
+                                        LowLatencyProfilePlanner.QTI_CORE, 1,
+                                        LowLatencyProfilePlanner.QTI_PICTURE_ORDER, 1)));
+
+        String attempt = MediaCodecDecoderRenderer.formatLowLatencyAttempt(2, profile);
+        assertEquals(
+                "CodecLLAttempt ordinal=2 profileIndex=3 profileName=qti-core-picture " +
+                        "requestedOptions={vendor.qti-ext-dec-low-latency.enable=1, " +
+                        "vendor.qti-ext-dec-picture-order.enable=1}",
+                attempt);
+        assertFalse(attempt.contains("supported"));
+        assertEquals(
+                "CodecLLFallback profileIndex=3 profileName=qti-core-picture " +
+                        "reason=IllegalStateException",
+                MediaCodecDecoderRenderer.formatLowLatencyFallback(
+                        profile, new IllegalStateException("codec rejected options")));
+        assertEquals(
+                "CodecLLSelected profileIndex=3 profileName=qti-core-picture",
+                MediaCodecDecoderRenderer.formatLowLatencySelected(profile));
+    }
+
+    private static MediaCodecHelper.LowLatencyConfigurationPlan createPlan(
+            MediaCodecInfo decoderInfo,
+            MediaCodecHelper.VendorParameterCapabilityStore store,
+            int sdkInt) {
+        return MediaCodecHelper.createDecoderLowLatencyPlan(
+                decoderInfo,
+                "video/avc",
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION,
+                store,
+                sdkInt,
+                true,
+                true,
+                "Samsung");
+    }
+
+    private static MediaCodecHelper.VendorParameterSession session(List<String> parameters) {
+        return new MediaCodecHelper.VendorParameterSession() {
+            @Override
+            public List<String> getSupportedVendorParameters() {
+                return parameters;
+            }
+
+            @Override
+            public void release() {
+            }
+        };
+    }
+
+    private static LowLatencyProfilePlanner.Capabilities capabilities(
+            String decoderName,
+            int sdkInt,
+            boolean androidLowLatencySupported,
+            boolean maxOperatingRateSupported,
+            boolean vendorParameterEnumerationAvailable,
+            Set<String> supportedVendorParameters) {
+        return new LowLatencyProfilePlanner.Capabilities(
+                LowLatencyProfilePlanner.DecoderFamily.QUALCOMM,
+                decoderName,
+                sdkInt,
+                androidLowLatencySupported,
+                maxOperatingRateSupported,
+                false,
+                vendorParameterEnumerationAvailable,
+                supportedVendorParameters);
+    }
+
+    private static LowLatencyProfilePlanner.Capabilities capabilities(
+            LowLatencyProfilePlanner.DecoderFamily family,
+            String decoderName,
+            int sdkInt,
+            boolean androidLowLatencySupported,
+            boolean maxOperatingRateSupported,
+            boolean legacyVdecLowLatencyAllowed,
+            boolean vendorParameterEnumerationAvailable,
+            Set<String> supportedVendorParameters) {
+        return new LowLatencyProfilePlanner.Capabilities(
+                family,
+                decoderName,
+                sdkInt,
+                androidLowLatencySupported,
+                maxOperatingRateSupported,
+                legacyVdecLowLatencyAllowed,
+                vendorParameterEnumerationAvailable,
+                supportedVendorParameters);
+    }
+
+    private static void assertNoMtkVendorOrSchedulerOptions(
+            List<LowLatencyProfilePlanner.Profile> profiles) {
+        assertNoMtkVendorOptions(profiles);
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            assertFalse(profile.integerOptions.containsKey(MediaFormat.KEY_OPERATING_RATE));
+            assertFalse(profile.integerOptions.containsKey(MediaFormat.KEY_PRIORITY));
+        }
+    }
+
+    private static void assertNoMtkVendorOptions(
+            List<LowLatencyProfilePlanner.Profile> profiles) {
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            for (String key : profile.integerOptions.keySet()) {
+                assertFalse(key.startsWith("vendor.mtk."));
+            }
+        }
+    }
+
+    private static void assertMtkProfilesAreSafeUniqueAndBounded(
+            List<LowLatencyProfilePlanner.Profile> profiles) {
+        assertTrue(profiles.size() <= 11);
+        assertEquals(profiles.size(), new LinkedHashSet<>(profiles).size());
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            assertFalse(profile.integerOptions.isEmpty());
+            for (String forbiddenKey : FORBIDDEN_MTK_KEYS) {
+                assertFalse(profile.integerOptions.containsKey(forbiddenKey));
+            }
+            assertFalse(profile.integerOptions.containsKey(MediaFormat.KEY_OPERATING_RATE) &&
+                    profile.integerOptions.containsKey(MediaFormat.KEY_PRIORITY));
+        }
+    }
+
+    private static List<String> advertisedMtkAliases(Map<String, Integer> options) {
+        List<String> aliases = new ArrayList<>();
+        for (String key : Arrays.asList(
+                MTK_FETCH_TIMEOUT,
+                MTK_FETCH_TIMEOUT_VALUE,
+                MTK_GUARD_INTERVAL,
+                MTK_GUARD_INTERVAL_VALUE,
+                MTK_CPU_BOOST,
+                MTK_CPU_BOOST_VALUE)) {
+            if (options.containsKey(key)) {
+                aliases.add(key);
+            }
+        }
+        return aliases;
+    }
+
+    private static int pictureOrderFor(String decoderName) {
+        List<LowLatencyProfilePlanner.Profile> profiles = LowLatencyProfilePlanner.plan(
+                capabilities(decoderName, 30, false, false,
+                        false, Collections.emptySet()),
+                false,
+                LowLatencyProfilePlanner.PlanPurpose.INITIAL_CONFIGURATION);
+        return profiles.get(0).integerOptions.get(
+                LowLatencyProfilePlanner.QTI_PICTURE_ORDER);
+    }
+
+    private static void assertNoFenceKeys(List<LowLatencyProfilePlanner.Profile> profiles) {
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            assertFalse(profile.integerOptions.containsKey(
+                    LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE));
+            assertFalse(profile.integerOptions.containsKey(
+                    LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE));
+            assertFalse(profile.integerOptions.containsKey(
+                    LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE));
+        }
+    }
+
+    private static List<String> profileNames(List<LowLatencyProfilePlanner.Profile> profiles) {
+        List<String> names = new ArrayList<>();
+        for (LowLatencyProfilePlanner.Profile profile : profiles) {
+            names.add(profile.name);
+        }
+        return names;
+    }
+
+    private static Set<String> parameters(String... values) {
+        return new LinkedHashSet<>(Arrays.asList(values));
+    }
+
+    private static Map<String, Integer> singleOption(String key, int value) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        options.put(key, value);
+        return options;
+    }
+
+    private static Map<String, Integer> options(Object... keyValues) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            options.put((String) keyValues[i], (Integer) keyValues[i + 1]);
+        }
+        return options;
+    }
+
+    private static LowLatencyProfilePlanner.Profile profile(
+            String name,
+            String firstKey,
+            int firstValue,
+            String secondKey,
+            int secondValue) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        options.put(firstKey, firstValue);
+        options.put(secondKey, secondValue);
+        return new LowLatencyProfilePlanner.Profile(name, options);
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/MediaCodecDecoderRecoveryProfileTest.java
+++ b/app/src/test/java/com/limelight/binding/video/MediaCodecDecoderRecoveryProfileTest.java
@@ -1,0 +1,309 @@
+package com.limelight.binding.video;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.media.MediaFormat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {33})
+public class MediaCodecDecoderRecoveryProfileTest {
+    @Test
+    public void zeroOptionProfilesAttemptsBaseExactlyOnce() {
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                MediaCodecDecoderRenderer.selectConfigurationProfiles(0, profileIndex -> null);
+
+        assertEquals(1, attempts.size());
+        assertBase(attempts.get(0));
+    }
+
+    @Test
+    public void earlyOptionExhaustionAttemptsBaseImmediatelyNext() {
+        List<Integer> requestedIndices = new ArrayList<>();
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                MediaCodecDecoderRenderer.selectConfigurationProfiles(0, profileIndex -> {
+                    requestedIndices.add(profileIndex);
+                    return profileIndex < 2 ? applied(profileIndex, "option-" + profileIndex) : null;
+                });
+
+        assertEquals(Arrays.asList(0, 1, 2), requestedIndices);
+        assertEquals(Arrays.asList("option-0", "option-1", "base"), names(attempts));
+        assertBase(attempts.get(2));
+    }
+
+    @Test
+    public void elevenOptionProfilesReserveTwelfthAttemptForBase() {
+        AtomicInteger sourceCalls = new AtomicInteger();
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                MediaCodecDecoderRenderer.selectConfigurationProfiles(0, profileIndex -> {
+                    sourceCalls.incrementAndGet();
+                    return profileIndex < 11 ? applied(profileIndex, "option-" + profileIndex) : null;
+                });
+
+        assertEquals(11, sourceCalls.get());
+        assertEquals(12, attempts.size());
+        assertEquals(10, attempts.get(10).profileIndex);
+        assertBase(attempts.get(11));
+    }
+
+    @Test
+    public void brokenEndlessSourceIsTruncatedBeforeForcedBase() {
+        AtomicInteger sourceCalls = new AtomicInteger();
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                MediaCodecDecoderRenderer.selectConfigurationProfiles(0, profileIndex -> {
+                    sourceCalls.incrementAndGet();
+                    return applied(profileIndex, "endless-" + profileIndex);
+                });
+
+        assertEquals(11, sourceCalls.get());
+        assertEquals(12, attempts.size());
+        assertBase(attempts.get(11));
+    }
+
+    @Test
+    public void startTrySkipsProfilesAndOutOfRangeStartsWithBase() {
+        List<Integer> requestedIndices = new ArrayList<>();
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                MediaCodecDecoderRenderer.selectConfigurationProfiles(3, profileIndex -> {
+                    requestedIndices.add(profileIndex);
+                    return applied(profileIndex, "option-" + profileIndex);
+                });
+
+        assertEquals(Arrays.asList(3, 4, 5, 6, 7, 8, 9, 10), requestedIndices);
+        assertEquals(9, attempts.size());
+        assertEquals(3, attempts.get(0).profileIndex);
+        assertBase(attempts.get(8));
+
+        AtomicInteger outOfRangeCalls = new AtomicInteger();
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> baseOnly =
+                MediaCodecDecoderRenderer.selectConfigurationProfiles(11, profileIndex -> {
+                    outOfRangeCalls.incrementAndGet();
+                    return applied(profileIndex, "must-not-be-requested");
+                });
+        assertEquals(0, outOfRangeCalls.get());
+        assertEquals(1, baseOnly.size());
+        assertBase(baseOnly.get(0));
+    }
+
+    @Test
+    public void negativeStartTryIsRejected() {
+        try {
+            MediaCodecDecoderRenderer.selectConfigurationProfiles(-1, profileIndex -> null);
+            fail("Negative startTry must be rejected");
+        }
+        catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("startTry"));
+        }
+    }
+
+    @Test
+    public void runtimeRecoveryFromNonStandardUsesStandardThenBase() {
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                MediaCodecDecoderRenderer.selectRuntimeRecoveryProfiles(
+                        MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind.NON_STANDARD,
+                        profileIndex -> profileIndex == 0 ?
+                                applied(profileIndex, "android-standard",
+                                        MediaFormat.KEY_LOW_LATENCY, 1) : null);
+
+        assertEquals(Arrays.asList("android-standard", "base"), names(attempts));
+        assertEquals(MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind.ANDROID_STANDARD,
+                attempts.get(0).kind);
+        assertEquals(Collections.singletonMap(MediaFormat.KEY_LOW_LATENCY, 1),
+                attempts.get(0).integerOptions);
+        assertBase(attempts.get(1));
+    }
+
+    @Test
+    public void runtimeRecoveryFromStandardOrBaseIsBaseOnly() {
+        for (MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind activeKind : Arrays.asList(
+                MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind.ANDROID_STANDARD,
+                MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind.BASE)) {
+            AtomicInteger sourceCalls = new AtomicInteger();
+            List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                    MediaCodecDecoderRenderer.selectRuntimeRecoveryProfiles(
+                            activeKind,
+                            profileIndex -> {
+                                sourceCalls.incrementAndGet();
+                                return applied(profileIndex, "unsafe-vendor");
+                            });
+
+            assertEquals(0, sourceCalls.get());
+            assertEquals(1, attempts.size());
+            assertBase(attempts.get(0));
+        }
+    }
+
+    @Test
+    public void runtimeRecoveryPlannerNeverIntroducesVendorOrPerformanceOptions() {
+        LowLatencyProfilePlanner.Capabilities capabilities =
+                new LowLatencyProfilePlanner.Capabilities(
+                        LowLatencyProfilePlanner.DecoderFamily.MEDIATEK,
+                        "c2.mtk.avc.decoder",
+                        33,
+                        true,
+                        true,
+                        true,
+                        true,
+                        Collections.singleton(LowLatencyProfilePlanner.MTK_ULTRA_LOW_LATENCY));
+        List<LowLatencyProfilePlanner.Profile> recovery = LowLatencyProfilePlanner.plan(
+                capabilities,
+                true,
+                LowLatencyProfilePlanner.PlanPurpose.RUNTIME_RECOVERY);
+
+        List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts =
+                MediaCodecDecoderRenderer.selectRuntimeRecoveryProfiles(
+                        MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind.NON_STANDARD,
+                        profileIndex -> profileIndex < recovery.size() ?
+                                new MediaCodecHelper.AppliedLowLatencyOptions(
+                                        profileIndex,
+                                        recovery.get(profileIndex).name,
+                                        recovery.get(profileIndex).integerOptions) : null);
+
+        assertEquals(Arrays.asList("android-standard", "base"), names(attempts));
+        assertEquals(Collections.singletonMap(MediaFormat.KEY_LOW_LATENCY, 1),
+                attempts.get(0).integerOptions);
+    }
+
+    @Test
+    public void transientRestartAndResetKeepTheActiveProfile() {
+        for (MediaCodecDecoderRenderer.RecoveryStage stage : Arrays.asList(
+                MediaCodecDecoderRenderer.RecoveryStage.TRANSIENT,
+                MediaCodecDecoderRenderer.RecoveryStage.RESTART,
+                MediaCodecDecoderRenderer.RecoveryStage.RESET)) {
+            assertEquals(MediaCodecDecoderRenderer.RecoveryAction.REUSE_ACTIVE_CONFIGURATION,
+                    MediaCodecDecoderRenderer.recoveryActionFor(stage));
+        }
+        assertEquals(MediaCodecDecoderRenderer.RecoveryAction.RUNTIME_DOWNGRADE,
+                MediaCodecDecoderRenderer.recoveryActionFor(
+                        MediaCodecDecoderRenderer.RecoveryStage.FULL_RECREATION));
+    }
+
+    @Test
+    public void failedCandidateDoesNotCommitStateAndSuccessCommitsAllMetadataTogether() {
+        MediaFormat oldFormat = MediaFormat.createVideoFormat("video/avc", 1280, 720);
+        MediaCodecDecoderRenderer.DecoderConfigurationProfile oldProfile =
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.base();
+        MediaCodecDecoderRenderer.ConfiguredDecoderState original =
+                MediaCodecDecoderRenderer.commitConfiguredState(
+                        null, oldFormat, oldProfile, true);
+
+        MediaFormat newFormat = MediaFormat.createVideoFormat("video/avc", 1920, 1080);
+        MediaCodecDecoderRenderer.DecoderConfigurationProfile newProfile =
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.from(
+                        applied(4, "qti-core-only", LowLatencyProfilePlanner.QTI_CORE, 1));
+
+        assertSame(original, MediaCodecDecoderRenderer.commitConfiguredState(
+                original, newFormat, newProfile, false));
+
+        MediaCodecDecoderRenderer.ConfiguredDecoderState committed =
+                MediaCodecDecoderRenderer.commitConfiguredState(
+                        original, newFormat, newProfile, true);
+        assertSame(newFormat, committed.format);
+        assertEquals(4, committed.profileIndex);
+        assertEquals("qti-core-only", committed.profileName);
+        assertEquals(MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind.NON_STANDARD,
+                committed.kind);
+    }
+
+    @Test
+    public void initialBaseFailureReturnsMinusFiveAndRecoveryBaseFailureRethrows() {
+        MediaCodecDecoderRenderer.DecoderConfigurationProfile base =
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.base();
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationFailureDisposition.RETURN_MINUS_FIVE,
+                MediaCodecDecoderRenderer.configurationFailureDisposition(
+                        MediaCodecDecoderRenderer.ConfigurationMode.INITIAL, base));
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationFailureDisposition.RETHROW,
+                MediaCodecDecoderRenderer.configurationFailureDisposition(
+                        MediaCodecDecoderRenderer.ConfigurationMode.RUNTIME_RECOVERY, base));
+
+        MediaCodecDecoderRenderer.DecoderConfigurationProfile option =
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.from(
+                        applied(0, "android-standard", MediaFormat.KEY_LOW_LATENCY, 1));
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationFailureDisposition.TRY_NEXT,
+                MediaCodecDecoderRenderer.configurationFailureDisposition(
+                        MediaCodecDecoderRenderer.ConfigurationMode.INITIAL, option));
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationFailureDisposition.TRY_NEXT,
+                MediaCodecDecoderRenderer.configurationFailureDisposition(
+                        MediaCodecDecoderRenderer.ConfigurationMode.RUNTIME_RECOVERY, option));
+    }
+
+    @Test
+    public void initializeDecoderBooleanSelectsTheEntryPointBaseFailurePolicy() {
+        MediaCodecDecoderRenderer.DecoderConfigurationProfile base =
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.base();
+
+        MediaCodecDecoderRenderer.ConfigurationMode setupMode =
+                MediaCodecDecoderRenderer.configurationModeForInitializeDecoder(false);
+        MediaCodecDecoderRenderer.ConfigurationMode recreationMode =
+                MediaCodecDecoderRenderer.configurationModeForInitializeDecoder(true);
+
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationMode.INITIAL, setupMode);
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationFailureDisposition.RETURN_MINUS_FIVE,
+                MediaCodecDecoderRenderer.configurationFailureDisposition(setupMode, base));
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationMode.RUNTIME_RECOVERY, recreationMode);
+        assertEquals(MediaCodecDecoderRenderer.ConfigurationFailureDisposition.RETHROW,
+                MediaCodecDecoderRenderer.configurationFailureDisposition(recreationMode, base));
+    }
+
+    @Test
+    public void finalFailureLogIdentifiesDecoderProfileCapabilityAndRequestedOptions() {
+        String message = MediaCodecDecoderRenderer.finalConfigurationFailureMessage(
+                "c2.qti.avc.decoder",
+                MediaCodecDecoderRenderer.DecoderConfigurationProfile.base(),
+                true);
+
+        assertTrue(message.contains("decoder=c2.qti.avc.decoder"));
+        assertTrue(message.contains("profileIndex=-1"));
+        assertTrue(message.contains("profileName=base"));
+        assertTrue(message.contains("requestedOptions={}"));
+        assertTrue(message.contains("FEATURE_LowLatency=true"));
+    }
+
+    private static MediaCodecHelper.AppliedLowLatencyOptions applied(
+            int profileIndex,
+            String profileName,
+            Object... keyValues) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        if (keyValues.length == 0) {
+            options.put("test-option-" + profileIndex, 1);
+        }
+        else {
+            for (int i = 0; i < keyValues.length; i += 2) {
+                options.put((String) keyValues[i], (Integer) keyValues[i + 1]);
+            }
+        }
+        return new MediaCodecHelper.AppliedLowLatencyOptions(
+                profileIndex, profileName, options);
+    }
+
+    private static List<String> names(
+            List<MediaCodecDecoderRenderer.DecoderConfigurationProfile> attempts) {
+        List<String> names = new ArrayList<>();
+        for (MediaCodecDecoderRenderer.DecoderConfigurationProfile attempt : attempts) {
+            names.add(attempt.profileName);
+        }
+        return names;
+    }
+
+    private static void assertBase(
+            MediaCodecDecoderRenderer.DecoderConfigurationProfile profile) {
+        assertEquals(-1, profile.profileIndex);
+        assertEquals("base", profile.profileName);
+        assertTrue(profile.integerOptions.isEmpty());
+        assertEquals(MediaCodecDecoderRenderer.ActiveLowLatencyProfileKind.BASE, profile.kind);
+    }
+}

--- a/app/src/test/java/com/limelight/binding/video/MediaCodecLowLatencyCapabilityTest.java
+++ b/app/src/test/java/com/limelight/binding/video/MediaCodecLowLatencyCapabilityTest.java
@@ -1,0 +1,826 @@
+package com.limelight.binding.video;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.media.MediaCodecInfo;
+import android.media.MediaFormat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {33})
+public class MediaCodecLowLatencyCapabilityTest {
+    private static final String MTK_LOW_LATENCY_MODE =
+            "vendor.mtk.vdec.low-latency.mode";
+    private static final String MTK_ULTRA_LOW_LATENCY =
+            "vendor.mtk.vdec.ultra-low-latency";
+    private static final String MTK_FETCH_TIMEOUT =
+            "vendor.mtk.vdec.buffer.fetch.timeout.ms";
+    private static final String MTK_FETCH_TIMEOUT_VALUE = MTK_FETCH_TIMEOUT + ".value";
+    private static final String NVIDIA_MEDIA_LOW_LATENCY = "media.low-latency.enable";
+    private static final String NVIDIA_VENDOR_LOW_LATENCY = "vendor.low-latency.enable";
+    private static final String NVIDIA_DISABLE_OUTPUT_REORDER = "disable-output-reorder";
+    private static final String NVIDIA_VENDOR_DISABLE_OUTPUT_REORDER =
+            "vendor.nvidia.disable-output-reorder";
+    private static final String KIRIN_LOW_LATENCY_REQUEST =
+            "vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-req";
+    private static final String KIRIN_LOW_LATENCY_READY =
+            "vendor.hisi-ext-low-latency-video-dec.video-scene-for-low-latency-rdy";
+    private static final String EXYNOS_LOW_LATENCY =
+            "vendor.rtc-ext-dec-low-latency.enable";
+
+    private static final List<String> LOW_LATENCY_OPTION_KEYS = Arrays.asList(
+            MediaFormat.KEY_LOW_LATENCY,
+            LowLatencyProfilePlanner.VDEC_LOW_LATENCY,
+            LowLatencyProfilePlanner.QTI_CORE,
+            LowLatencyProfilePlanner.QTI_PICTURE_ORDER,
+            LowLatencyProfilePlanner.QTI_SOFTWARE_FENCE,
+            LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE,
+            LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE,
+            MTK_LOW_LATENCY_MODE,
+            MTK_ULTRA_LOW_LATENCY,
+            MTK_FETCH_TIMEOUT,
+            MTK_FETCH_TIMEOUT_VALUE,
+            MediaFormat.KEY_OPERATING_RATE,
+            MediaFormat.KEY_PRIORITY);
+
+    @Before
+    public void initializeCodecHelper() {
+        MediaCodecHelper.initialize(RuntimeEnvironment.getApplication(), "Adreno 740");
+    }
+
+    @Test
+    public void appliedOptionsAreNamedIndexedOrderedImmutableAndDefensive() {
+        LinkedHashMap<String, Integer> source = new LinkedHashMap<>();
+        source.put("first", 1);
+        source.put("second", 2);
+
+        MediaCodecHelper.AppliedLowLatencyOptions applied =
+                new MediaCodecHelper.AppliedLowLatencyOptions(3, "named-profile", source);
+        source.put("third", 3);
+
+        assertEquals(3, applied.profileIndex);
+        assertEquals("named-profile", applied.profileName);
+        assertEquals(Arrays.asList("first", "second"),
+                Arrays.asList(applied.integerOptions.keySet().toArray(new String[0])));
+        assertEquals(options("first", 1, "second", 2), applied.integerOptions);
+        try {
+            applied.integerOptions.put("mutation", 4);
+            fail("Applied options must be immutable");
+        }
+        catch (UnsupportedOperationException expected) {
+            // Expected.
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void appliedOptionsRejectEmptyMaps() {
+        new MediaCodecHelper.AppliedLowLatencyOptions(
+                0, "invalid-empty", Collections.emptyMap());
+    }
+
+    @Test
+    public void advertisedParametersAreNormalizedImmutableCachedAndReleased() {
+        AtomicInteger openCount = new AtomicInteger();
+        AtomicInteger releaseCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    return session(Arrays.asList(
+                            "Vendor.QTI-Ext-Output-Fence.Enable",
+                            "vendor.qti-ext-dec-picture-order.enable"), releaseCount);
+                });
+
+        MediaCodecHelper.VendorParameterSnapshot first =
+                store.getSnapshot("C2.QTI.AVC.Decoder", 31);
+        MediaCodecHelper.VendorParameterSnapshot cached =
+                store.getSnapshot("c2.qti.avc.decoder", 36);
+
+        assertTrue(first.enumerationAvailable);
+        assertEquals(Arrays.asList(
+                        "vendor.qti-ext-dec-picture-order.enable",
+                        "vendor.qti-ext-output-fence.enable"),
+                Arrays.asList(first.supportedParameters.toArray(new String[0])));
+        assertEquals(first.supportedParameters, cached.supportedParameters);
+        assertEquals(1, openCount.get());
+        assertEquals(1, releaseCount.get());
+
+        try {
+            first.supportedParameters.add("mutation");
+            fail("Vendor parameter snapshot must be immutable");
+        }
+        catch (UnsupportedOperationException expected) {
+            // Expected.
+        }
+    }
+
+    @Test
+    public void successfulEmptyEnumerationIsAvailableAndCached() {
+        AtomicInteger openCount = new AtomicInteger();
+        AtomicInteger releaseCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    return session(Collections.emptyList(), releaseCount);
+                });
+
+        MediaCodecHelper.VendorParameterSnapshot first =
+                store.getSnapshot("c2.qti.hevc.decoder", 31);
+        MediaCodecHelper.VendorParameterSnapshot second =
+                store.getSnapshot("C2.QTI.HEVC.DECODER", 31);
+
+        assertTrue(first.enumerationAvailable);
+        assertTrue(first.supportedParameters.isEmpty());
+        assertTrue(second.enumerationAvailable);
+        assertEquals(1, openCount.get());
+        assertEquals(1, releaseCount.get());
+    }
+
+    @Test
+    public void failedEnumerationIsUnavailableReleasedAndNotCached() {
+        AtomicInteger openCount = new AtomicInteger();
+        AtomicInteger releaseCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    return new MediaCodecHelper.VendorParameterSession() {
+                        @Override
+                        public List<String> getSupportedVendorParameters() throws Exception {
+                            throw new Exception("codec query failed");
+                        }
+
+                        @Override
+                        public void release() {
+                            releaseCount.incrementAndGet();
+                        }
+                    };
+                });
+
+        MediaCodecHelper.VendorParameterSnapshot first =
+                store.getSnapshot("c2.qti.av1.decoder", 31);
+        MediaCodecHelper.VendorParameterSnapshot retried =
+                store.getSnapshot("C2.QTI.AV1.DECODER", 31);
+
+        assertFalse(first.enumerationAvailable);
+        assertTrue(first.supportedParameters.isEmpty());
+        assertFalse(retried.enumerationAvailable);
+        assertEquals(2, openCount.get());
+        assertEquals(2, releaseCount.get());
+    }
+
+    @Test
+    public void api26And30NeverOpenProvider() {
+        AtomicInteger openCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    throw new AssertionError("Provider must not be opened before API 31");
+                });
+
+        for (int sdkInt : Arrays.asList(26, 30)) {
+            MediaCodecHelper.VendorParameterSnapshot snapshot =
+                    store.getSnapshot("c2.qti.avc.decoder", sdkInt);
+            assertFalse(snapshot.enumerationAvailable);
+            assertTrue(snapshot.supportedParameters.isEmpty());
+        }
+        assertEquals(0, openCount.get());
+    }
+
+    @Test
+    public void concurrentCaseVariantLookupsShareOneCompleteSnapshot() throws Exception {
+        AtomicInteger openCount = new AtomicInteger();
+        AtomicInteger enumerationCount = new AtomicInteger();
+        AtomicInteger releaseCount = new AtomicInteger();
+        CyclicBarrier callersReady = new CyclicBarrier(2);
+        CountDownLatch enumerationEntered = new CountDownLatch(1);
+        CountDownLatch allowEnumerationToComplete = new CountDownLatch(1);
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    return new MediaCodecHelper.VendorParameterSession() {
+                        @Override
+                        public List<String> getSupportedVendorParameters() throws Exception {
+                            enumerationCount.incrementAndGet();
+                            enumerationEntered.countDown();
+                            if (!allowEnumerationToComplete.await(5, TimeUnit.SECONDS)) {
+                                throw new AssertionError("Timed out waiting to complete enumeration");
+                            }
+                            return Arrays.asList(
+                                    "Vendor.QTI-Ext-Dec-Picture-Order.Enable",
+                                    "vendor.qti-ext-output-fence.enable");
+                        }
+
+                        @Override
+                        public void release() {
+                            releaseCount.incrementAndGet();
+                        }
+                    };
+                });
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<MediaCodecHelper.VendorParameterSnapshot> firstFuture = executor.submit(() -> {
+                callersReady.await(5, TimeUnit.SECONDS);
+                return store.getSnapshot("C2.QTI.AVC.Decoder", 33);
+            });
+            Future<MediaCodecHelper.VendorParameterSnapshot> secondFuture = executor.submit(() -> {
+                callersReady.await(5, TimeUnit.SECONDS);
+                return store.getSnapshot("c2.qti.avc.decoder", 33);
+            });
+
+            assertTrue(enumerationEntered.await(5, TimeUnit.SECONDS));
+            allowEnumerationToComplete.countDown();
+
+            MediaCodecHelper.VendorParameterSnapshot first =
+                    firstFuture.get(5, TimeUnit.SECONDS);
+            MediaCodecHelper.VendorParameterSnapshot second =
+                    secondFuture.get(5, TimeUnit.SECONDS);
+
+            assertSame(first, second);
+            assertTrue(first.enumerationAvailable);
+            assertEquals(Arrays.asList(
+                            "vendor.qti-ext-dec-picture-order.enable",
+                            "vendor.qti-ext-output-fence.enable"),
+                    Arrays.asList(first.supportedParameters.toArray(new String[0])));
+            assertEquals(1, openCount.get());
+            assertEquals(1, enumerationCount.get());
+            assertEquals(1, releaseCount.get());
+            try {
+                first.supportedParameters.add("mutation");
+                fail("Concurrent snapshot must be immutable");
+            }
+            catch (UnsupportedOperationException expected) {
+                // Expected.
+            }
+        }
+        finally {
+            allowEnumerationToComplete.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void qualcommHelperAppliesOneS25ProfilePerAttemptAndTerminates() {
+        AtomicInteger openCount = new AtomicInteger();
+        AtomicInteger releaseCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store = s25Store(
+                openCount, releaseCount);
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("c2.qti.avc.decoder.low_latency");
+
+        List<Map<String, Integer>> expectedProfiles = Arrays.asList(
+                options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        LowLatencyProfilePlanner.QTI_PICTURE_ORDER, 1,
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE, 1,
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        LowLatencyProfilePlanner.QTI_PICTURE_ORDER, 1,
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE, 1,
+                        LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE, 1),
+                options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        LowLatencyProfilePlanner.QTI_PICTURE_ORDER, 1),
+                options(MediaFormat.KEY_LOW_LATENCY, 1));
+
+        for (int tryNumber = 0; tryNumber < expectedProfiles.size(); tryNumber++) {
+            MediaFormat format = videoFormat();
+            MediaCodecHelper.AppliedLowLatencyOptions applied =
+                    MediaCodecHelper.setDecoderLowLatencyOptions(
+                    format,
+                    decoderInfo,
+                    true,
+                    tryNumber,
+                    store,
+                    33,
+                    true,
+                    true);
+            assertNotNull(applied);
+            assertEquals(tryNumber, applied.profileIndex);
+            assertEquals(Arrays.asList(
+                    "qti-experimental-full",
+                    "qti-experimental-no-scheduler",
+                    "qti-no-fence",
+                    "android-standard").get(tryNumber), applied.profileName);
+            assertEquals(expectedProfiles.get(tryNumber), applied.integerOptions);
+            assertEquals(expectedProfiles.get(tryNumber).keySet(), optionKeys(format));
+            assertEquals(expectedProfiles.get(tryNumber), lowLatencyOptions(format));
+        }
+
+        MediaFormat exhausted = videoFormat();
+        String exhaustedBefore = exhausted.toString();
+        assertNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                exhausted,
+                decoderInfo,
+                true,
+                expectedProfiles.size(),
+                store,
+                33,
+                true,
+                true));
+        assertEquals(exhaustedBefore, exhausted.toString());
+        assertTrue(lowLatencyOptions(exhausted).isEmpty());
+        assertEquals(1, openCount.get());
+        assertEquals(1, releaseCount.get());
+    }
+
+    @Test
+    public void qualcommHelperUllOffStartsWithStandardAndRejectsInvalidAttempts() {
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                s25Store(new AtomicInteger(), new AtomicInteger());
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("c2.qti.hevc.decoder.low_latency");
+
+        MediaFormat standard = videoFormat();
+        MediaCodecHelper.AppliedLowLatencyOptions applied =
+                MediaCodecHelper.setDecoderLowLatencyOptions(
+                standard,
+                decoderInfo,
+                false,
+                0,
+                store,
+                33,
+                true,
+                true);
+        assertNotNull(applied);
+        assertEquals(0, applied.profileIndex);
+        assertEquals("android-standard", applied.profileName);
+        assertEquals(options(MediaFormat.KEY_LOW_LATENCY, 1),
+                lowLatencyOptions(standard));
+
+        for (int invalidAttempt : Arrays.asList(-1, 1, 100)) {
+            MediaFormat untouched = videoFormat();
+            String untouchedBefore = untouched.toString();
+            assertNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                    untouched,
+                    decoderInfo,
+                    false,
+                    invalidAttempt,
+                    store,
+                    33,
+                    true,
+                    true));
+            assertEquals(untouchedBefore, untouched.toString());
+            assertTrue(lowLatencyOptions(untouched).isEmpty());
+        }
+    }
+
+    @Test
+    public void injectableHelperUsesStandardForNonQualcommWithoutOpeningProvider() {
+        AtomicInteger openCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    throw new AssertionError("Non-Qualcomm decoder must not probe QTI parameters");
+                });
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("c2.vendor.avc.decoder");
+        MediaFormat format = videoFormat();
+        String before = format.toString();
+
+        MediaCodecHelper.AppliedLowLatencyOptions applied =
+                MediaCodecHelper.setDecoderLowLatencyOptions(
+                format,
+                decoderInfo,
+                true,
+                0,
+                store,
+                33,
+                true,
+                true);
+        assertNotNull(applied);
+        assertEquals("android-standard", applied.profileName);
+        assertEquals(options(MediaFormat.KEY_LOW_LATENCY, 1), lowLatencyOptions(format));
+        assertFalse(before.equals(format.toString()));
+        assertEquals(0, openCount.get());
+    }
+
+    @Test
+    public void mediatekHelperAppliesFreshFiniteProfilesAndTerminates() {
+        AtomicInteger openCount = new AtomicInteger();
+        AtomicInteger releaseCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    return session(Arrays.asList(
+                            MTK_LOW_LATENCY_MODE,
+                            MTK_ULTRA_LOW_LATENCY,
+                            MTK_FETCH_TIMEOUT,
+                            MTK_FETCH_TIMEOUT_VALUE), releaseCount);
+                });
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("C2.MTK.AVC.Decoder");
+        List<Map<String, Integer>> expectedProfiles = Arrays.asList(
+                options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1,
+                        MTK_LOW_LATENCY_MODE, 1,
+                        MTK_ULTRA_LOW_LATENCY, 1,
+                        MTK_FETCH_TIMEOUT_VALUE, 2,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                options(
+                        MediaFormat.KEY_LOW_LATENCY, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                options(MediaFormat.KEY_LOW_LATENCY, 1),
+                options(
+                        LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1,
+                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                options(LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1),
+                options(MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE));
+
+        for (int tryNumber = 0; tryNumber < expectedProfiles.size(); tryNumber++) {
+            MediaFormat format = videoFormat();
+            MediaCodecHelper.AppliedLowLatencyOptions applied =
+                    MediaCodecHelper.setDecoderLowLatencyOptions(
+                    format,
+                    decoderInfo,
+                    true,
+                    tryNumber,
+                    store,
+                    33,
+                    true,
+                    true,
+                    "Samsung");
+            assertNotNull(applied);
+            assertEquals(tryNumber, applied.profileIndex);
+            assertEquals(expectedProfiles.get(tryNumber), applied.integerOptions);
+            assertEquals(expectedProfiles.get(tryNumber).keySet(), optionKeys(format));
+            assertEquals(expectedProfiles.get(tryNumber), lowLatencyOptions(format));
+        }
+
+        MediaFormat exhausted = videoFormat();
+        String exhaustedBefore = exhausted.toString();
+        assertNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                exhausted,
+                decoderInfo,
+                true,
+                expectedProfiles.size(),
+                store,
+                33,
+                true,
+                true,
+                "Samsung"));
+        assertEquals(exhaustedBefore, exhausted.toString());
+        assertTrue(lowLatencyOptions(exhausted).isEmpty());
+        assertEquals(1, openCount.get());
+        assertEquals(1, releaseCount.get());
+    }
+
+    @Test
+    public void genericAmlogicLegacyHelperDoesNotProbeVendorParameters() {
+        AtomicInteger openCount = new AtomicInteger();
+        MediaCodecHelper.VendorParameterCapabilityStore store =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    openCount.incrementAndGet();
+                    throw new AssertionError("Generic legacy path must not enumerate vendor parameters");
+                });
+        MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+        when(decoderInfo.getName()).thenReturn("OMX.AMLOGIC.video.decoder.avc");
+
+        MediaFormat standard = videoFormat();
+        assertNotNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                standard, decoderInfo, true, 0, store, 33, true, true, "Google"));
+        assertEquals(options(MediaFormat.KEY_LOW_LATENCY, 1), lowLatencyOptions(standard));
+
+        MediaFormat legacy = videoFormat();
+        assertNotNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                legacy, decoderInfo, true, 1, store, 33, true, true, "Google"));
+        assertEquals(options(LowLatencyProfilePlanner.VDEC_LOW_LATENCY, 1),
+                lowLatencyOptions(legacy));
+
+        MediaFormat exhausted = videoFormat();
+        assertNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                exhausted, decoderInfo, true, 2, store, 33, true, true, "Google"));
+        assertTrue(lowLatencyOptions(exhausted).isEmpty());
+        assertEquals(0, openCount.get());
+    }
+
+    @Test
+    public void legacyProfilesPreserveFiniteRiskToSafeCombinations() {
+        MediaCodecHelper.VendorParameterCapabilityStore unusedStore =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    throw new AssertionError("Legacy paths must not enumerate vendor parameters");
+                });
+        List<LegacyFixture> fixtures = Arrays.asList(
+                new LegacyFixture(
+                        "c2.nvidia.avc.decoder",
+                        "NVIDIA",
+                        true,
+                        true,
+                        Arrays.asList(
+                                "nvidia-legacy-full",
+                                "nvidia-legacy-standard",
+                                "android-standard",
+                                "nvidia-legacy-performance",
+                                "nvidia-legacy",
+                                "performance-only"),
+                        Arrays.asList(
+                                options(
+                                        MediaFormat.KEY_LOW_LATENCY, 1,
+                                        NVIDIA_MEDIA_LOW_LATENCY, 1,
+                                        NVIDIA_VENDOR_LOW_LATENCY, 1,
+                                        NVIDIA_DISABLE_OUTPUT_REORDER, 1,
+                                        NVIDIA_VENDOR_DISABLE_OUTPUT_REORDER, 1,
+                                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                                options(
+                                        MediaFormat.KEY_LOW_LATENCY, 1,
+                                        NVIDIA_MEDIA_LOW_LATENCY, 1,
+                                        NVIDIA_VENDOR_LOW_LATENCY, 1,
+                                        NVIDIA_DISABLE_OUTPUT_REORDER, 1,
+                                        NVIDIA_VENDOR_DISABLE_OUTPUT_REORDER, 1),
+                                options(MediaFormat.KEY_LOW_LATENCY, 1),
+                                options(
+                                        NVIDIA_MEDIA_LOW_LATENCY, 1,
+                                        NVIDIA_VENDOR_LOW_LATENCY, 1,
+                                        NVIDIA_DISABLE_OUTPUT_REORDER, 1,
+                                        NVIDIA_VENDOR_DISABLE_OUTPUT_REORDER, 1,
+                                        MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE),
+                                options(
+                                        NVIDIA_MEDIA_LOW_LATENCY, 1,
+                                        NVIDIA_VENDOR_LOW_LATENCY, 1,
+                                        NVIDIA_DISABLE_OUTPUT_REORDER, 1,
+                                        NVIDIA_VENDOR_DISABLE_OUTPUT_REORDER, 1),
+                                options(MediaFormat.KEY_OPERATING_RATE, (int) Short.MAX_VALUE))),
+                new LegacyFixture(
+                        "OMX.hisi.video.decoder.avc",
+                        "Huawei",
+                        false,
+                        false,
+                        Arrays.asList(
+                                "kirin-legacy-performance",
+                                "kirin-legacy",
+                                "performance-only"),
+                        Arrays.asList(
+                                options(
+                                        KIRIN_LOW_LATENCY_REQUEST, 1,
+                                        KIRIN_LOW_LATENCY_READY, -1,
+                                        MediaFormat.KEY_PRIORITY, 0),
+                                options(
+                                        KIRIN_LOW_LATENCY_REQUEST, 1,
+                                        KIRIN_LOW_LATENCY_READY, -1),
+                                options(MediaFormat.KEY_PRIORITY, 0))),
+                new LegacyFixture(
+                        "c2.exynos.avc.decoder",
+                        "Samsung",
+                        true,
+                        false,
+                        Arrays.asList(
+                                "exynos-legacy-full",
+                                "exynos-legacy-standard",
+                                "android-standard",
+                                "exynos-legacy-performance",
+                                "exynos-legacy",
+                                "performance-only"),
+                        Arrays.asList(
+                                options(
+                                        MediaFormat.KEY_LOW_LATENCY, 1,
+                                        EXYNOS_LOW_LATENCY, 1,
+                                        MediaFormat.KEY_PRIORITY, 0),
+                                options(
+                                        MediaFormat.KEY_LOW_LATENCY, 1,
+                                        EXYNOS_LOW_LATENCY, 1),
+                                options(MediaFormat.KEY_LOW_LATENCY, 1),
+                                options(
+                                        EXYNOS_LOW_LATENCY, 1,
+                                        MediaFormat.KEY_PRIORITY, 0),
+                                options(EXYNOS_LOW_LATENCY, 1),
+                                options(MediaFormat.KEY_PRIORITY, 0))));
+
+        for (LegacyFixture fixture : fixtures) {
+            MediaCodecInfo decoderInfo = mock(MediaCodecInfo.class);
+            when(decoderInfo.getName()).thenReturn(fixture.decoderName);
+            List<MediaCodecHelper.AppliedLowLatencyOptions> profiles = new ArrayList<>();
+            for (int profileIndex = 0; profileIndex < fixture.expectedNames.size(); profileIndex++) {
+                MediaFormat format = videoFormat();
+                MediaCodecHelper.AppliedLowLatencyOptions applied =
+                        MediaCodecHelper.setDecoderLowLatencyOptions(
+                                format,
+                                decoderInfo,
+                                true,
+                                profileIndex,
+                                unusedStore,
+                                33,
+                                fixture.androidStandardSupported,
+                                fixture.maxOperatingRateSupported,
+                                fixture.manufacturer);
+                assertNotNull(fixture.decoderName, applied);
+                profiles.add(applied);
+                assertEquals(fixture.expectedOptions.get(profileIndex), applied.integerOptions);
+                assertEquals(fixture.expectedOptions.get(profileIndex).keySet(), optionKeys(format));
+            }
+
+            assertEquals(fixture.expectedNames, appliedNames(profiles));
+            assertNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                    videoFormat(),
+                    decoderInfo,
+                    true,
+                    fixture.expectedNames.size(),
+                    unusedStore,
+                    33,
+                    fixture.androidStandardSupported,
+                    fixture.maxOperatingRateSupported,
+                    fixture.manufacturer));
+        }
+    }
+
+    @Test
+    public void legacyUllOffOmitsVendorAndKeepsStandardOrSchedulerFallbacks() {
+        MediaCodecHelper.VendorParameterCapabilityStore unusedStore =
+                new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+                    throw new AssertionError("Legacy paths must not enumerate vendor parameters");
+                });
+
+        MediaCodecInfo nvidiaInfo = mock(MediaCodecInfo.class);
+        when(nvidiaInfo.getName()).thenReturn("c2.nvidia.avc.decoder");
+        assertLegacyProfiles(
+                nvidiaInfo,
+                false,
+                unusedStore,
+                true,
+                false,
+                "NVIDIA",
+                Arrays.asList("android-standard", "performance-only"),
+                Arrays.asList(
+                        options(MediaFormat.KEY_LOW_LATENCY, 1),
+                        options(MediaFormat.KEY_PRIORITY, 0)));
+
+        MediaCodecInfo genericInfo = mock(MediaCodecInfo.class);
+        when(genericInfo.getName()).thenReturn("c2.vendor.avc.decoder");
+        assertLegacyProfiles(
+                genericInfo,
+                false,
+                unusedStore,
+                false,
+                false,
+                "Generic",
+                Collections.singletonList("performance-only"),
+                Collections.singletonList(options(MediaFormat.KEY_PRIORITY, 0)));
+    }
+
+    private static void assertLegacyProfiles(
+            MediaCodecInfo decoderInfo,
+            boolean ultraLowLatency,
+            MediaCodecHelper.VendorParameterCapabilityStore capabilityStore,
+            boolean androidLowLatencySupported,
+            boolean maxOperatingRateSupported,
+            String manufacturer,
+            List<String> expectedNames,
+            List<Map<String, Integer>> expectedOptions) {
+        List<MediaCodecHelper.AppliedLowLatencyOptions> profiles = new ArrayList<>();
+        for (int profileIndex = 0; profileIndex < expectedNames.size(); profileIndex++) {
+            MediaFormat format = videoFormat();
+            MediaCodecHelper.AppliedLowLatencyOptions applied =
+                    MediaCodecHelper.setDecoderLowLatencyOptions(
+                            format,
+                            decoderInfo,
+                            ultraLowLatency,
+                            profileIndex,
+                            capabilityStore,
+                            33,
+                            androidLowLatencySupported,
+                            maxOperatingRateSupported,
+                            manufacturer);
+            assertNotNull(applied);
+            assertEquals(expectedOptions.get(profileIndex), applied.integerOptions);
+            assertEquals(expectedOptions.get(profileIndex).keySet(), optionKeys(format));
+            profiles.add(applied);
+        }
+        assertEquals(expectedNames, appliedNames(profiles));
+        assertNull(MediaCodecHelper.setDecoderLowLatencyOptions(
+                videoFormat(),
+                decoderInfo,
+                ultraLowLatency,
+                expectedNames.size(),
+                capabilityStore,
+                33,
+                androidLowLatencySupported,
+                maxOperatingRateSupported,
+                manufacturer));
+    }
+
+    private static List<String> appliedNames(
+            List<MediaCodecHelper.AppliedLowLatencyOptions> profiles) {
+        List<String> names = new ArrayList<>();
+        for (MediaCodecHelper.AppliedLowLatencyOptions profile : profiles) {
+            names.add(profile.profileName);
+        }
+        return names;
+    }
+
+    private static final class LegacyFixture {
+        final String decoderName;
+        final String manufacturer;
+        final boolean androidStandardSupported;
+        final boolean maxOperatingRateSupported;
+        final List<String> expectedNames;
+        final List<Map<String, Integer>> expectedOptions;
+
+        LegacyFixture(String decoderName,
+                      String manufacturer,
+                      boolean androidStandardSupported,
+                      boolean maxOperatingRateSupported,
+                      List<String> expectedNames,
+                      List<Map<String, Integer>> expectedOptions) {
+            this.decoderName = decoderName;
+            this.manufacturer = manufacturer;
+            this.androidStandardSupported = androidStandardSupported;
+            this.maxOperatingRateSupported = maxOperatingRateSupported;
+            this.expectedNames = expectedNames;
+            this.expectedOptions = expectedOptions;
+        }
+    }
+
+    private static MediaCodecHelper.VendorParameterCapabilityStore s25Store(
+            AtomicInteger openCount,
+            AtomicInteger releaseCount) {
+        return new MediaCodecHelper.VendorParameterCapabilityStore(decoderName -> {
+            openCount.incrementAndGet();
+            return session(Arrays.asList(
+                    LowLatencyProfilePlanner.QTI_PICTURE_ORDER,
+                    LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_ENABLE,
+                    LowLatencyProfilePlanner.QTI_OUTPUT_FENCE_TYPE), releaseCount);
+        });
+    }
+
+    private static MediaFormat videoFormat() {
+        return MediaFormat.createVideoFormat("video/avc", 1920, 1080);
+    }
+
+    private static Map<String, Integer> lowLatencyOptions(MediaFormat format) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        for (String key : LOW_LATENCY_OPTION_KEYS) {
+            if (format.containsKey(key)) {
+                options.put(key, format.getInteger(key));
+            }
+        }
+        return options;
+    }
+
+    private static Set<String> optionKeys(MediaFormat format) {
+        Set<String> keys = new HashSet<>(format.getKeys());
+        keys.remove(MediaFormat.KEY_MIME);
+        keys.remove(MediaFormat.KEY_WIDTH);
+        keys.remove(MediaFormat.KEY_HEIGHT);
+        return keys;
+    }
+
+    private static Map<String, Integer> options(Object... keyValues) {
+        LinkedHashMap<String, Integer> options = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            options.put((String) keyValues[i], (Integer) keyValues[i + 1]);
+        }
+        return options;
+    }
+
+    private static MediaCodecHelper.VendorParameterSession session(
+            List<String> parameters,
+            AtomicInteger releaseCount) {
+        return new MediaCodecHelper.VendorParameterSession() {
+            @Override
+            public List<String> getSupportedVendorParameters() {
+                return parameters;
+            }
+
+            @Override
+            public void release() {
+                releaseCount.incrementAndGet();
+            }
+        };
+    }
+}

--- a/app/src/test/java/com/limelight/profiles/ProfilesOverlayTest.java
+++ b/app/src/test/java/com/limelight/profiles/ProfilesOverlayTest.java
@@ -2,10 +2,14 @@ package com.limelight.profiles;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 
+import androidx.preference.PreferenceManager;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.limelight.R;
 import com.limelight.TestLogSuppressor;
+import com.limelight.nvstream.StreamConfiguration;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -16,6 +20,7 @@ import org.robolectric.annotation.Config;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -24,6 +29,8 @@ import static org.junit.Assert.*;
 @Config(sdk = {33}, shadows = {com.limelight.shadows.ShadowMoonBridge.class, com.limelight.shadows.ShadowGameManager.class})
 @RunWith(RobolectricTestRunner.class)
 public class ProfilesOverlayTest {
+    private static final String ULTRA_LOW_LATENCY_KEY = "checkbox_ultra_low_latency";
+
     private Context context;
 
     @BeforeClass
@@ -34,6 +41,7 @@ public class ProfilesOverlayTest {
     @Before
     public void setUp() {
         context = ApplicationProvider.getApplicationContext();
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit();
         // Reset singleton and clean files to ensure clean slate
         ProfilesManager.instance = null;
         File profilesDir = new File(context.getFilesDir(), "profiles");
@@ -41,15 +49,59 @@ public class ProfilesOverlayTest {
     }
 
     @Test
+    public void ultraLowLatencyPreference_keepsCompatibleKeyAndDefaultsOff() {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+
+        PreferenceManager.setDefaultValues(context, R.xml.preferences, true);
+
+        assertTrue(preferences.contains(ULTRA_LOW_LATENCY_KEY));
+        assertFalse(preferences.getBoolean(ULTRA_LOW_LATENCY_KEY, true));
+    }
+
+    @Test
+    public void ultraLowLatencyPreference_explainsAutomaticStandardAndOptionalVendorPaths() {
+        assertUltraLowLatencyCopy(
+                Locale.ENGLISH,
+                "Vendor ultra-low-latency optimizations (experimental)",
+                "Android standard low latency is enabled automatically when supported. " +
+                        "This option adds capability-checked vendor decoder optimizations.");
+        assertUltraLowLatencyCopy(
+                Locale.FRENCH,
+                "Optimisations de latence ultra-faible du fournisseur (expérimental)",
+                "La faible latence standard d’Android est activée automatiquement lorsqu’elle est prise en charge. " +
+                        "Cette option ajoute des optimisations de décodeur propres au fournisseur, vérifiées selon les capacités.");
+        assertUltraLowLatencyCopy(
+                new Locale("ru"),
+                "Оптимизации сверхнизкой задержки от производителя (экспериментально)",
+                "Стандартный режим низкой задержки Android включается автоматически, если поддерживается. " +
+                        "Этот параметр добавляет оптимизации декодера от производителя, проверяемые по возможностям.");
+        assertUltraLowLatencyCopy(
+                Locale.SIMPLIFIED_CHINESE,
+                "厂商超低延迟优化（实验性）",
+                "支持时会自动启用 Android 标准低延迟。此选项会添加经过能力检查的厂商解码器优化。");
+        assertUltraLowLatencyCopy(
+                Locale.TRADITIONAL_CHINESE,
+                "廠商超低延遲最佳化（實驗性）",
+                "支援時會自動啟用 Android 標準低延遲。此選項會加入經能力檢查的廠商解碼器最佳化。");
+    }
+
+    @Test
+    public void ultraLowLatencyPreference_isNotDuplicatedInStreamTransportConfiguration() {
+        assertNoDeclaredField(StreamConfiguration.class, "enableUltraLowLatency");
+        assertNoDeclaredMethod(StreamConfiguration.class, "getEnableUltraLowLatency");
+        assertNoDeclaredMethod(StreamConfiguration.Builder.class, "setEnableUltraLowLatency", boolean.class);
+    }
+
+    @Test
     public void overlaySharedPreferences_returnsPatchedValues() {
-        SharedPreferences base = androidx.preference.PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences base = PreferenceManager.getDefaultSharedPreferences(context);
         base.edit()
-            .putBoolean("checkbox_ultra_low_latency", false)
+            .putBoolean(ULTRA_LOW_LATENCY_KEY, false)
             .putInt("seekbar_bitrate_kbps", 15000)
             .apply();
 
         Map<String, Object> patch = new HashMap<>();
-        patch.put("checkbox_ultra_low_latency", true);
+        patch.put(ULTRA_LOW_LATENCY_KEY, true);
         patch.put("seekbar_bitrate_kbps", 30000);
 
         SettingsProfile profile = new SettingsProfile(UUID.randomUUID(), "Test", System.currentTimeMillis(), System.currentTimeMillis(), patch);
@@ -58,14 +110,14 @@ public class ProfilesOverlayTest {
         pm.setActive(profile.getUuid());
 
         SharedPreferences overlay = pm.getOverlayingSharedPreferences(context);
-        assertTrue(overlay.getBoolean("checkbox_ultra_low_latency", false));
+        assertTrue(overlay.getBoolean(ULTRA_LOW_LATENCY_KEY, false));
         assertEquals(30000, overlay.getInt("seekbar_bitrate_kbps", 0));
     }
 
     @Test
     public void overlayPersistsAcrossSessions() {
         Map<String, Object> patch = new HashMap<>();
-        patch.put("checkbox_ultra_low_latency", true);
+        patch.put(ULTRA_LOW_LATENCY_KEY, true);
 
         SettingsProfile profile = new SettingsProfile(UUID.randomUUID(), "Persist", System.currentTimeMillis(), System.currentTimeMillis(), patch);
         ProfilesManager pm = ProfilesManager.getInstance();
@@ -79,7 +131,34 @@ public class ProfilesOverlayTest {
         fresh.load(context);
 
         SharedPreferences overlay = fresh.getOverlayingSharedPreferences(context);
-        assertTrue(overlay.getBoolean("checkbox_ultra_low_latency", false));
+        assertTrue(overlay.getBoolean(ULTRA_LOW_LATENCY_KEY, false));
+    }
+
+    private void assertUltraLowLatencyCopy(Locale locale, String expectedTitle, String expectedSummary) {
+        Configuration configuration = new Configuration(context.getResources().getConfiguration());
+        configuration.setLocale(locale);
+        Context localizedContext = context.createConfigurationContext(configuration);
+
+        assertEquals(expectedTitle, localizedContext.getString(R.string.title_checkbox_ultra_low_latency));
+        assertEquals(expectedSummary, localizedContext.getString(R.string.summary_checkbox_ultra_low_latency));
+    }
+
+    private void assertNoDeclaredField(Class<?> type, String fieldName) {
+        try {
+            type.getDeclaredField(fieldName);
+            fail(type.getSimpleName() + " must not transport the ultra-low-latency preference");
+        } catch (NoSuchFieldException expected) {
+            // Expected: PreferenceConfiguration is the renderer's sole runtime source.
+        }
+    }
+
+    private void assertNoDeclaredMethod(Class<?> type, String methodName, Class<?>... parameterTypes) {
+        try {
+            type.getDeclaredMethod(methodName, parameterTypes);
+            fail(type.getSimpleName() + "." + methodName + " must not transport the ultra-low-latency preference");
+        } catch (NoSuchMethodException expected) {
+            // Expected: PreferenceConfiguration is the renderer's sole runtime source.
+        }
     }
 
     private void deleteRecursively(File f) {


### PR DESCRIPTION
## Summary

- enable Android standard codec low latency automatically when the selected decoder supports it
- add capability-gated Qualcomm/QTI and MediaTek vendor profiles without relying on SoC marketing names
- bound configuration attempts and preserve a guaranteed base-codec fallback
- downgrade unsafe profiles during runtime recovery instead of retrying an unbounded vendor sequence
- add deterministic profile diagnostics and a thread-safe decoder latency sampler
- clarify that the preference enables experimental vendor optimizations, while Android standard low latency is automatic
- add an isolated `lowLatencyDebug` build (`com.limelight.artemis.lowlatency.debug`) for side-by-side device testing

This publication commit is a squash of 12 local development commits and is intentionally independent from the fully external display change in #589.

## Galaxy S25+ device validation

This was tested on a real Samsung Galaxy S25+ (`SM-S936N`) with Snapdragon 8 Elite for Galaxy (`SM8750`) while streaming from an Apollo server.

Repeated ULL on/off testing produced a clearly noticeable and meaningful latency improvement with the vendor optimization enabled. The captured target-app sessions show:

- ULL on: `qti-full` selected on configuration attempt 0
- ULL off: `android-standard` selected on configuration attempt 0
- ULL on again: `qti-full` selected on configuration attempt 0
- no codec low-latency fallback, codec exception, decoder reset, or decoder recreation in those sessions

Decoder-side diagnostic summaries were approximately 0.9-1.0 ms p50 with ULL on and 10.9 ms p50 with ULL off in the captured sessions. These values are useful device evidence but are not presented as a controlled end-to-end latency benchmark.

The MediaTek path is tested with Lenovo Tablet TB373FU and confirmed is OK.

## Validation

- focused codec/profile tests: 89 passed, 0 failed
- full JVM suite: 138 tests, 133 passed, 5 existing unrelated Robolectric failures, 0 errors, 0 skipped
- `assembleNonRoot_gameLowLatencyDebug`: passed, including native builds for all configured ABIs
- ARM64 isolated APK produced successfully
- no fully external display files or Presentation behavior are included in this PR

The five failures are the existing layout/profile/startup baseline failures and are unchanged by this patch.

Related low-latency work: #106, #178, #361, #443
