### PR TITLE
Fix 4K streams disconnecting during startup

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -1484,7 +1484,11 @@ public class Game extends AppCompatActivity implements SurfaceHolder.Callback,
                 // On non-4K streams, we force the resolution to never change unless it's above
                 // 60 FPS, which may require a resolution reduction due to HDMI bandwidth limitations,
                 // or it's a native resolution stream.
-                if (prefConfig.width < 3840 && prefConfig.fps <= 60 && !isNativeResolutionStream) {
+                // Also preserve the current resolution if it already exactly matches the stream.
+                if (prefConfig.fps <= 60 &&
+                        ((prefConfig.width < 3840 && !isNativeResolutionStream) ||
+                        (currentDisplay.getMode().getPhysicalWidth() == prefConfig.width &&
+                                currentDisplay.getMode().getPhysicalHeight() == prefConfig.height))) {
                     if (currentDisplay.getMode().getPhysicalWidth() != candidate.getPhysicalWidth() ||
                             currentDisplay.getMode().getPhysicalHeight() != candidate.getPhysicalHeight()) {
                         continue;


### PR DESCRIPTION
Fixes #505.

## Summary

On the affected Android TV device, 1080p60 and 1440p60 streams worked normally,
but a 3840x2160@60 stream connected and then immediately returned to the
Artemis menu.

Apollo still showed the session as active briefly before it timed out.

The issue was traced to an unnecessary Android display-mode transition during
4K stream startup.

## Root cause

Tested on a Homatics Box R 4K Plus running Android TV 14 connected to an LG 4K TV.

With the system output set to 3840x2160@60, Android reports both:

- 3840x2160 @ 60 Hz
- 4096x2160 @ 60 Hz

The 4096x2160 mode is exposed by the client-side Android/HDMI display stack; it
is not a resolution requested by Apollo.

`Game.prepareDisplayForRendering()` iterates through the available
`Display.Mode` candidates before starting rendering.

The existing resolution-preservation logic only applied when:

```java
prefConfig.width < 3840
```

As a result, for a 3840x2160 stream, Artemis could select the 4096x2160@60 mode
even though the current display mode already exactly matched the requested
3840x2160 resolution.

On this device, that display-mode transition recreated the Activity and Surface
while decoder initialization was already in progress.

The failing path then reached `MediaCodec.configure()` with the previous Surface
already released:

```text
IllegalArgumentException: The surface has been released
Video stream start failed: -5
```

The failed startup did not reach video packet reception or MediaCodec
input/output.

When the Android system display mode was manually set to 4096x2160 before
starting the same 3840x2160 AV1 stream, decoder configuration, first input,
first output, and first rendered frame all succeeded. This helped isolate the
failure to the display-mode / Surface lifecycle transition rather than the
3840x2160 AV1 format itself.

## Change

Preserve the current physical display resolution when it already exactly
matches the requested stream resolution at 60 FPS or below.

This prevents an unnecessary physical resolution transition during startup.

Refresh-rate selection is still allowed between display modes with the same
physical resolution.

## Validation

Tested with:

- Homatics Box R 4K Plus
- Android TV 14
- LG 4K TV
- Wired Gigabit Ethernet
- Windows host with Apollo 0.4.6
- NVIDIA RTX 5080
- SDR
- Artemis codec preference: **Prefer AV1**

Results:

| System output | Stream | Result |
| --- | --- | --- |
| 3840x2160@60 | 2560x1440@60 AV1 | Works before and after the fix |
| 3840x2160@60 | 3840x2160@60 AV1 | Failed before; works after the fix |
| 4096x2160@60 | 3840x2160@60 AV1 | Started before the fix, with pillarboxing |
| 3840x2160@60 | 3840x2160@60 AV1, 20 Mbps | Ran for ~6m40s after the fix without startup, Surface, or decoder failure |

Post-fix logs show:

- no request to switch the display to 4096x2160
- a valid Surface at `MediaCodec.configure()`
- successful decoder startup
- first input buffer
- first output buffer
- first rendered frame

## Limitations

- Validation was performed on one Homatics Box R 4K Plus / LG TV combination.
- AV1 was used for validation.
- HEVC was not validated because it is independently broken on this test setup.
- HDR was not tested.
- Longer stress testing and higher bitrates were not tested.